### PR TITLE
Add fluent API code examples to architecture documentation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -181,11 +181,13 @@ _Note: Similarly to the previous example, even without specifying the model here
 
 ##### Fluent API
 ```php
+$history = [
+    new UserMessage('Do you spell it WordPress or Wordpress?'),
+    new AgentMessage('The correct spelling is WordPress.'),
+];
+
 $text = AiClient::prompt('Can you repeat that please?')
-    ->withHistory(
-        new UserMessage('Do you spell it WordPress or Wordpress?'),
-        new AgentMessage('The correct spelling is WordPress.')
-    )
+    ->withHistory(...$history)
     ->generateText();
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -156,7 +156,7 @@ _Note: Since this omits the model parameter, the SDK will automatically determin
 ##### Fluent API
 ```php
 $text = AiClient::prompt('Generate alternative text for this image.')
-    ->withImageFile(new InlineFile('image/png', $base64blob))
+    ->withInlineImage($base64Blob, 'image/png')
     ->generateText();
 ```
 
@@ -328,6 +328,9 @@ direction LR
 
         class PromptBuilder {
             +withText(string $text) self
+            +withInlineImage(string $base64Blob, string $mimeType)
+            +withLocalImage(string $path, string $mimeType)
+            +withRemoteImage(string $uri, string $mimeType)
             +withImageFile(File $file) self
             +withAudioFile(File $file) self
             +withVideoFile(File $file) self
@@ -487,6 +490,9 @@ direction LR
 
         class PromptBuilder {
             +withText(string $text) self
+            +withInlineImage(string $base64Blob, string $mimeType)
+            +withLocalImage(string $path, string $mimeType)
+            +withRemoteImage(string $uri, string $mimeType)
             +withImageFile(File $file) self
             +withAudioFile(File $file) self
             +withVideoFile(File $file) self

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -362,14 +362,14 @@ direction LR
             +generateSpeechOperation() GenerativeAiOperation
             +generateEmbeddingsOperation() EmbeddingOperation
             +generateText() string
-            +generateTexts(int $candidateCount) string
+            +generateTexts(int $candidateCount) string[]
             +streamGenerateText() Generator< string >
             +generateImage() File
-            +generateImages(int $candidateCount) File
+            +generateImages(int $candidateCount) File[]
             +convertTextToSpeech() File
-            +convertTextToSpeeches(int $candidateCount) File
+            +convertTextToSpeeches(int $candidateCount) File[]
             +generateSpeech() File
-            +generateSpeeches(int $candidateCount) File
+            +generateSpeeches(int $candidateCount) File[]
             +generateEmbeddings() Embedding[]
             +getModelRequirements() AiModelRequirements
             +isSupported() bool
@@ -524,14 +524,14 @@ direction LR
             +generateSpeechOperation() GenerativeAiOperation
             +generateEmbeddingsOperation() EmbeddingOperation
             +generateText() string
-            +generateTexts(int $candidateCount) string
+            +generateTexts(int $candidateCount) string[]
             +streamGenerateText() Generator< string >
             +generateImage() File
-            +generateImages(int $candidateCount) File
+            +generateImages(int $candidateCount) File[]
             +convertTextToSpeech() File
-            +convertTextToSpeeches(int $candidateCount) File
+            +convertTextToSpeeches(int $candidateCount) File[]
             +generateSpeech() File
-            +generateSpeeches(int $candidateCount) File
+            +generateSpeeches(int $candidateCount) File[]
             +generateEmbeddings() Embedding[]
             +getModelRequirements() AiModelRequirements
             +isSupported() bool

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -321,8 +321,8 @@ classDiagram
 direction LR
     namespace Ai {
         class AiClient {
-            +prompt(string ...$text) PromptBuilder$
-            +message(string ...$text) MessageBuilder$
+            +prompt(string|Message ...$text) PromptBuilder$
+            +message(string $text) MessageBuilder$
         }
 
         class PromptBuilder {
@@ -468,8 +468,8 @@ classDiagram
 direction LR
     namespace Ai {
         class AiClient {
-            +prompt(string ...$text) PromptBuilder$
-            +message(string ...$text) MessageBuilder$
+            +prompt(string|Message ...$text) PromptBuilder$
+            +message(string $text) MessageBuilder$
             +defaultRegistry() AiProviderRegistry$
             +isConfigured(AiProviderAvailability $availability) bool$
             +generateResult(string|MessagePart|MessagePart[]|Message|Message[] $prompt, AiModel $model) GenerativeAiResult$

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -346,38 +346,27 @@ direction LR
             +usingOutputModalities(...AiModality $modalities) self
             +asJsonResponse(?array< string, mixed > $schema) self
             +generateResult() GenerativeAiResult
-            +generateResults(int $candidateCount) GenerativeAiResult[]
             +generateOperation() GenerativeAiOperation
-            +generateOperations(int $candidateCount) GenerativeAiOperation[]
             +generateTextResult() GenerativeAiResult
-            +generateTextResults(int $candidateCount) GenerativeAiResult[]
             +streamGenerateTextResult() Generator< GenerativeAiResult >
             +generateImageResult() GenerativeAiResult
-            +generateImageResults(int $candidateCount) GenerativeAiResult[]
             +convertTextToSpeechResult() GenerativeAiResult
-            +convertTextToSpeechResults(int $candidateCount) GenerativeAiResult[]
             +generateSpeechResult() GenerativeAiResult
-            +generateSpeechResults(int $candidateCount) GenerativeAiResult[]
             +generateEmbeddingsResult() EmbeddingResult
-            +generateEmbeddingsResults(int $candidateCount) EmbeddingResult[]
             +generateTextOperation() GenerativeAiOperation
-            +generateTextOperations(int $candidateCount) GenerativeAiOperation[]
             +generateImageOperation() GenerativeAiOperation
-            +generateImageOperations(int $candidateCount) GenerativeAiOperation[]
             +convertTextToSpeechOperation() GenerativeAiOperation
             +generateSpeechOperation() GenerativeAiOperation
-            +generateSpeechOperations(int $candidateCount) GenerativeAiOperation[]
             +generateEmbeddingsOperation() EmbeddingOperation
-            +generateEmbeddingsOperations(int $candidateCount) EmbeddingOperation[]
             +generateText() string
-            +generateTexts(int $candidateCount) string[]
+            +generateTexts(int $candidateCount) string
             +streamGenerateText() Generator< string >
             +generateImage() File
-            +generateImages(int $candidateCount) File[]
+            +generateImages(int $candidateCount) File
             +convertTextToSpeech() File
-            +convertTextToSpeeches(int $candidateCount) File[]
+            +convertTextToSpeeches(int $candidateCount) File
             +generateSpeech() File
-            +generateSpeeches(int $candidateCount) File[]
+            +generateSpeeches(int $candidateCount) File
             +generateEmbeddings() Embedding[]
             +getModelRequirements() AiModelRequirements
             +isSupported() bool
@@ -518,38 +507,27 @@ direction LR
             +usingOutputModalities(...AiModality $modalities) self
             +asJsonResponse(?array< string, mixed > $schema) self
             +generateResult() GenerativeAiResult
-            +generateResults(int $candidateCount) GenerativeAiResult[]
             +generateOperation() GenerativeAiOperation
-            +generateOperations(int $candidateCount) GenerativeAiOperation[]
             +generateTextResult() GenerativeAiResult
-            +generateTextResults(int $candidateCount) GenerativeAiResult[]
             +streamGenerateTextResult() Generator< GenerativeAiResult >
             +generateImageResult() GenerativeAiResult
-            +generateImageResults(int $candidateCount) GenerativeAiResult[]
             +convertTextToSpeechResult() GenerativeAiResult
-            +convertTextToSpeechResults(int $candidateCount) GenerativeAiResult[]
             +generateSpeechResult() GenerativeAiResult
-            +generateSpeechResults(int $candidateCount) GenerativeAiResult[]
             +generateEmbeddingsResult() EmbeddingResult
-            +generateEmbeddingsResults(int $candidateCount) EmbeddingResult[]
             +generateTextOperation() GenerativeAiOperation
-            +generateTextOperations(int $candidateCount) GenerativeAiOperation[]
             +generateImageOperation() GenerativeAiOperation
-            +generateImageOperations(int $candidateCount) GenerativeAiOperation[]
             +convertTextToSpeechOperation() GenerativeAiOperation
             +generateSpeechOperation() GenerativeAiOperation
-            +generateSpeechOperations(int $candidateCount) GenerativeAiOperation[]
             +generateEmbeddingsOperation() EmbeddingOperation
-            +generateEmbeddingsOperations(int $candidateCount) EmbeddingOperation[]
             +generateText() string
-            +generateTexts(int $candidateCount) string[]
+            +generateTexts(int $candidateCount) string
             +streamGenerateText() Generator< string >
             +generateImage() File
-            +generateImages(int $candidateCount) File[]
+            +generateImages(int $candidateCount) File
             +convertTextToSpeech() File
-            +convertTextToSpeeches(int $candidateCount) File[]
+            +convertTextToSpeeches(int $candidateCount) File
             +generateSpeech() File
-            +generateSpeeches(int $candidateCount) File[]
+            +generateSpeeches(int $candidateCount) File
             +generateEmbeddings() Embedding[]
             +getModelRequirements() AiModelRequirements
             +isSupported() bool

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -273,32 +273,6 @@ $jsonString = AiClient::generateTextResult(
 )->toText();
 ```
 
-#### Generate embeddings using any suitable model from any provider
-
-##### Fluent API
-```php
-$embeddings = AiClient::prompt('A very long text.', 'Another very long text.', 'More long text.')
-    ->generateEmbeddings();
-```
-
-##### Traditional API
-```php
-$providerModelsMetadata = AiClient::defaultRegistry()->findModelsMetadataForSupport(
-    new AiModelRequirements([AiCapability::EMBEDDING_GENERATION])
-);
-$embeddings = AiClient::generateEmbeddingsResult(
-    [
-        'A very long text.',
-        'Another very long text.',
-        'More long text.',
-    ],
-    AiClient::defaultRegistry()->getProviderModel(
-        $providerModelsMetadata[0]->getProvider()->getId(),
-        $providerModelsMetadata[0]->getModels()[0]->getId()
-    )
-)->getEmbeddings();
-```
-
 ## Class diagrams
 
 This section shows comprehensive class diagrams for the proposed architecture. For explanation on specific terms, see the [glossary](./GLOSSARY.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -75,7 +75,6 @@ $texts = AiClient::generateTextResult(
 ```php
 $imageFile = AiClient::prompt('Generate an illustration of the PHP elephant in the Carribean sea.')
     ->usingProvider('openai')
-    ->usingModelSupportingImages() // Optional.
     ->generateImage();
 ```
 
@@ -99,7 +98,6 @@ $imageFile = AiClient::generateImageResult(
 ##### Fluent API
 ```php
 $imageFile = AiClient::prompt('Generate an illustration of the PHP elephant in the Carribean sea.')
-    ->usingModelSupportingImages() // Optional.
     ->generateImage();
 ```
 
@@ -123,8 +121,17 @@ _Note: This does effectively the exact same as [the first code example](#generat
 
 ##### Fluent API
 ```php
+$providerModelsMetadata = AiClient::defaultRegistry()->findModelsMetadataForSupport(
+    new AiModelRequirements([AiCapability::TEXT_GENERATION])
+);
+
 $text = AiClient::prompt('Write a 2-verse poem about PHP.')
-    ->usingModelSupportingText() // Optional.
+    ->withModel(
+        AiClient::defaultRegistry()->getProviderModel(
+            $providerModelsMetadata[0]->getProvider()->getId(),
+            $providerModelsMetadata[0]->getModels()[0]->getId()
+        )
+    )
     ->generateText();
 ```
 
@@ -320,20 +327,6 @@ direction LR
             +withMessageParts(...MessagePart $part) self
             +withHistory(...Message $messages) self
             +usingModel(AiModel $model) self
-            +usingModelSupporting(...AiCapability|AiOption $aiCapabilityOrOption) self
-            +usingModelSupportingCapability(...AiCapability $aiCapability) self
-            +usingModelSupportingOption(...AiOption $aiOption) self
-            +usingModelSupportingAudio() self
-            +usingModelSupportingHistory() self
-            +usingModelSupportingEmbeddings() self
-            +usingModelSupportingImages() self
-            +usingModelSupportingJsonOutput() self
-            +usingModelSupportingMusic() self
-            +usingModelSupportingOutputSchema() self
-            +usingModelSupportingSpeech() self
-            +usingModelSupportingText() self
-            +usingModelSupportingTextToSpeech() self
-            +usingModelSupportingVideo() self
             +usingSystemInstruction(string|MessagePart[]|Message $systemInstruction) self
             +usingMaxTokens(int $maxTokens) self
             +usingTemperature(float $temperature) self
@@ -507,20 +500,6 @@ direction LR
             +withMessageParts(...MessagePart $part) self
             +withHistory(...Message $messages) self
             +usingModel(AiModel $model) self
-            +usingModelSupporting(...AiCapability|AiOption $aiCapabilityOrOption) self
-            +usingModelSupportingCapability(...AiCapability $aiCapability) self
-            +usingModelSupportingOption(...AiOption $aiOption) self
-            +usingModelSupportingAudio() self
-            +usingModelSupportingHistory() self
-            +usingModelSupportingEmbeddings() self
-            +usingModelSupportingImages() self
-            +usingModelSupportingJsonOutput() self
-            +usingModelSupportingMusic() self
-            +usingModelSupportingOutputSchema() self
-            +usingModelSupportingSpeech() self
-            +usingModelSupportingText() self
-            +usingModelSupportingTextToSpeech() self
-            +usingModelSupportingVideo() self
             +usingSystemInstruction(string|MessagePart[]|Message $systemInstruction) self
             +usingMaxTokens(int $maxTokens) self
             +usingTemperature(float $temperature) self

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,6 +19,13 @@ The following examples indicate how this SDK could eventually be used.
 
 #### Generate text using any suitable model from any provider (most basic example)
 
+##### Fluent API
+```php
+$text = AiClient::prompt('Write a 2-verse poem about PHP.')
+    ->generateText();
+```
+
+##### Traditional API
 ```php
 $text = AiClient::generateTextResult(
     'Write a 2-verse poem about PHP.'
@@ -27,6 +34,14 @@ $text = AiClient::generateTextResult(
 
 #### Generate text using a Google model
 
+##### Fluent API
+```php
+$text = AiClient::prompt('Write a 2-verse poem about PHP.')
+    ->usingModel('gemini-2.5-flash')
+    ->generateText();
+```
+
+##### Traditional API
 ```php
 $text = AiClient::generateTextResult(
     'Write a 2-verse poem about PHP.',
@@ -36,6 +51,14 @@ $text = AiClient::generateTextResult(
 
 #### Generate multiple text candidates using an Anthropic model
 
+##### Fluent API
+```php
+$texts = AiClient::prompt('Write a 2-verse poem about PHP.')
+    ->usingModel('claude-3.7-sonnet')
+    ->generateTexts(4);
+```
+
+##### Traditional API
 ```php
 $texts = AiClient::generateTextResult(
     'Write a 2-verse poem about PHP.',
@@ -48,6 +71,15 @@ $texts = AiClient::generateTextResult(
 
 #### Generate an image using any suitable OpenAI model
 
+##### Fluent API
+```php
+$imageFile = AiClient::prompt('Generate an illustration of the PHP elephant in the Carribean sea.')
+    ->usingProvider('openai')
+    ->usingModelSupportingImages() // Optional.
+    ->generateImage();
+```
+
+##### Traditional API
 ```php
 $modelsMetadata = AiClient::defaultRegistry()->findProviderModelsMetadataForSupport(
     'openai',
@@ -64,6 +96,14 @@ $imageFile = AiClient::generateImageResult(
 
 #### Generate an image using any suitable model from any provider
 
+##### Fluent API
+```php
+$imageFile = AiClient::prompt('Generate an illustration of the PHP elephant in the Carribean sea.')
+    ->usingModelSupportingImages() // Optional.
+    ->generateImage();
+```
+
+##### Traditional API
 ```php
 $providerModelsMetadata = AiClient::defaultRegistry()->findModelsMetadataForSupport(
     new AiModelRequirements([AiCapability::IMAGE_GENERATION])
@@ -81,6 +121,14 @@ $imageFile = AiClient::generateImageResult(
 
 _Note: This does effectively the exact same as [the first code example](#generate-text-using-any-suitable-model-from-any-provider-most-basic-example), but more verbosely. In other words, if you omit the model parameter, the SDK will do this internally._
 
+##### Fluent API
+```php
+$text = AiClient::prompt('Write a 2-verse poem about PHP.')
+    ->usingModelSupportingText() // Optional.
+    ->generateText();
+```
+
+##### Traditional API
 ```php
 $providerModelsMetadata = AiClient::defaultRegistry()->findModelsMetadataForSupport(
     new AiModelRequirements([AiCapability::TEXT_GENERATION])
@@ -98,6 +146,14 @@ $text = AiClient::generateTextResult(
 
 _Note: Since this omits the model parameter, the SDK will automatically determine which models are suitable and use any of them, similar to [the first code example](#generate-text-using-any-suitable-model-from-any-provider-most-basic-example). Since it knows the input includes an image, it can internally infer that the model needs to not only support `AiCapability::TEXT_GENERATION`, but also `AiOption::INPUT_MODALITIES => ['text', 'image']`._
 
+##### Fluent API
+```php
+$text = AiClient::prompt('Generate alternative text for this image.')
+    ->withImage('image/png', $base64blob)
+    ->generateText();
+```
+
+##### Traditional API
 ```php
 $text = AiClient::generateTextResult(
     [
@@ -116,6 +172,17 @@ $text = AiClient::generateTextResult(
 
 _Note: Similarly to the previous example, even without specifying the model here, the SDK will be able to infer required model capabilities because it can detect that multiple chat messages are passed. Therefore it will internally only consider models that support `AiCapability::TEXT_GENERATION` as well as `AiCapability::CHAT_HISTORY`._
 
+##### Fluent API
+```php
+$text = AiClient::prompt('Can you repeat that please?')
+    ->withHistory(
+        new UserMessage('Do you spell it WordPress or Wordpress?'),
+        new AgentMessage('The correct spelling is WordPress.')
+    )
+    ->generateText();
+```
+
+##### Traditional API
 ```php
 $text = AiClient::generateTextResult(
     [
@@ -139,6 +206,21 @@ $text = AiClient::generateTextResult(
 
 _Note: Unlike the previous two examples, to require JSON output it is necessary to go the verbose route, since it is impossible for the SDK to detect whether you require JSON output purely from the prompt input. Therefore this code example contains the logic to manually search for suitable models and then use one of them for the task._
 
+##### Fluent API
+```php
+// Verbose.
+$text = AiClient::prompt('Transform the following CSV content into a JSON array of row data.')
+    ->asJsonResponse()
+    ->usingOutputSchema(['name' => 'string', 'age' => 'integer'])
+    ->generateText();
+
+// Simple.
+$text = AiClient::prompt('Transform the following CSV content into a JSON array of row data.')
+    ->asJsonResponse(['name' => 'string', 'age' => 'integer'])
+    ->generateText();
+```
+
+##### Traditional API
 ```php
 $providerModelsMetadata = AiClient::defaultRegistry()->findModelsMetadataForSupport(
     new AiModelRequirements(
@@ -178,6 +260,13 @@ $jsonString = AiClient::generateTextResult(
 
 #### Generate embeddings using any suitable model from any provider
 
+##### Fluent API
+```php
+$embeddings = AiClient::prompt('A very long text.', 'Another very long text.', 'More long text.')
+    ->generateEmbeddings();
+```
+
+##### Traditional API
 ```php
 $providerModelsMetadata = AiClient::defaultRegistry()->findModelsMetadataForSupport(
     new AiModelRequirements([AiCapability::EMBEDDING_GENERATION])
@@ -217,12 +306,13 @@ classDiagram
 direction LR
     namespace Ai {
         class AiClient {
-            +prompt(?string $text) PromptBuilder$
-            +message(?string $text) MessageBuilder$
+            +prompt(...string $text) PromptBuilder$
+            +message(...string $text) MessageBuilder$
         }
 
         class PromptBuilder {
             +withText(string $text) self
+            +withImage(string $mimeType, string $base64Blob) self
             +withImageFile(File $file) self
             +withAudioFile(File $file) self
             +withVideoFile(File $file) self
@@ -230,6 +320,20 @@ direction LR
             +withMessageParts(...MessagePart $part) self
             +withHistory(...Message $messages) self
             +usingModel(AiModel $model) self
+            +usingModelSupporting(...AiCapability|AiOption $aiCapabilityOrOption) self
+            +usingModelSupportingCapability(...AiCapability $aiCapability) self
+            +usingModelSupportingOption(...AiOption $aiOption) self
+            +usingModelSupportingAudio() self
+            +usingModelSupportingHistory() self
+            +usingModelSupportingEmbeddings() self
+            +usingModelSupportingImages() self
+            +usingModelSupportingJsonOutput() self
+            +usingModelSupportingMusic() self
+            +usingModelSupportingOutputSchema() self
+            +usingModelSupportingSpeech() self
+            +usingModelSupportingText() self
+            +usingModelSupportingTextToSpeech() self
+            +usingModelSupportingVideo() self
             +usingSystemInstruction(string|MessagePart[]|Message $systemInstruction) self
             +usingMaxTokens(int $maxTokens) self
             +usingTemperature(float $temperature) self
@@ -240,24 +344,41 @@ direction LR
             +usingOutputMime(string $mimeType) self
             +usingOutputSchema(array< string, mixed > $schema) self
             +usingOutputModalities(...AiModality $modalities) self
+            +asArrayResponse(?array< string, mixed > $schema) self
+            +asJsonResponse(?array< string, mixed > $schema) self
             +generateResult() GenerativeAiResult
+            +generateResults(int $candidateCount) GenerativeAiResult[]
             +generateOperation() GenerativeAiOperation
+            +generateOperations(int $candidateCount) GenerativeAiOperation[]
             +generateTextResult() GenerativeAiResult
+            +generateTextResults(int $candidateCount) GenerativeAiResult[]
             +streamGenerateTextResult() Generator< GenerativeAiResult >
             +generateImageResult() GenerativeAiResult
+            +generateImageResults(int $candidateCount) GenerativeAiResult[]
             +convertTextToSpeechResult() GenerativeAiResult
+            +convertTextToSpeechResults(int $candidateCount) GenerativeAiResult[]
             +generateSpeechResult() GenerativeAiResult
+            +generateSpeechResults(int $candidateCount) GenerativeAiResult[]
             +generateEmbeddingsResult() EmbeddingResult
+            +generateEmbeddingsResults(int $candidateCount) EmbeddingResult[]
             +generateTextOperation() GenerativeAiOperation
+            +generateTextOperations(int $candidateCount) GenerativeAiOperation[]
             +generateImageOperation() GenerativeAiOperation
+            +generateImageOperations(int $candidateCount) GenerativeAiOperation[]
             +convertTextToSpeechOperation() GenerativeAiOperation
             +generateSpeechOperation() GenerativeAiOperation
+            +generateSpeechOperations(int $candidateCount) GenerativeAiOperation[]
             +generateEmbeddingsOperation() EmbeddingOperation
+            +generateEmbeddingsOperations(int $candidateCount) EmbeddingOperation[]
             +generateText() string
+            +generateTexts(int $candidateCount) string[]
             +streamGenerateText() Generator< string >
             +generateImage() File
+            +generateImages(int $candidateCount) File[]
             +convertTextToSpeech() File
+            +convertTextToSpeeches(int $candidateCount) File[]
             +generateSpeech() File
+            +generateSpeeches(int $candidateCount) File[]
             +generateEmbeddings() Embedding[]
             +getModelRequirements() AiModelRequirements
             +isSupported() bool
@@ -266,6 +387,7 @@ direction LR
         class MessageBuilder {
             +usingRole(MessageRole $role) self
             +withText(string $text) self
+            +withImage(string $mimeType, string $base64Blob) self
             +withImageFile(File $file) self
             +withAudioFile(File $file) self
             +withVideoFile(File $file) self
@@ -356,8 +478,8 @@ classDiagram
 direction LR
     namespace Ai {
         class AiClient {
-            +prompt(?string $text) PromptBuilder$
-            +message(?string $text) MessageBuilder$
+            +prompt(...string $text) PromptBuilder$
+            +message(...string $text) MessageBuilder$
             +defaultRegistry() AiProviderRegistry$
             +isConfigured(AiProviderAvailability $availability) bool$
             +generateResult(string|MessagePart|MessagePart[]|Message|Message[] $prompt, AiModel $model) GenerativeAiResult$
@@ -377,6 +499,7 @@ direction LR
 
         class PromptBuilder {
             +withText(string $text) self
+            +withImage(string $mimeType, string $base64Blob) self
             +withImageFile(File $file) self
             +withAudioFile(File $file) self
             +withVideoFile(File $file) self
@@ -384,6 +507,20 @@ direction LR
             +withMessageParts(...MessagePart $part) self
             +withHistory(...Message $messages) self
             +usingModel(AiModel $model) self
+            +usingModelSupporting(...AiCapability|AiOption $aiCapabilityOrOption) self
+            +usingModelSupportingCapability(...AiCapability $aiCapability) self
+            +usingModelSupportingOption(...AiOption $aiOption) self
+            +usingModelSupportingAudio() self
+            +usingModelSupportingHistory() self
+            +usingModelSupportingEmbeddings() self
+            +usingModelSupportingImages() self
+            +usingModelSupportingJsonOutput() self
+            +usingModelSupportingMusic() self
+            +usingModelSupportingOutputSchema() self
+            +usingModelSupportingSpeech() self
+            +usingModelSupportingText() self
+            +usingModelSupportingTextToSpeech() self
+            +usingModelSupportingVideo() self
             +usingSystemInstruction(string|MessagePart[]|Message $systemInstruction) self
             +usingMaxTokens(int $maxTokens) self
             +usingTemperature(float $temperature) self
@@ -394,24 +531,41 @@ direction LR
             +usingOutputMime(string $mimeType) self
             +usingOutputSchema(array< string, mixed > $schema) self
             +usingOutputModalities(...AiModality $modalities) self
+            +asArrayResponse(?array< string, mixed > $schema) self
+            +asJsonResponse(?array< string, mixed > $schema) self
             +generateResult() GenerativeAiResult
+            +generateResults(int $candidateCount) GenerativeAiResult[]
             +generateOperation() GenerativeAiOperation
+            +generateOperations(int $candidateCount) GenerativeAiOperation[]
             +generateTextResult() GenerativeAiResult
+            +generateTextResults(int $candidateCount) GenerativeAiResult[]
             +streamGenerateTextResult() Generator< GenerativeAiResult >
             +generateImageResult() GenerativeAiResult
+            +generateImageResults(int $candidateCount) GenerativeAiResult[]
             +convertTextToSpeechResult() GenerativeAiResult
+            +convertTextToSpeechResults(int $candidateCount) GenerativeAiResult[]
             +generateSpeechResult() GenerativeAiResult
+            +generateSpeechResults(int $candidateCount) GenerativeAiResult[]
             +generateEmbeddingsResult() EmbeddingResult
+            +generateEmbeddingsResults(int $candidateCount) EmbeddingResult[]
             +generateTextOperation() GenerativeAiOperation
+            +generateTextOperations(int $candidateCount) GenerativeAiOperation[]
             +generateImageOperation() GenerativeAiOperation
+            +generateImageOperations(int $candidateCount) GenerativeAiOperation[]
             +convertTextToSpeechOperation() GenerativeAiOperation
             +generateSpeechOperation() GenerativeAiOperation
+            +generateSpeechOperations(int $candidateCount) GenerativeAiOperation[]
             +generateEmbeddingsOperation() EmbeddingOperation
+            +generateEmbeddingsOperations(int $candidateCount) EmbeddingOperation[]
             +generateText() string
+            +generateTexts(int $candidateCount) string[]
             +streamGenerateText() Generator< string >
             +generateImage() File
+            +generateImages(int $candidateCount) File[]
             +convertTextToSpeech() File
+            +convertTextToSpeeches(int $candidateCount) File[]
             +generateSpeech() File
+            +generateSpeeches(int $candidateCount) File[]
             +generateEmbeddings() Embedding[]
             +getModelRequirements() AiModelRequirements
             +isSupported() bool
@@ -420,6 +574,7 @@ direction LR
         class MessageBuilder {
             +usingRole(MessageRole $role) self
             +withText(string $text) self
+            +withImage(string $mimeType, string $base64Blob) self
             +withImageFile(File $file) self
             +withAudioFile(File $file) self
             +withVideoFile(File $file) self

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,7 +37,7 @@ $text = AiClient::generateTextResult(
 ##### Fluent API
 ```php
 $text = AiClient::prompt('Write a 2-verse poem about PHP.')
-    ->usingModel('gemini-2.5-flash')
+    ->usingModel(Google::model('gemini-2.5-flash'))
     ->generateText();
 ```
 
@@ -54,7 +54,7 @@ $text = AiClient::generateTextResult(
 ##### Fluent API
 ```php
 $texts = AiClient::prompt('Write a 2-verse poem about PHP.')
-    ->usingModel('claude-3.7-sonnet')
+    ->usingModel(Anthropic::model('claude-3.7-sonnet'))
     ->generateTexts(4);
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -362,14 +362,14 @@ direction LR
             +generateSpeechOperation() GenerativeAiOperation
             +generateEmbeddingsOperation() EmbeddingOperation
             +generateText() string
-            +generateTexts(int $candidateCount) string[]
+            +generateTexts(?int $candidateCount) string[]
             +streamGenerateText() Generator< string >
             +generateImage() File
-            +generateImages(int $candidateCount) File[]
+            +generateImages(?int $candidateCount) File[]
             +convertTextToSpeech() File
-            +convertTextToSpeeches(int $candidateCount) File[]
+            +convertTextToSpeeches(?int $candidateCount) File[]
             +generateSpeech() File
-            +generateSpeeches(int $candidateCount) File[]
+            +generateSpeeches(?int $candidateCount) File[]
             +generateEmbeddings() Embedding[]
             +getModelRequirements() AiModelRequirements
             +isSupported() bool
@@ -524,14 +524,14 @@ direction LR
             +generateSpeechOperation() GenerativeAiOperation
             +generateEmbeddingsOperation() EmbeddingOperation
             +generateText() string
-            +generateTexts(int $candidateCount) string[]
+            +generateTexts(?int $candidateCount) string[]
             +streamGenerateText() Generator< string >
             +generateImage() File
-            +generateImages(int $candidateCount) File[]
+            +generateImages(?int $candidateCount) File[]
             +convertTextToSpeech() File
-            +convertTextToSpeeches(int $candidateCount) File[]
+            +convertTextToSpeeches(?int $candidateCount) File[]
             +generateSpeech() File
-            +generateSpeeches(int $candidateCount) File[]
+            +generateSpeeches(?int $candidateCount) File[]
             +generateEmbeddings() Embedding[]
             +getModelRequirements() AiModelRequirements
             +isSupported() bool

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -322,7 +322,7 @@ direction LR
     namespace Ai {
         class AiClient {
             +prompt(string|Message ...$text) PromptBuilder$
-            +message(string $text) MessageBuilder$
+            +message(?string $text) MessageBuilder$
         }
 
         class PromptBuilder {
@@ -469,7 +469,7 @@ direction LR
     namespace Ai {
         class AiClient {
             +prompt(string|Message ...$text) PromptBuilder$
-            +message(string $text) MessageBuilder$
+            +message(?string $text) MessageBuilder$
             +defaultRegistry() AiProviderRegistry$
             +isConfigured(AiProviderAvailability $availability) bool$
             +generateResult(string|MessagePart|MessagePart[]|Message|Message[] $prompt, AiModel $model) GenerativeAiResult$

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -295,7 +295,7 @@ classDiagram
 direction LR
     namespace Ai {
         class AiClient {
-            +prompt(string|Message ...$text) PromptBuilder$
+            +prompt(string|Message|null $text = null) PromptBuilder$
             +message(?string $text) MessageBuilder$
         }
 
@@ -442,7 +442,7 @@ classDiagram
 direction LR
     namespace Ai {
         class AiClient {
-            +prompt(string|Message ...$text) PromptBuilder$
+            +prompt(string|Message|null $text = null) PromptBuilder$
             +message(?string $text) MessageBuilder$
             +defaultRegistry() AiProviderRegistry$
             +isConfigured(AiProviderAvailability $availability) bool$

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -181,13 +181,12 @@ _Note: Similarly to the previous example, even without specifying the model here
 
 ##### Fluent API
 ```php
-$history = [
-    new UserMessage('Do you spell it WordPress or Wordpress?'),
-    new AgentMessage('The correct spelling is WordPress.'),
-];
-
-$text = AiClient::prompt('Can you repeat that please?')
-    ->withHistory(...$history)
+$text = AiClient::prompt()
+    ->withHistory(
+        new UserMessage('Do you spell it WordPress or Wordpress?'),
+        new AgentMessage('The correct spelling is WordPress.'),
+    )
+    ->withText('Can you repeat that please?')
     ->generateText();
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -215,15 +215,22 @@ _Note: Unlike the previous two examples, to require JSON output it is necessary 
 
 ##### Fluent API
 ```php
-// Verbose.
 $text = AiClient::prompt('Transform the following CSV content into a JSON array of row data.')
     ->asJsonResponse()
-    ->usingOutputSchema(['name' => 'string', 'age' => 'integer'])
-    ->generateText();
-
-// Simple.
-$text = AiClient::prompt('Transform the following CSV content into a JSON array of row data.')
-    ->asJsonResponse(['name' => 'string', 'age' => 'integer'])
+    ->usingOutputSchema([
+        'type'  => 'array',
+        'items' => [
+            'type'       => 'object',
+            'properties' => [
+                'name' => [
+                    'type' => 'string',
+                ],
+                'age'  => [
+                    'type' => 'integer',
+                ],
+            ],
+        ],
+    ])
     ->generateText();
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -344,7 +344,6 @@ direction LR
             +usingOutputMime(string $mimeType) self
             +usingOutputSchema(array< string, mixed > $schema) self
             +usingOutputModalities(...AiModality $modalities) self
-            +asArrayResponse(?array< string, mixed > $schema) self
             +asJsonResponse(?array< string, mixed > $schema) self
             +generateResult() GenerativeAiResult
             +generateResults(int $candidateCount) GenerativeAiResult[]
@@ -517,7 +516,6 @@ direction LR
             +usingOutputMime(string $mimeType) self
             +usingOutputSchema(array< string, mixed > $schema) self
             +usingOutputModalities(...AiModality $modalities) self
-            +asArrayResponse(?array< string, mixed > $schema) self
             +asJsonResponse(?array< string, mixed > $schema) self
             +generateResult() GenerativeAiResult
             +generateResults(int $candidateCount) GenerativeAiResult[]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -156,7 +156,7 @@ _Note: Since this omits the model parameter, the SDK will automatically determin
 ##### Fluent API
 ```php
 $text = AiClient::prompt('Generate alternative text for this image.')
-    ->withImage('image/png', $base64blob)
+    ->withImageFile(new InlineFile('image/png', $base64blob))
     ->generateText();
 ```
 
@@ -326,7 +326,6 @@ direction LR
 
         class PromptBuilder {
             +withText(string $text) self
-            +withImage(string $mimeType, string $base64Blob) self
             +withImageFile(File $file) self
             +withAudioFile(File $file) self
             +withVideoFile(File $file) self
@@ -375,7 +374,6 @@ direction LR
         class MessageBuilder {
             +usingRole(MessageRole $role) self
             +withText(string $text) self
-            +withImage(string $mimeType, string $base64Blob) self
             +withImageFile(File $file) self
             +withAudioFile(File $file) self
             +withVideoFile(File $file) self
@@ -487,7 +485,6 @@ direction LR
 
         class PromptBuilder {
             +withText(string $text) self
-            +withImage(string $mimeType, string $base64Blob) self
             +withImageFile(File $file) self
             +withAudioFile(File $file) self
             +withVideoFile(File $file) self
@@ -536,7 +533,6 @@ direction LR
         class MessageBuilder {
             +usingRole(MessageRole $role) self
             +withText(string $text) self
-            +withImage(string $mimeType, string $base64Blob) self
             +withImageFile(File $file) self
             +withAudioFile(File $file) self
             +withVideoFile(File $file) self

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -322,8 +322,8 @@ classDiagram
 direction LR
     namespace Ai {
         class AiClient {
-            +prompt(...string $text) PromptBuilder$
-            +message(...string $text) MessageBuilder$
+            +prompt(string ...$text) PromptBuilder$
+            +message(string ...$text) MessageBuilder$
         }
 
         class PromptBuilder {
@@ -466,8 +466,8 @@ classDiagram
 direction LR
     namespace Ai {
         class AiClient {
-            +prompt(...string $text) PromptBuilder$
-            +message(...string $text) MessageBuilder$
+            +prompt(string ...$text) PromptBuilder$
+            +message(string ...$text) MessageBuilder$
             +defaultRegistry() AiProviderRegistry$
             +isConfigured(AiProviderAvailability $availability) bool$
             +generateResult(string|MessagePart|MessagePart[]|Message|Message[] $prompt, AiModel $model) GenerativeAiResult$


### PR DESCRIPTION
This proposed set of changes to #2 and is doing a few things:

1. Adding Fluent API code examples (similar to those suggested by @JasonTheAdams [here](https://github.com/WordPress/php-ai-client/pull/2#issuecomment-3054047920)) alongside the Traditional API examples.
2. Proposing a handful of helper methods to simplify the usage of Candidate Count and avoid implementers from needing to understand what _Candidate Count_ means.
3. Representing @JasonTheAdams' suggestion of `AiClient::withImage(string $mimeType, string $base64Blob)` to mimic the input simplicity that the Traditional API supports.
4. Adding the `AiClient::asJsonResponse()` and `AiClient::asArrayResponse()` as a helper methods for `usingOutputMime('application/json')`
5. Adding helper methods for specifying models that support a certain capability or option.

Here's the [ARCHITECTURE.md file](https://github.com/borkweb/php-ai-client/blob/add/fluent-code-examples/docs/ARCHITECTURE.md) in a readable format.