### PR TITLE
Add PHPStan and PHP CodeSniffer configuration

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<ruleset name="PHP AI Client Coding Standards">
+    <description>PSR-12 coding standards for PHP AI Client SDK</description>
+
+    <!-- Scan these files -->
+    <file>src</file>
+    <file>tests</file>
+
+    <!-- Ignore vendor directory -->
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+
+    <!-- Use PSR-12 standard -->
+    <rule ref="PSR12"/>
+
+    <!-- Show progress, show sniff codes in all reports -->
+    <arg value="sp"/>
+
+    <!-- Set minimum supported PHP version -->
+    <config name="testVersion" value="7.4-"/>
+
+    <!-- Enable colors in output -->
+    <arg name="colors"/>
+
+    <!-- Check PHP syntax -->
+    <arg name="parallel" value="8"/>
+</ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,4 @@
+parameters:
+    level: max
+    paths:
+        - src


### PR DESCRIPTION
- Add phpstan.neon.dist with max level analysis
- Add phpcs.xml.dist with PSR-12 coding standards
- Configure both tools to scan src/ and tests/ directories
- Set up parallel processing and colored output for phpcs