### PR TITLE
Add isType() fallback method to MimeType value object

### DIFF
--- a/src/Files/ValueObjects/MimeType.php
+++ b/src/Files/ValueObjects/MimeType.php
@@ -179,7 +179,7 @@ final class MimeType
      * @param string $mimeType The MIME type to check.
      * @return bool True if the MIME type has the specified MIME type.
      */
-    public function hasMimeType(string $mimeType): bool
+    public function isType(string $mimeType): bool
     {
         return strpos($this->value, $mimeType . '/') === 0;
     }
@@ -193,7 +193,7 @@ final class MimeType
      */
     public function isImage(): bool
     {
-        return $this->hasMimeType('image');
+        return $this->isType('image');
     }
 
     /**
@@ -205,7 +205,7 @@ final class MimeType
      */
     public function isAudio(): bool
     {
-        return $this->hasMimeType('audio');
+        return $this->isType('audio');
     }
 
     /**
@@ -217,7 +217,7 @@ final class MimeType
      */
     public function isVideo(): bool
     {
-        return $this->hasMimeType('video');
+        return $this->isType('video');
     }
 
     /**
@@ -229,7 +229,7 @@ final class MimeType
      */
     public function isText(): bool
     {
-        return $this->hasMimeType('text');
+        return $this->isType('text');
     }
 
     /**

--- a/src/Files/ValueObjects/MimeType.php
+++ b/src/Files/ValueObjects/MimeType.php
@@ -170,6 +170,21 @@ final class MimeType
     }
 
     /**
+     * Checks if this MIME type has a specific MIME type.
+     *
+     * This method checks if the MIME type starts with the specified MIME type.
+     *
+     * @since n.e.x.t
+     *
+     * @param string $mimeType The MIME type to check.
+     * @return bool True if the MIME type has the specified MIME type.
+     */
+    public function hasMimeType(string $mimeType): bool
+    {
+        return strpos($this->value, $mimeType . '/') === 0;
+    }
+
+    /**
      * Checks if this is an image MIME type.
      *
      * @since n.e.x.t
@@ -178,7 +193,7 @@ final class MimeType
      */
     public function isImage(): bool
     {
-        return strpos($this->value, 'image/') === 0;
+        return $this->hasMimeType('image');
     }
 
     /**
@@ -190,7 +205,7 @@ final class MimeType
      */
     public function isAudio(): bool
     {
-        return strpos($this->value, 'audio/') === 0;
+        return $this->hasMimeType('audio');
     }
 
     /**
@@ -202,7 +217,7 @@ final class MimeType
      */
     public function isVideo(): bool
     {
-        return strpos($this->value, 'video/') === 0;
+        return $this->hasMimeType('video');
     }
 
     /**
@@ -214,7 +229,7 @@ final class MimeType
      */
     public function isText(): bool
     {
-        return strpos($this->value, 'text/') === 0;
+        return $this->hasMimeType('text');
     }
 
     /**

--- a/src/Files/ValueObjects/MimeType.php
+++ b/src/Files/ValueObjects/MimeType.php
@@ -181,7 +181,7 @@ final class MimeType
      */
     public function isType(string $mimeType): bool
     {
-        return strpos($this->value, $mimeType . '/') === 0;
+        return strpos($this->value, strtolower($mimeType) . '/') === 0;
     }
 
     /**

--- a/src/Files/ValueObjects/MimeType.php
+++ b/src/Files/ValueObjects/MimeType.php
@@ -170,14 +170,15 @@ final class MimeType
     }
 
     /**
-     * Checks if this MIME type has a specific MIME type.
+     * Checks if this MIME type is a specific type.
      *
-     * This method checks if the MIME type starts with the specified MIME type.
+     * This method returns true when the stored MIME type begins with the
+     * given prefix. For example, `"audio"` matches `"audio/mpeg"`.
      *
      * @since n.e.x.t
      *
-     * @param string $mimeType The MIME type to check.
-     * @return bool True if the MIME type has the specified MIME type.
+     * @param string $mimeType The MIME type prefix to check (e.g., "audio", "image").
+     * @return bool True if this MIME type is of the specified type.
      */
     public function isType(string $mimeType): bool
     {

--- a/tests/unit/Files/ValueObjects/MimeTypeTest.php
+++ b/tests/unit/Files/ValueObjects/MimeTypeTest.php
@@ -288,10 +288,10 @@ class MimeTypeTest extends TestCase
         $mimeType = new MimeType('image/jpeg');
         $fontType = new MimeType('font/ttf');
         
-        $this->assertTrue($mimeType->hasMimeType('image'));
-        $this->assertFalse($mimeType->hasMimeType('video'));
+        $this->assertTrue($mimeType->isType('image'));
+        $this->assertFalse($mimeType->isType('video'));
 
-        $this->assertTrue($fontType->hasMimeType('font'));
-        $this->assertFalse($fontType->hasMimeType('image'));
+        $this->assertTrue($fontType->isType('font'));
+        $this->assertFalse($fontType->isType('image'));
     }
 }

--- a/tests/unit/Files/ValueObjects/MimeTypeTest.php
+++ b/tests/unit/Files/ValueObjects/MimeTypeTest.php
@@ -282,4 +282,16 @@ class MimeTypeTest extends TestCase
         $mimeType = new MimeType('IMAGE/JPEG');
         $this->assertEquals('image/jpeg', (string) $mimeType);
     }
+
+    public function testHasMimeType(): void
+    {
+        $mimeType = new MimeType('image/jpeg');
+        $fontType = new MimeType('font/ttf');
+        
+        $this->assertTrue($mimeType->hasMimeType('image'));
+        $this->assertFalse($mimeType->hasMimeType('video'));
+
+        $this->assertTrue($fontType->hasMimeType('font'));
+        $this->assertFalse($fontType->hasMimeType('image'));
+    }
 }

--- a/tests/unit/Files/ValueObjects/MimeTypeTest.php
+++ b/tests/unit/Files/ValueObjects/MimeTypeTest.php
@@ -283,15 +283,21 @@ class MimeTypeTest extends TestCase
         $this->assertEquals('image/jpeg', (string) $mimeType);
     }
 
-    public function testHasMimeType(): void
+    public function testIsType(): void
     {
-        $mimeType = new MimeType('image/jpeg');
+        $imageType = new MimeType('image/jpeg');
         $fontType = new MimeType('font/ttf');
         
-        $this->assertTrue($mimeType->isType('image'));
-        $this->assertFalse($mimeType->isType('video'));
+        $this->assertTrue($imageType->isType('image'));
+        $this->assertFalse($imageType->isType('video'));
 
         $this->assertTrue($fontType->isType('font'));
         $this->assertFalse($fontType->isType('image'));
+
+        // Case insensitive.
+        $this->assertTrue($fontType->isType('Font'));
+        $this->assertTrue($fontType->isType('FONT'));
+        $this->assertTrue($imageType->isType('image'));
+        $this->assertTrue($imageType->isType('IMAGE'));
     }
 }


### PR DESCRIPTION
### What's changed

- New method: isType(string $prefix): bool added to `WordPress\AiClient\Files\ValueObjects\MimeType`.
- Refactor: `isImage()`, `isAudio()`, `isVideo()`, and `isText()` now delegate to isType() instead of repeating strpos() logic.
- Tests: Added `testIsType()` to cover positive and negative cases; all existing tests remain green.

### Why it matters
- Keeps the convenient is*() helpers for common categories while introducing a general-purpose fallback for any non-enumerated MIME groups (e.g., fonts, scripts) without bloating the API.
- Centralizes prefix matching, reducing duplication and clarifying intent.
- Lays groundwork for future category checks with no breaking changes.
- All tests including the new MimeTypeTest::testIsType() should pass.

Open to feedback, happy to adjust if we'd like any tweaks