### PR TITLE
Adds documetation standards to contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ All code must be properly documented with PHPDoc blocks following these standard
 ### General rules
 - All descriptions must end with a period.
 - Use `@since n.e.x.t` for new code (will be replaced with actual version on release).
-- Place `@since` tags below the description and above `@param` tags.
+- Place `@since` tags below the description and above `@param` tags, with spaces around it.
 
 ### Method documentation
 - Method descriptions must start with a third-person verb (e.g., "Creates", "Returns", "Checks").
@@ -49,6 +49,7 @@ class AuthHandler
      * Validates user credentials against the database.
      *
      * @since n.e.x.t
+     * 
      * @param string $username The username to validate.
      * @param string $password The password to validate.
      * @return bool True if credentials are valid, false otherwise.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ All code must be properly documented with PHPDoc blocks following these standard
 ### General rules
 - All descriptions must end with a period.
 - Use `@since n.e.x.t` for new code (will be replaced with actual version on release).
-- Place `@since` tags below the description and above `@param` tags, with spaces around it.
+- Place `@since` tags below the description and above `@param` tags, with blank comment lines around it.
 
 ### Method documentation
 - Method descriptions must start with a third-person verb (e.g., "Creates", "Returns", "Checks").

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,48 @@ The following naming conventions must be followed for consistency and autoloadin
 - File names are the same as the class, trait, and interface name for PSR-4 autoloading.
 - Classes, interfaces, and traits, and namespaces are not prefixed with `Ai`, exluding the root namespace.
 
+## Documentation standards
+
+All code must be properly documented with PHPDoc blocks following these standards:
+
+### General rules
+- All descriptions must end with a period.
+- Use `@since n.e.x.t` for new code (will be replaced with actual version on release).
+- Place `@since` tags below the description and above `@param` tags.
+
+### Method documentation
+- Method descriptions must start with a third-person verb (e.g., "Creates", "Returns", "Checks").
+- Exceptions: Constructors and magic methods may use different phrasing.
+- All `@return` annotations must include a description.
+
+### Interface implementations
+- Use `{@inheritDoc}` instead of duplicating descriptions when implementing interface methods.
+- Only provide a unique description if it adds value beyond the interface documentation.
+
+### Example
+```php
+/**
+ * Handles user authentication requests.
+ *
+ * @since n.e.x.t
+ */
+class AuthHandler
+{
+    /**
+     * Validates user credentials against the database.
+     *
+     * @since n.e.x.t
+     * @param string $username The username to validate.
+     * @param string $password The password to validate.
+     * @return bool True if credentials are valid, false otherwise.
+     */
+    public function validate(string $username, string $password): bool
+    {
+        // Implementation
+    }
+}
+```
+
 ## PHP Compatibility
 
 All code must be backward compatible with PHP 7.4, which is the minimum required PHP version for this project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ All code must be properly documented with PHPDoc blocks following these standard
 ### Example
 ```php
 /**
- * Handles user authentication requests.
+ * Class for handling user authentication requests.
  *
  * @since n.e.x.t
  */


### PR DESCRIPTION
This adds details to the CONTRIBUTING doc on documentation standards not covered in PER. The standards should not conflict with PER, but are additional preferences for readability.