### PR TITLE
Add .gitattributes for package distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,7 @@
 /.github/              export-ignore
 .gitignore             export-ignore
 /*.md                  export-ignore
-/LICENSE.md            -export-ignore
+/LICENSE.md           -export-ignore
 /README.md            -export-ignore
 /docs/                 export-ignore
 /tests/                export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,6 @@
 /docs/                 export-ignore
 /tests/                export-ignore
 /vendor/               export-ignore
+/phpcs.xml.dist        export-ignore
 /phpstan.neon.dist     export-ignore
 /phpunit.xml.dist      export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,9 @@
 .gitattributes         export-ignore
 /.github/              export-ignore
 .gitignore             export-ignore
+/*.md                  export-ignore
+/LICENSE.md            -export-ignore
+/README.md            -export-ignore
 /docs/                 export-ignore
 /tests/                export-ignore
 /vendor/               export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+.editorconfig          export-ignore
+.gitattributes         export-ignore
+/.github/              export-ignore
+.gitignore             export-ignore
+/docs/                 export-ignore
+/tests/                export-ignore
+/vendor/               export-ignore
+/phpstan.neon.dist     export-ignore
+/phpunit.xml.dist      export-ignore


### PR DESCRIPTION
Excludes development and documentation files from Composer package:
- Development configs (.editorconfig, .gitignore, .gitattributes)
- GitHub workflows
- Documentation folder
- Test files and configs
- Vendor directory

This is, of course, excluding things that are not yet part of the repository but will likely be part of it soon.