### PR TITLE
Add composer.json with PHP 7.4+ support, phpcs, phpstan, and phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "wordpress/php-ai-client",
-    "description": "A provider-agnostic PHP SDK for communicating with generative AI models",
+    "description": "A provider agnostic PHP AI client SDK to communicate with any generative AI models of various capabilities using a uniform API.",
     "license": "GPL-2.0-or-later",
     "type": "library",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
         "source": "https://github.com/WordPress/php-ai-client"
     },
     "require": {
-        "php": ">=7.4 || ^8.0",
+        "php": ">=7.4",
         "ext-json": "*"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan": "~2.1",
         "phpunit/phpunit": "^9.5 || ^10.0",
         "squizlabs/php_codesniffer": "^3.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -52,14 +52,13 @@
         "sort-packages": true
     },
     "scripts": {
-        "analyze": "phpstan analyze",
-        "check": [
-            "@test",
-            "@analyze",
-            "@cs"
+        "lint": [
+            "@phpcs",
+            "@phpstan"
         ],
-        "cs": "phpcs",
-        "cs-fix": "phpcbf",
-        "test": "phpunit"
+        "phpcbf": "phpcbf",
+        "phpcs": "phpcs",
+        "phpstan": "phpstan analyze",
+        "phpunit": "phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,10 @@
         "ext-json": "*"
     },
     "require-dev": {
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^9.5 || ^10.0"
+        "phpunit/phpunit": "^9.5 || ^10.0",
+        "squizlabs/php_codesniffer": "^3.7"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -53,8 +55,11 @@
         "analyze": "phpstan analyze",
         "check": [
             "@test",
-            "@analyze"
+            "@analyze",
+            "@cs"
         ],
+        "cs": "phpcs",
+        "cs-fix": "phpcbf",
         "test": "phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,60 @@
+{
+    "name": "wordpress/php-ai-client",
+    "description": "A provider-agnostic PHP SDK for communicating with generative AI models",
+    "license": "GPL-2.0-or-later",
+    "type": "library",
+    "keywords": [
+        "ai",
+        "api",
+        "llm"
+    ],
+    "authors": [
+        {
+            "name": "WordPress AI Team",
+            "homepage": "https://make.wordpress.org/ai/"
+        }
+    ],
+    "homepage": "https://github.com/WordPress/php-ai-client",
+    "support": {
+        "issues": "https://github.com/WordPress/php-ai-client/issues",
+        "source": "https://github.com/WordPress/php-ai-client"
+    },
+    "require": {
+        "php": ">=7.4 || ^8.0",
+        "ext-json": "*"
+    },
+    "require-dev": {
+        "phpstan/phpstan": "^1.10",
+        "phpunit/phpunit": "^9.5 || ^10.0"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "autoload": {
+        "psr-4": {
+            "WordPress\\AI\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "WordPress\\AI\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "optimize-autoloader": true,
+        "platform": {
+            "php": "7.4"
+        },
+        "sort-packages": true
+    },
+    "scripts": {
+        "analyze": "phpstan analyze",
+        "check": [
+            "@test",
+            "@analyze"
+        ],
+        "test": "phpunit"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -33,12 +33,12 @@
     "prefer-stable": true,
     "autoload": {
         "psr-4": {
-            "WordPress\\AI\\": "src/"
+            "WordPress\\AiClient\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "WordPress\\AI\\Tests\\": "tests/"
+            "WordPress\\AiClient\\Tests\\": "tests/"
         }
     },
     "config": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<ruleset name="PHP AI Client Coding Standards">
+    <description>PSR-12 coding standards for PHP AI Client SDK</description>
+
+    <!-- Scan these files -->
+    <file>src</file>
+    <file>tests</file>
+
+    <!-- Ignore vendor directory -->
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+
+    <!-- Use PSR-12 standard -->
+    <rule ref="PSR12"/>
+
+    <!-- Show progress, show sniff codes in all reports -->
+    <arg value="sp"/>
+
+    <!-- Set minimum supported PHP version -->
+    <config name="testVersion" value="7.4-"/>
+
+    <!-- Enable colors in output -->
+    <arg name="colors"/>
+
+    <!-- Check PHP syntax -->
+    <arg name="parallel" value="8"/>
+</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,7 +4,6 @@
 
     <!-- Scan these files -->
     <file>src</file>
-    <file>tests</file>
 
     <!-- Ignore vendor directory -->
     <exclude-pattern>*/vendor/*</exclude-pattern>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,4 @@
+parameters:
+    level: max
+    paths:
+        - src

--- a/src/DummyForAnalysis.php
+++ b/src/DummyForAnalysis.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * DummyForAnalysis class file.
+ *
+ * @package WordPress\AiClient
+ */
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient;
+
+/**
+ * Class DummyForAnalysis
+ *
+ * This is a dummy class for testing that phpcs and phpstan are working.
+ * It should be removed once we have a real class.
+ */
+class DummyForAnalysis
+{
+    public function dummy(): void
+    {
+        // Placeholder.
+    }
+}


### PR DESCRIPTION
I made some assumptions in this PR that may be inaccurate.

1. I'm assuming we'll be using PHPStan. I'll PR a suggested `phpstan.neon.dist` in a follow-up PR.
2. ~Is `WordPress\AI` the correct namespace?~ Updated to `WordPress\AiClient`

The main bits:

- Configures package as wordpress/php-ai-client library
- Requires PHP 7.4 or higher
- Adds PHPUnit and PHPStan as dev dependencies and sets up initial configuration
- Sets up PSR-4 autoloading with WordPress\AI namespace
- Includes convenient scripts for testing and analysis
- Adds keywords for package discovery
- Add a dummy source file so phpstan and phpcs can be run