### PR TITLE
Adds a new `isType(string $type): bool` method to the File DTO, enabling specific MIME type checking beyond the existing predefined type methods.

### DIFF
--- a/src/Files/DTO/File.php
+++ b/src/Files/DTO/File.php
@@ -295,7 +295,7 @@ class File extends AbstractDataValueObject
      *
      * @return bool True if the file is of the specified type.
      */
-    public function isType(string $type): bool
+    public function isMimeType(string $type): bool
     {
         return $this->mimeType->isType($type);
     }

--- a/src/Files/DTO/File.php
+++ b/src/Files/DTO/File.php
@@ -87,10 +87,11 @@ class File extends AbstractDataValueObject
             return;
         }
 
-        // Check if it's a data URI
+        // Data URI pattern.
         $dataUriPattern = '/^data:(?:([a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+.]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+.]*'
-            . '(?:;[a-zA-Z0-9\-]+=[a-zA-Z0-9\-]+)*)?;)?base64,([A-Za-z0-9+\/]*={0,2})$/';
+        . '(?:;[a-zA-Z0-9\-]+=[a-zA-Z0-9\-]+)*)?;)?base64,([A-Za-z0-9+\/]*={0,2})$/';
 
+        // Check if it's a data URI.
         if (preg_match($dataUriPattern, $file, $matches)) {
             $this->fileType = FileTypeEnum::inline();
             $this->base64Data = $matches[2]; // Extract just the base64 data
@@ -283,6 +284,20 @@ class File extends AbstractDataValueObject
     public function isText(): bool
     {
         return $this->mimeType->isText();
+    }
+
+    /**
+     * Checks if the file is a specific MIME type.
+     *
+     * @since n.e.x.t
+     *
+     * @param string $type The type to check.
+     *
+     * @return bool True if the file is of the specified type.
+     */
+    public function isType(string $type): bool
+    {
+        return $this->mimeType->isType($type);
     }
 
     /**

--- a/src/Files/DTO/File.php
+++ b/src/Files/DTO/File.php
@@ -291,7 +291,7 @@ class File extends AbstractDataValueObject
      *
      * @since n.e.x.t
      *
-     * @param string $type The type to check.
+     * @param string $type The mime type to check (e.g. 'image', 'text', 'video', 'audio').
      *
      * @return bool True if the file is of the specified type.
      */

--- a/tests/unit/Files/DTO/FileTest.php
+++ b/tests/unit/Files/DTO/FileTest.php
@@ -207,6 +207,10 @@ class FileTest extends TestCase
         $this->assertFalse($file->isImage());
         $this->assertFalse($file->isAudio());
         $this->assertFalse($file->isText());
+        $this->assertTrue($file->isType('video'));
+        $this->assertFalse($file->isType('image'));
+        $this->assertFalse($file->isType('audio'));
+        $this->assertFalse($file->isType('text'));
     }
 
     /**

--- a/tests/unit/Files/DTO/FileTest.php
+++ b/tests/unit/Files/DTO/FileTest.php
@@ -207,10 +207,10 @@ class FileTest extends TestCase
         $this->assertFalse($file->isImage());
         $this->assertFalse($file->isAudio());
         $this->assertFalse($file->isText());
-        $this->assertTrue($file->isType('video'));
-        $this->assertFalse($file->isType('image'));
-        $this->assertFalse($file->isType('audio'));
-        $this->assertFalse($file->isType('text'));
+        $this->assertTrue($file->isMimeType('video'));
+        $this->assertFalse($file->isMimeType('image'));
+        $this->assertFalse($file->isMimeType('audio'));
+        $this->assertFalse($file->isMimeType('text'));
     }
 
     /**


### PR DESCRIPTION
## Summary
Adds a new `isType(string $type): bool` method to the File DTO class, enabling specific MIME type checking beyond the existing predefined type methods.

## Changes
- **New Method**: `File::isType(string $type): bool` - delegates to MimeType object for flexible type checking
- **Code Quality**: Improved comments and formatting for data URI pattern handling
- **Testing**: Extended `testMimeTypeMethods()` to include assertions for the new `isType()` method

## Testing
- Added test cases for positive and negative type detection
- Follows existing test patterns in `testMimeTypeMethods()`