### PR TITLE
Corrects DTO abstract class name

### DIFF
--- a/src/Common/AbstractDataTransferObject.php
+++ b/src/Common/AbstractDataTransferObject.php
@@ -27,7 +27,7 @@ use WordPress\AiClient\Common\Contracts\WithJsonSchemaInterface;
  * @template TArrayShape of array<string, mixed>
  * @implements WithArrayTransformationInterface<TArrayShape>
  */
-abstract class AbstractDataValueObject implements
+abstract class AbstractDataTransferObject implements
     WithArrayTransformationInterface,
     WithJsonSchemaInterface,
     JsonSerializable

--- a/src/Files/DTO/File.php
+++ b/src/Files/DTO/File.php
@@ -6,7 +6,7 @@ namespace WordPress\AiClient\Files\DTO;
 
 use InvalidArgumentException;
 use RuntimeException;
-use WordPress\AiClient\Common\AbstractDataValueObject;
+use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Files\Enums\FileTypeEnum;
 use WordPress\AiClient\Files\ValueObjects\MimeType;
 
@@ -25,9 +25,9 @@ use WordPress\AiClient\Files\ValueObjects\MimeType;
  *     base64Data?: string
  * }
  *
- * @extends AbstractDataValueObject<FileArrayShape>
+ * @extends AbstractDataTransferObject<FileArrayShape>
  */
-class File extends AbstractDataValueObject
+class File extends AbstractDataTransferObject
 {
     public const KEY_FILE_TYPE = 'fileType';
     public const KEY_MIME_TYPE = 'mimeType';

--- a/src/Messages/DTO/Message.php
+++ b/src/Messages/DTO/Message.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace WordPress\AiClient\Messages\DTO;
 
 use InvalidArgumentException;
-use WordPress\AiClient\Common\AbstractDataValueObject;
+use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 
 /**
@@ -23,9 +23,9 @@ use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
  *     parts: array<MessagePartArrayShape>
  * }
  *
- * @extends AbstractDataValueObject<MessageArrayShape>
+ * @extends AbstractDataTransferObject<MessageArrayShape>
  */
-class Message extends AbstractDataValueObject
+class Message extends AbstractDataTransferObject
 {
     public const KEY_ROLE = 'role';
     public const KEY_PARTS = 'parts';

--- a/src/Messages/DTO/MessagePart.php
+++ b/src/Messages/DTO/MessagePart.php
@@ -6,7 +6,7 @@ namespace WordPress\AiClient\Messages\DTO;
 
 use InvalidArgumentException;
 use RuntimeException;
-use WordPress\AiClient\Common\AbstractDataValueObject;
+use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Messages\Enums\MessagePartTypeEnum;
 use WordPress\AiClient\Tools\DTO\FunctionCall;
@@ -32,9 +32,9 @@ use WordPress\AiClient\Tools\DTO\FunctionResponse;
  *     functionResponse?: FunctionResponseArrayShape
  * }
  *
- * @extends AbstractDataValueObject<MessagePartArrayShape>
+ * @extends AbstractDataTransferObject<MessagePartArrayShape>
  */
-class MessagePart extends AbstractDataValueObject
+class MessagePart extends AbstractDataTransferObject
 {
     public const KEY_TYPE = 'type';
     public const KEY_TEXT = 'text';

--- a/src/Operations/DTO/GenerativeAiOperation.php
+++ b/src/Operations/DTO/GenerativeAiOperation.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace WordPress\AiClient\Operations\DTO;
 
 use InvalidArgumentException;
-use WordPress\AiClient\Common\AbstractDataValueObject;
+use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Operations\Contracts\OperationInterface;
 use WordPress\AiClient\Operations\Enums\OperationStateEnum;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
@@ -22,9 +22,9 @@ use WordPress\AiClient\Results\DTO\GenerativeAiResult;
  *
  * @phpstan-type GenerativeAiOperationArrayShape array{id: string, state: string, result?: GenerativeAiResultArrayShape}
  *
- * @extends AbstractDataValueObject<GenerativeAiOperationArrayShape>
+ * @extends AbstractDataTransferObject<GenerativeAiOperationArrayShape>
  */
-class GenerativeAiOperation extends AbstractDataValueObject implements OperationInterface
+class GenerativeAiOperation extends AbstractDataTransferObject implements OperationInterface
 {
     public const KEY_ID = 'id';
     public const KEY_STATE = 'state';

--- a/src/Providers/DTO/ProviderMetadata.php
+++ b/src/Providers/DTO/ProviderMetadata.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace WordPress\AiClient\Providers\DTO;
 
-use WordPress\AiClient\Common\AbstractDataValueObject;
+use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
 
 /**
@@ -21,9 +21,9 @@ use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
  *     type: string
  * }
  *
- * @extends AbstractDataValueObject<ProviderMetadataArrayShape>
+ * @extends AbstractDataTransferObject<ProviderMetadataArrayShape>
  */
-class ProviderMetadata extends AbstractDataValueObject
+class ProviderMetadata extends AbstractDataTransferObject
 {
     public const KEY_ID = 'id';
     public const KEY_NAME = 'name';

--- a/src/Providers/DTO/ProviderModelsMetadata.php
+++ b/src/Providers/DTO/ProviderModelsMetadata.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace WordPress\AiClient\Providers\DTO;
 
 use InvalidArgumentException;
-use WordPress\AiClient\Common\AbstractDataValueObject;
+use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 
 /**
@@ -24,9 +24,9 @@ use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
  *     models: list<ModelMetadataArrayShape>
  * }
  *
- * @extends AbstractDataValueObject<ProviderModelsMetadataArrayShape>
+ * @extends AbstractDataTransferObject<ProviderModelsMetadataArrayShape>
  */
-class ProviderModelsMetadata extends AbstractDataValueObject
+class ProviderModelsMetadata extends AbstractDataTransferObject
 {
     public const KEY_PROVIDER = 'provider';
     public const KEY_MODELS = 'models';

--- a/src/Providers/Models/DTO/ModelConfig.php
+++ b/src/Providers/Models/DTO/ModelConfig.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace WordPress\AiClient\Providers\Models\DTO;
 
 use InvalidArgumentException;
-use WordPress\AiClient\Common\AbstractDataValueObject;
+use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Messages\Enums\ModalityEnum;
 use WordPress\AiClient\Tools\DTO\Tool;
 
@@ -39,9 +39,9 @@ use WordPress\AiClient\Tools\DTO\Tool;
  *     customOptions?: array<string, mixed>
  * }
  *
- * @extends AbstractDataValueObject<ModelConfigArrayShape>
+ * @extends AbstractDataTransferObject<ModelConfigArrayShape>
  */
-class ModelConfig extends AbstractDataValueObject
+class ModelConfig extends AbstractDataTransferObject
 {
     public const KEY_OUTPUT_MODALITIES = 'outputModalities';
     public const KEY_SYSTEM_INSTRUCTION = 'systemInstruction';

--- a/src/Providers/Models/DTO/ModelMetadata.php
+++ b/src/Providers/Models/DTO/ModelMetadata.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace WordPress\AiClient\Providers\Models\DTO;
 
 use InvalidArgumentException;
-use WordPress\AiClient\Common\AbstractDataValueObject;
+use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 
 /**
@@ -25,9 +25,9 @@ use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
  *     supportedOptions: list<SupportedOptionArrayShape>
  * }
  *
- * @extends AbstractDataValueObject<ModelMetadataArrayShape>
+ * @extends AbstractDataTransferObject<ModelMetadataArrayShape>
  */
-class ModelMetadata extends AbstractDataValueObject
+class ModelMetadata extends AbstractDataTransferObject
 {
     public const KEY_ID = 'id';
     public const KEY_NAME = 'name';

--- a/src/Providers/Models/DTO/ModelRequirements.php
+++ b/src/Providers/Models/DTO/ModelRequirements.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace WordPress\AiClient\Providers\Models\DTO;
 
 use InvalidArgumentException;
-use WordPress\AiClient\Common\AbstractDataValueObject;
+use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 
 /**
@@ -23,9 +23,9 @@ use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
  *     requiredOptions: list<RequiredOptionArrayShape>
  * }
  *
- * @extends AbstractDataValueObject<ModelRequirementsArrayShape>
+ * @extends AbstractDataTransferObject<ModelRequirementsArrayShape>
  */
-class ModelRequirements extends AbstractDataValueObject
+class ModelRequirements extends AbstractDataTransferObject
 {
     public const KEY_REQUIRED_CAPABILITIES = 'requiredCapabilities';
     public const KEY_REQUIRED_OPTIONS = 'requiredOptions';

--- a/src/Providers/Models/DTO/RequiredOption.php
+++ b/src/Providers/Models/DTO/RequiredOption.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace WordPress\AiClient\Providers\Models\DTO;
 
-use WordPress\AiClient\Common\AbstractDataValueObject;
+use WordPress\AiClient\Common\AbstractDataTransferObject;
 
 /**
  * Represents an option that the implementing code requires the model to support.
@@ -19,9 +19,9 @@ use WordPress\AiClient\Common\AbstractDataValueObject;
  *     value: mixed
  * }
  *
- * @extends AbstractDataValueObject<RequiredOptionArrayShape>
+ * @extends AbstractDataTransferObject<RequiredOptionArrayShape>
  */
-class RequiredOption extends AbstractDataValueObject
+class RequiredOption extends AbstractDataTransferObject
 {
     public const KEY_NAME = 'name';
     public const KEY_VALUE = 'value';

--- a/src/Providers/Models/DTO/SupportedOption.php
+++ b/src/Providers/Models/DTO/SupportedOption.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace WordPress\AiClient\Providers\Models\DTO;
 
 use InvalidArgumentException;
-use WordPress\AiClient\Common\AbstractDataValueObject;
+use WordPress\AiClient\Common\AbstractDataTransferObject;
 
 /**
  * Represents a supported configuration option for an AI model.
@@ -20,9 +20,9 @@ use WordPress\AiClient\Common\AbstractDataValueObject;
  *     supportedValues?: list<mixed>
  * }
  *
- * @extends AbstractDataValueObject<SupportedOptionArrayShape>
+ * @extends AbstractDataTransferObject<SupportedOptionArrayShape>
  */
-class SupportedOption extends AbstractDataValueObject
+class SupportedOption extends AbstractDataTransferObject
 {
     public const KEY_NAME = 'name';
     public const KEY_SUPPORTED_VALUES = 'supportedValues';

--- a/src/Results/DTO/Candidate.php
+++ b/src/Results/DTO/Candidate.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace WordPress\AiClient\Results\DTO;
 
 use InvalidArgumentException;
-use WordPress\AiClient\Common\AbstractDataValueObject;
+use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Results\Enums\FinishReasonEnum;
 
@@ -21,9 +21,9 @@ use WordPress\AiClient\Results\Enums\FinishReasonEnum;
  *
  * @phpstan-type CandidateArrayShape array{message: MessageArrayShape, finishReason: string, tokenCount: int}
  *
- * @extends AbstractDataValueObject<CandidateArrayShape>
+ * @extends AbstractDataTransferObject<CandidateArrayShape>
  */
-class Candidate extends AbstractDataValueObject
+class Candidate extends AbstractDataTransferObject
 {
     public const KEY_MESSAGE = 'message';
     public const KEY_FINISH_REASON = 'finishReason';

--- a/src/Results/DTO/GenerativeAiResult.php
+++ b/src/Results/DTO/GenerativeAiResult.php
@@ -6,7 +6,7 @@ namespace WordPress\AiClient\Results\DTO;
 
 use InvalidArgumentException;
 use RuntimeException;
-use WordPress\AiClient\Common\AbstractDataValueObject;
+use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Results\Contracts\ResultInterface;
@@ -29,9 +29,9 @@ use WordPress\AiClient\Results\Contracts\ResultInterface;
  *     providerMetadata?: array<string, mixed>
  * }
  *
- * @extends AbstractDataValueObject<GenerativeAiResultArrayShape>
+ * @extends AbstractDataTransferObject<GenerativeAiResultArrayShape>
  */
-class GenerativeAiResult extends AbstractDataValueObject implements ResultInterface
+class GenerativeAiResult extends AbstractDataTransferObject implements ResultInterface
 {
     public const KEY_ID = 'id';
     public const KEY_CANDIDATES = 'candidates';

--- a/src/Results/DTO/TokenUsage.php
+++ b/src/Results/DTO/TokenUsage.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace WordPress\AiClient\Results\DTO;
 
-use WordPress\AiClient\Common\AbstractDataValueObject;
+use WordPress\AiClient\Common\AbstractDataTransferObject;
 
 /**
  * Represents token usage statistics for an AI operation.
@@ -20,9 +20,9 @@ use WordPress\AiClient\Common\AbstractDataValueObject;
  *     totalTokens: int
  * }
  *
- * @extends AbstractDataValueObject<TokenUsageArrayShape>
+ * @extends AbstractDataTransferObject<TokenUsageArrayShape>
  */
-class TokenUsage extends AbstractDataValueObject
+class TokenUsage extends AbstractDataTransferObject
 {
     public const KEY_PROMPT_TOKENS = 'promptTokens';
     public const KEY_COMPLETION_TOKENS = 'completionTokens';

--- a/src/Tools/DTO/FunctionCall.php
+++ b/src/Tools/DTO/FunctionCall.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace WordPress\AiClient\Tools\DTO;
 
 use InvalidArgumentException;
-use WordPress\AiClient\Common\AbstractDataValueObject;
+use WordPress\AiClient\Common\AbstractDataTransferObject;
 
 /**
  * Represents a function call request from an AI model.
@@ -17,9 +17,9 @@ use WordPress\AiClient\Common\AbstractDataValueObject;
  *
  * @phpstan-type FunctionCallArrayShape array{id?: string, name?: string, args?: array<string, mixed>}
  *
- * @extends AbstractDataValueObject<FunctionCallArrayShape>
+ * @extends AbstractDataTransferObject<FunctionCallArrayShape>
  */
-class FunctionCall extends AbstractDataValueObject
+class FunctionCall extends AbstractDataTransferObject
 {
     public const KEY_ID = 'id';
     public const KEY_NAME = 'name';

--- a/src/Tools/DTO/FunctionDeclaration.php
+++ b/src/Tools/DTO/FunctionDeclaration.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace WordPress\AiClient\Tools\DTO;
 
 use InvalidArgumentException;
-use WordPress\AiClient\Common\AbstractDataValueObject;
+use WordPress\AiClient\Common\AbstractDataTransferObject;
 
 /**
  * Represents a function declaration for AI models.
@@ -17,9 +17,9 @@ use WordPress\AiClient\Common\AbstractDataValueObject;
  *
  * @phpstan-type FunctionDeclarationArrayShape array{name: string, description: string, parameters?: mixed}
  *
- * @extends AbstractDataValueObject<FunctionDeclarationArrayShape>
+ * @extends AbstractDataTransferObject<FunctionDeclarationArrayShape>
  */
-class FunctionDeclaration extends AbstractDataValueObject
+class FunctionDeclaration extends AbstractDataTransferObject
 {
     public const KEY_NAME = 'name';
     public const KEY_DESCRIPTION = 'description';

--- a/src/Tools/DTO/FunctionResponse.php
+++ b/src/Tools/DTO/FunctionResponse.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace WordPress\AiClient\Tools\DTO;
 
-use WordPress\AiClient\Common\AbstractDataValueObject;
+use WordPress\AiClient\Common\AbstractDataTransferObject;
 
 /**
  * Represents a response to a function call.
@@ -16,9 +16,9 @@ use WordPress\AiClient\Common\AbstractDataValueObject;
  *
  * @phpstan-type FunctionResponseArrayShape array{id: string, name: string, response: mixed}
  *
- * @extends AbstractDataValueObject<FunctionResponseArrayShape>
+ * @extends AbstractDataTransferObject<FunctionResponseArrayShape>
  */
-class FunctionResponse extends AbstractDataValueObject
+class FunctionResponse extends AbstractDataTransferObject
 {
     public const KEY_ID = 'id';
     public const KEY_NAME = 'name';

--- a/src/Tools/DTO/Tool.php
+++ b/src/Tools/DTO/Tool.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace WordPress\AiClient\Tools\DTO;
 
 use InvalidArgumentException;
-use WordPress\AiClient\Common\AbstractDataValueObject;
+use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Providers\Enums\ToolTypeEnum;
 
 /**
@@ -25,9 +25,9 @@ use WordPress\AiClient\Providers\Enums\ToolTypeEnum;
  *     webSearch?: WebSearchArrayShape
  * }
  *
- * @extends AbstractDataValueObject<ToolArrayShape>
+ * @extends AbstractDataTransferObject<ToolArrayShape>
  */
-class Tool extends AbstractDataValueObject
+class Tool extends AbstractDataTransferObject
 {
     public const KEY_TYPE = 'type';
     public const KEY_FUNCTION_DECLARATIONS = 'functionDeclarations';

--- a/src/Tools/DTO/WebSearch.php
+++ b/src/Tools/DTO/WebSearch.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace WordPress\AiClient\Tools\DTO;
 
-use WordPress\AiClient\Common\AbstractDataValueObject;
+use WordPress\AiClient\Common\AbstractDataTransferObject;
 
 /**
  * Represents web search configuration for AI models.
@@ -16,9 +16,9 @@ use WordPress\AiClient\Common\AbstractDataValueObject;
  *
  * @phpstan-type WebSearchArrayShape array{allowedDomains?: string[], disallowedDomains?: string[]}
  *
- * @extends AbstractDataValueObject<WebSearchArrayShape>
+ * @extends AbstractDataTransferObject<WebSearchArrayShape>
  */
-class WebSearch extends AbstractDataValueObject
+class WebSearch extends AbstractDataTransferObject
 {
     public const KEY_ALLOWED_DOMAINS = 'allowedDomains';
     public const KEY_DISALLOWED_DOMAINS = 'disallowedDomains';

--- a/tests/unit/Common/AbstractDataValueObjectTest.php
+++ b/tests/unit/Common/AbstractDataValueObjectTest.php
@@ -7,19 +7,19 @@ namespace WordPress\AiClient\Tests\unit\Common;
 use JsonSerializable;
 use PHPUnit\Framework\TestCase;
 use stdClass;
-use WordPress\AiClient\Common\AbstractDataValueObject;
+use WordPress\AiClient\Common\AbstractDataTransferObject;
 
 /**
- * Tests for the AbstractDataValueObject class.
+ * Tests for the AbstractDataTransferObject class.
  *
- * This test class verifies that the AbstractDataValueObject correctly
+ * This test class verifies that the AbstractDataTransferObject correctly
  * implements JSON serialization with proper empty array to object conversion
  * based on JSON schema definitions. It combines the functionality previously
  * tested in HasJsonSerializationTest.
  *
- * @covers \WordPress\AiClient\Common\AbstractDataValueObject
+ * @covers \WordPress\AiClient\Common\AbstractDataTransferObject
  */
-class AbstractDataValueObjectTest extends TestCase
+class AbstractDataTransferObjectTest extends TestCase
 {
     /**
      * Tests that empty arrays are converted to objects when schema expects object type.
@@ -28,7 +28,7 @@ class AbstractDataValueObjectTest extends TestCase
      */
     public function testEmptyArraysConvertedToObjects(): void
     {
-        $testObject = new class extends AbstractDataValueObject {
+        $testObject = new class extends AbstractDataTransferObject {
             public function toArray(): array
             {
                 return [
@@ -109,7 +109,7 @@ class AbstractDataValueObjectTest extends TestCase
      */
     public function testNestedObjectConversion(): void
     {
-        $testObject = new class extends AbstractDataValueObject {
+        $testObject = new class extends AbstractDataTransferObject {
             public function toArray(): array
             {
                 return [
@@ -170,7 +170,7 @@ class AbstractDataValueObjectTest extends TestCase
      */
     public function testOneOfSchemaHandling(): void
     {
-        $testObject = new class extends AbstractDataValueObject {
+        $testObject = new class extends AbstractDataTransferObject {
             public function toArray(): array
             {
                 return [
@@ -250,7 +250,7 @@ class AbstractDataValueObjectTest extends TestCase
      */
     public function testArrayOfObjectsProcessing(): void
     {
-        $testObject = new class extends AbstractDataValueObject {
+        $testObject = new class extends AbstractDataTransferObject {
             public function toArray(): array
             {
                 return [
@@ -321,7 +321,7 @@ class AbstractDataValueObjectTest extends TestCase
      */
     public function testDeeplyNestedStructures(): void
     {
-        $testObject = new class extends AbstractDataValueObject {
+        $testObject = new class extends AbstractDataTransferObject {
             public function toArray(): array
             {
                 return [
@@ -397,7 +397,7 @@ class AbstractDataValueObjectTest extends TestCase
      */
     public function testNonArrayDataPassesThrough(): void
     {
-        $testObject = new class extends AbstractDataValueObject {
+        $testObject = new class extends AbstractDataTransferObject {
             public function toArray(): array
             {
                 return [
@@ -468,7 +468,7 @@ class AbstractDataValueObjectTest extends TestCase
      */
     public function testMissingSchemaProperties(): void
     {
-        $testObject = new class extends AbstractDataValueObject {
+        $testObject = new class extends AbstractDataTransferObject {
             public function toArray(): array
             {
                 return [
@@ -516,13 +516,13 @@ class AbstractDataValueObjectTest extends TestCase
     }
 
     /**
-     * Tests that AbstractDataValueObject implements all required interfaces.
+     * Tests that AbstractDataTransferObject implements all required interfaces.
      *
      * @return void
      */
     public function testImplementsRequiredInterfaces(): void
     {
-        $testObject = new class extends AbstractDataValueObject {
+        $testObject = new class extends AbstractDataTransferObject {
             public function toArray(): array
             {
                 return ['test' => 'value'];


### PR DESCRIPTION
I apparently accidentally named the abstract DTO class "AbstractData**Value**Object" instead of `AbstractDataTransferObject`. 🤦‍♂️ 

This corrects that typo.