### PR TITLE
Update contributing doc to mention PER

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to the PHP AI Client package! Here y
 
 ## Coding standards
 
-While this project is stewarded by [WordPress AI Team](https://make.wordpress.org/ai/) members and contributors, it is a WordPress agnostic PHP package that can benefit any project in the PHP ecosystem. As such, all code must follow the [PER Coding Style](https://www.php-fig.org/per/coding-style/), which extends PSR-12. Note that the PHPCS config is using PSR-12 due to the fact that it does not support PER, yet. So PER is preferred, but PSR-12 is acceptable.
+While this project is stewarded by [WordPress AI Team](https://make.wordpress.org/ai/) members and contributors, it is a WordPress agnostic PHP package that can benefit any project in the PHP ecosystem. As such, all code must follow the [PER Coding Style](https://www.php-fig.org/per/coding-style/), which extends [PSR-12](https://www.php-fig.org/psr/psr-12/). Note that the PHPCS config is using PSR-12 due to the fact that it does not support PER, yet. So PER is preferred, but PSR-12 is acceptable.
 
 All parameters, return values, and properties must use explicit type hints, except in cases where providing the correct type hint would be impossible given limitations of the oldest supported PHP version (see below).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to the PHP AI Client package! Here y
 
 ## Coding standards
 
-While this project is stewarded by [WordPress AI Team](https://make.wordpress.org/ai/) members and contributors, it is a WordPress agnostic PHP package that can benefit any project in the PHP ecosystem. As such, all code must follow the [PSR-12 Coding Standards](https://www.php-fig.org/psr/psr-12/).
+While this project is stewarded by [WordPress AI Team](https://make.wordpress.org/ai/) members and contributors, it is a WordPress agnostic PHP package that can benefit any project in the PHP ecosystem. As such, all code must follow the [PER Coding Style](https://www.php-fig.org/per/coding-style/), which extends PSR-12. Note that the PHPCS config is using PSR-12 due to the fact that it does not support PER, yet. So PER is preferred, but PSR-12 is acceptable.
 
 All parameters, return values, and properties must use explicit type hints, except in cases where providing the correct type hint would be impossible given limitations of the oldest supported PHP version (see below).
 


### PR DESCRIPTION
The [PER Coding Style](https://www.php-fig.org/per/coding-style/) is the successor and extension of PSR-12. As such, we should be encouraging folks to use that standard. Some IDEs support it, and the AI agents will know what to do with it. Unfortunately, PHPCS doesn't yet support it. The good news is that if someone is using PER then PHPCS will not flag anything as incorrect, as it simply doesn't cover the areas that PER does, but PER covers everything PSR-12 did.

I didn't want to get full into this in the doc, but wanted to at least mention and address that PER _is_ the intended standard.