### PR TITLE
Add PHP lint workflow

### DIFF
--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -1,0 +1,59 @@
+name: PHP Code Linting
+
+on:
+  push:
+    branches:
+      - trunk
+      - 'feature/**'
+      - 'release/**'
+    # Only run if PHP-related files changed.
+    paths:
+      - '.github/workflows/php-lint.yml'
+      - '**.php'
+      - 'phpcs.xml.dist'
+      - 'phpstan.neon.dist'
+      - 'composer.json'
+      - 'composer.lock'
+  pull_request:
+    # Only run if PHP-related files changed.
+    paths:
+      - '.github/workflows/php-lint.yml'
+      - '**.php'
+      - 'phpcs.xml.dist'
+      - 'phpstan.neon.dist'
+      - 'composer.json'
+      - 'composer.lock'
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  php-lint:
+    name: PHP
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: 'latest'
+
+      - name: Validate Composer configuration
+        run: composer validate
+
+      - name: Install PHP dependencies
+        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520
+        with:
+          composer-options: '--prefer-dist'
+
+      - name: PHPStan
+        run: composer phpstan
+
+      - name: PHP Code Sniffer
+        run: composer phpcs

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -48,7 +48,7 @@ jobs:
         run: composer validate
 
       - name: Install PHP dependencies
-        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520
+        uses: ramsey/composer-install@v3
         with:
           composer-options: '--prefer-dist'
 


### PR DESCRIPTION
Adds GitHub Actions workflow to validate PHP syntax with PHPStan and PHPCS. The workflow runs on push and pull requests - the tools execute with the latest PHP version while PHPStan will validate the code against the version of PHP specified in `composer.json` (which is PHP 7.4).

(I used [WordPress/plugin-check](https://github.com/WordPress/plugin-check) for reference)