### PR TITLE
Implement additional model config params

### DIFF
--- a/src/Files/Enums/MediaOrientationEnum.php
+++ b/src/Files/Enums/MediaOrientationEnum.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Files\Enums;
+
+use WordPress\AiClient\Common\AbstractEnum;
+
+/**
+ * Represents the type of file storage.
+ *
+ * @method static self square() Returns the square orientation
+ * @method static self landscape() Returns the landscape orientation.
+ * @method static self portrait() Returns the portrait orientation.
+ * @method bool isSquare() Checks if this is an square orientation
+ * @method bool isLandscape() Checks if this is a landscape orientation.
+ * @method bool isPortrait() Checks if this is a portrait orientation.
+ *
+ * @since n.e.x.t
+ */
+class MediaOrientationEnum extends AbstractEnum
+{
+    /**
+     * Square orientation.
+     *
+     * @var string
+     */
+    public const SQUARE = 'square';
+
+    /**
+     * Landscape orientation.
+     *
+     * @var string
+     */
+    public const LANDSCAPE = 'landscape';
+
+    /**
+     * Portrait orientation.
+     *
+     * @var string
+     */
+    public const PORTRAIT = 'portrait';
+}

--- a/src/Providers/Models/DTO/ModelConfig.php
+++ b/src/Providers/Models/DTO/ModelConfig.php
@@ -7,6 +7,7 @@ namespace WordPress\AiClient\Providers\Models\DTO;
 use InvalidArgumentException;
 use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Files\Enums\FileTypeEnum;
+use WordPress\AiClient\Files\Enums\MediaOrientationEnum;
 use WordPress\AiClient\Messages\Enums\ModalityEnum;
 use WordPress\AiClient\Tools\DTO\Tool;
 
@@ -38,6 +39,7 @@ use WordPress\AiClient\Tools\DTO\Tool;
  *     outputFileType?: string,
  *     outputMimeType?: string,
  *     outputSchema?: array<string, mixed>,
+ *     outputMediaOrientation?: string,
  *     customOptions?: array<string, mixed>
  * }
  *
@@ -61,6 +63,7 @@ class ModelConfig extends AbstractDataTransferObject
     public const KEY_OUTPUT_FILE_TYPE = 'outputFileType';
     public const KEY_OUTPUT_MIME_TYPE = 'outputMimeType';
     public const KEY_OUTPUT_SCHEMA = 'outputSchema';
+    public const KEY_OUTPUT_MEDIA_ORIENTATION = 'outputMediaOrientation';
     public const KEY_CUSTOM_OPTIONS = 'customOptions';
 
     /**
@@ -142,6 +145,11 @@ class ModelConfig extends AbstractDataTransferObject
      * @var array<string, mixed>|null Output schema (JSON schema).
      */
     protected ?array $outputSchema = null;
+
+    /**
+     * @var MediaOrientationEnum|null Output media orientation.
+     */
+    protected ?MediaOrientationEnum $outputMediaOrientation = null;
 
     /**
      * @var array<string, mixed> Custom provider-specific options.
@@ -559,6 +567,30 @@ class ModelConfig extends AbstractDataTransferObject
     }
 
     /**
+     * Sets the output media orientation.
+     *
+     * @since n.e.x.t
+     *
+     * @param MediaOrientationEnum $outputMediaOrientation The output media orientation.
+     */
+    public function setOutputMediaOrientation(MediaOrientationEnum $outputMediaOrientation): void
+    {
+        $this->outputMediaOrientation = $outputMediaOrientation;
+    }
+
+    /**
+     * Gets the output media orientation.
+     *
+     * @since n.e.x.t
+     *
+     * @return MediaOrientationEnum|null The output media orientation.
+     */
+    public function getOutputMediaOrientation(): ?MediaOrientationEnum
+    {
+        return $this->outputMediaOrientation;
+    }
+
+    /**
      * Sets a single custom option.
      *
      * @since n.e.x.t
@@ -687,6 +719,11 @@ class ModelConfig extends AbstractDataTransferObject
                     'additionalProperties' => true,
                     'description' => 'Output schema (JSON schema).',
                 ],
+                self::KEY_OUTPUT_MEDIA_ORIENTATION => [
+                    'type' => 'string',
+                    'enum' => MediaOrientationEnum::getValues(),
+                    'description' => 'Output media orientation.',
+                ],
                 self::KEY_CUSTOM_OPTIONS => [
                     'type' => 'object',
                     'additionalProperties' => true,
@@ -779,6 +816,10 @@ class ModelConfig extends AbstractDataTransferObject
             $data[self::KEY_OUTPUT_SCHEMA] = $this->outputSchema;
         }
 
+        if ($this->outputMediaOrientation !== null) {
+            $data[self::KEY_OUTPUT_MEDIA_ORIENTATION] = $this->outputMediaOrientation->value;
+        }
+
         $data[self::KEY_CUSTOM_OPTIONS] = $this->customOptions;
 
         return $data;
@@ -860,6 +901,10 @@ class ModelConfig extends AbstractDataTransferObject
 
         if (isset($array[self::KEY_OUTPUT_SCHEMA])) {
             $config->setOutputSchema($array[self::KEY_OUTPUT_SCHEMA]);
+        }
+
+        if (isset($array[self::KEY_OUTPUT_MEDIA_ORIENTATION])) {
+            $config->setOutputMediaOrientation(MediaOrientationEnum::from($array[self::KEY_OUTPUT_MEDIA_ORIENTATION]));
         }
 
         if (isset($array[self::KEY_CUSTOM_OPTIONS])) {

--- a/src/Providers/Models/DTO/ModelConfig.php
+++ b/src/Providers/Models/DTO/ModelConfig.php
@@ -35,6 +35,7 @@ use WordPress\AiClient\Tools\DTO\Tool;
  *     logprobs?: bool,
  *     topLogprobs?: int,
  *     tools?: list<ToolArrayShape>,
+ *     outputFileType?: string,
  *     outputMimeType?: string,
  *     outputSchema?: array<string, mixed>,
  *     customOptions?: array<string, mixed>
@@ -850,11 +851,6 @@ class ModelConfig extends AbstractDataTransferObject
         }
 
         if (isset($array[self::KEY_OUTPUT_FILE_TYPE])) {
-            if (!is_string($array[self::KEY_OUTPUT_FILE_TYPE])) {
-                throw new InvalidArgumentException(
-                    'Output file type must be a string.'
-                );
-            }
             $config->setOutputFileType(FileTypeEnum::from($array[self::KEY_OUTPUT_FILE_TYPE]));
         }
 

--- a/src/Providers/Models/DTO/ModelConfig.php
+++ b/src/Providers/Models/DTO/ModelConfig.php
@@ -6,6 +6,7 @@ namespace WordPress\AiClient\Providers\Models\DTO;
 
 use InvalidArgumentException;
 use WordPress\AiClient\Common\AbstractDataTransferObject;
+use WordPress\AiClient\Files\Enums\FileTypeEnum;
 use WordPress\AiClient\Messages\Enums\ModalityEnum;
 use WordPress\AiClient\Tools\DTO\Tool;
 
@@ -56,6 +57,7 @@ class ModelConfig extends AbstractDataTransferObject
     public const KEY_LOGPROBS = 'logprobs';
     public const KEY_TOP_LOGPROBS = 'topLogprobs';
     public const KEY_TOOLS = 'tools';
+    public const KEY_OUTPUT_FILE_TYPE = 'outputFileType';
     public const KEY_OUTPUT_MIME_TYPE = 'outputMimeType';
     public const KEY_OUTPUT_SCHEMA = 'outputSchema';
     public const KEY_CUSTOM_OPTIONS = 'customOptions';
@@ -124,6 +126,11 @@ class ModelConfig extends AbstractDataTransferObject
      * @var list<Tool>|null Tools available to the model.
      */
     protected ?array $tools = null;
+
+    /**
+     * @var FileTypeEnum|null Output file type.
+     */
+    protected ?FileTypeEnum $outputFileType = null;
 
     /**
      * @var string|null Output MIME type.
@@ -471,6 +478,30 @@ class ModelConfig extends AbstractDataTransferObject
     }
 
     /**
+     * Sets the output file type.
+     *
+     * @since n.e.x.t
+     *
+     * @param FileTypeEnum $outputFileType The output file type.
+     */
+    public function setOutputFileType(FileTypeEnum $outputFileType): void
+    {
+        $this->outputFileType = $outputFileType;
+    }
+
+    /**
+     * Gets the output file type.
+     *
+     * @since n.e.x.t
+     *
+     * @return FileTypeEnum|null The output file type.
+     */
+    public function getOutputFileType(): ?FileTypeEnum
+    {
+        return $this->outputFileType;
+    }
+
+    /**
      * Sets the output MIME type.
      *
      * @since n.e.x.t
@@ -641,6 +672,11 @@ class ModelConfig extends AbstractDataTransferObject
                     'items' => Tool::getJsonSchema(),
                     'description' => 'Tools available to the model.',
                 ],
+                self::KEY_OUTPUT_FILE_TYPE => [
+                    'type' => 'string',
+                    'enum' => FileTypeEnum::getValues(),
+                    'description' => 'Output file type.',
+                ],
                 self::KEY_OUTPUT_MIME_TYPE => [
                     'type' => 'string',
                     'description' => 'Output MIME type.',
@@ -730,6 +766,10 @@ class ModelConfig extends AbstractDataTransferObject
             }, $this->tools);
         }
 
+        if ($this->outputFileType !== null) {
+            $data[self::KEY_OUTPUT_FILE_TYPE] = $this->outputFileType->value;
+        }
+
         if ($this->outputMimeType !== null) {
             $data[self::KEY_OUTPUT_MIME_TYPE] = $this->outputMimeType;
         }
@@ -807,6 +847,15 @@ class ModelConfig extends AbstractDataTransferObject
             $config->setTools(array_map(static function (array $toolData): Tool {
                 return Tool::fromArray($toolData);
             }, $array[self::KEY_TOOLS]));
+        }
+
+        if (isset($array[self::KEY_OUTPUT_FILE_TYPE])) {
+            if (!is_string($array[self::KEY_OUTPUT_FILE_TYPE])) {
+                throw new InvalidArgumentException(
+                    'Output file type must be a string.'
+                );
+            }
+            $config->setOutputFileType(FileTypeEnum::from($array[self::KEY_OUTPUT_FILE_TYPE]));
         }
 
         if (isset($array[self::KEY_OUTPUT_MIME_TYPE])) {

--- a/src/Providers/Models/DTO/ModelConfig.php
+++ b/src/Providers/Models/DTO/ModelConfig.php
@@ -40,6 +40,7 @@ use WordPress\AiClient\Tools\DTO\Tool;
  *     outputMimeType?: string,
  *     outputSchema?: array<string, mixed>,
  *     outputMediaOrientation?: string,
+ *     outputMediaAspectRatio?: string,
  *     customOptions?: array<string, mixed>
  * }
  *
@@ -64,6 +65,7 @@ class ModelConfig extends AbstractDataTransferObject
     public const KEY_OUTPUT_MIME_TYPE = 'outputMimeType';
     public const KEY_OUTPUT_SCHEMA = 'outputSchema';
     public const KEY_OUTPUT_MEDIA_ORIENTATION = 'outputMediaOrientation';
+    public const KEY_OUTPUT_MEDIA_ASPECT_RATIO = 'outputMediaAspectRatio';
     public const KEY_CUSTOM_OPTIONS = 'customOptions';
 
     /**
@@ -150,6 +152,11 @@ class ModelConfig extends AbstractDataTransferObject
      * @var MediaOrientationEnum|null Output media orientation.
      */
     protected ?MediaOrientationEnum $outputMediaOrientation = null;
+
+    /**
+     * @var string|null Output media aspect ratio (e.g. 3:2, 16:9).
+     */
+    protected ?string $outputMediaAspectRatio = null;
 
     /**
      * @var array<string, mixed> Custom provider-specific options.
@@ -591,6 +598,37 @@ class ModelConfig extends AbstractDataTransferObject
     }
 
     /**
+     * Sets the output media aspect ratio.
+     *
+     * If set, this supersedes the output media orientation, as it is a more specific configuration.
+     *
+     * @since n.e.x.t
+     *
+     * @param string $outputMediaAspectRatio The output media aspect ratio (e.g. 3:2, 16:9).
+     */
+    public function setOutputMediaAspectRatio(string $outputMediaAspectRatio): void
+    {
+        if (!preg_match('/^\d+:\d+$/', $outputMediaAspectRatio)) {
+            throw new InvalidArgumentException(
+                'Output media aspect ratio must be in the format "width:height" (e.g. 3:2, 16:9).'
+            );
+        }
+        $this->outputMediaAspectRatio = $outputMediaAspectRatio;
+    }
+
+    /**
+     * Gets the output media aspect ratio.
+     *
+     * @since n.e.x.t
+     *
+     * @return string|null The output media aspect ratio (e.g. 3:2, 16:9).
+     */
+    public function getOutputMediaAspectRatio(): ?string
+    {
+        return $this->outputMediaAspectRatio;
+    }
+
+    /**
      * Sets a single custom option.
      *
      * @since n.e.x.t
@@ -724,6 +762,11 @@ class ModelConfig extends AbstractDataTransferObject
                     'enum' => MediaOrientationEnum::getValues(),
                     'description' => 'Output media orientation.',
                 ],
+                self::KEY_OUTPUT_MEDIA_ASPECT_RATIO => [
+                    'type' => 'string',
+                    'pattern' => '^\d+:\d+$',
+                    'description' => 'Output media aspect ratio.',
+                ],
                 self::KEY_CUSTOM_OPTIONS => [
                     'type' => 'object',
                     'additionalProperties' => true,
@@ -820,6 +863,10 @@ class ModelConfig extends AbstractDataTransferObject
             $data[self::KEY_OUTPUT_MEDIA_ORIENTATION] = $this->outputMediaOrientation->value;
         }
 
+        if ($this->outputMediaAspectRatio !== null) {
+            $data[self::KEY_OUTPUT_MEDIA_ASPECT_RATIO] = $this->outputMediaAspectRatio;
+        }
+
         $data[self::KEY_CUSTOM_OPTIONS] = $this->customOptions;
 
         return $data;
@@ -905,6 +952,10 @@ class ModelConfig extends AbstractDataTransferObject
 
         if (isset($array[self::KEY_OUTPUT_MEDIA_ORIENTATION])) {
             $config->setOutputMediaOrientation(MediaOrientationEnum::from($array[self::KEY_OUTPUT_MEDIA_ORIENTATION]));
+        }
+
+        if (isset($array[self::KEY_OUTPUT_MEDIA_ASPECT_RATIO])) {
+            $config->setOutputMediaAspectRatio($array[self::KEY_OUTPUT_MEDIA_ASPECT_RATIO]);
         }
 
         if (isset($array[self::KEY_CUSTOM_OPTIONS])) {

--- a/tests/unit/Providers/Models/DTO/ModelConfigTest.php
+++ b/tests/unit/Providers/Models/DTO/ModelConfigTest.php
@@ -6,6 +6,8 @@ namespace WordPress\AiClient\Tests\unit\Providers\Models\DTO;
 
 use JsonSerializable;
 use PHPUnit\Framework\TestCase;
+use WordPress\AiClient\Files\Enums\FileTypeEnum;
+use WordPress\AiClient\Files\Enums\MediaOrientationEnum;
 use WordPress\AiClient\Messages\Enums\ModalityEnum;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WordPress\AiClient\Tools\DTO\Tool;
@@ -53,8 +55,11 @@ class ModelConfigTest extends TestCase
         $this->assertNull($config->getLogprobs());
         $this->assertNull($config->getTopLogprobs());
         $this->assertNull($config->getTools());
+        $this->assertNull($config->getOutputFileType());
         $this->assertNull($config->getOutputMimeType());
         $this->assertNull($config->getOutputSchema());
+        $this->assertNull($config->getOutputMediaOrientation());
+        $this->assertNull($config->getOutputMediaAspectRatio());
         $this->assertEquals([], $config->getCustomOptions());
     }
 
@@ -138,6 +143,18 @@ class ModelConfigTest extends TestCase
         $config->setOutputSchema($outputSchema);
         $this->assertEquals($outputSchema, $config->getOutputSchema());
 
+        // Test output file type
+        $config->setOutputFileType(FileTypeEnum::inline());
+        $this->assertEquals(FileTypeEnum::inline(), $config->getOutputFileType());
+
+        // Test output media orientation
+        $config->setOutputMediaOrientation(MediaOrientationEnum::landscape());
+        $this->assertEquals(MediaOrientationEnum::landscape(), $config->getOutputMediaOrientation());
+
+        // Test output media aspect ratio
+        $config->setOutputMediaAspectRatio('4:3');
+        $this->assertEquals('4:3', $config->getOutputMediaAspectRatio());
+
         // Test custom options
         $customOptions = ['custom_param' => 'value', 'another_param' => 123];
         $config->setCustomOptions($customOptions);
@@ -173,8 +190,11 @@ class ModelConfigTest extends TestCase
             ModelConfig::KEY_LOGPROBS,
             ModelConfig::KEY_TOP_LOGPROBS,
             ModelConfig::KEY_TOOLS,
+            ModelConfig::KEY_OUTPUT_FILE_TYPE,
             ModelConfig::KEY_OUTPUT_MIME_TYPE,
             ModelConfig::KEY_OUTPUT_SCHEMA,
+            ModelConfig::KEY_OUTPUT_MEDIA_ORIENTATION,
+            ModelConfig::KEY_OUTPUT_MEDIA_ASPECT_RATIO,
             ModelConfig::KEY_CUSTOM_OPTIONS
         ];
 
@@ -190,6 +210,9 @@ class ModelConfigTest extends TestCase
         $this->assertEquals('boolean', $schema['properties'][ModelConfig::KEY_LOGPROBS]['type']);
         $this->assertEquals('string', $schema['properties'][ModelConfig::KEY_OUTPUT_MIME_TYPE]['type']);
         $this->assertEquals('object', $schema['properties'][ModelConfig::KEY_OUTPUT_SCHEMA]['type']);
+        $this->assertEquals('string', $schema['properties'][ModelConfig::KEY_OUTPUT_FILE_TYPE]['type']);
+        $this->assertEquals('string', $schema['properties'][ModelConfig::KEY_OUTPUT_MEDIA_ORIENTATION]['type']);
+        $this->assertEquals('string', $schema['properties'][ModelConfig::KEY_OUTPUT_MEDIA_ASPECT_RATIO]['type']);
         $this->assertEquals('object', $schema['properties'][ModelConfig::KEY_CUSTOM_OPTIONS]['type']);
 
         // Check constraints
@@ -223,8 +246,11 @@ class ModelConfigTest extends TestCase
         $config->setLogprobs(true);
         $config->setTopLogprobs(10);
         $config->setTools([$tool]);
+        $config->setOutputFileType(FileTypeEnum::remote());
         $config->setOutputMimeType('application/json');
         $config->setOutputSchema(['type' => 'object']);
+        $config->setOutputMediaOrientation(MediaOrientationEnum::portrait());
+        $config->setOutputMediaAspectRatio('9:16');
         $config->setCustomOptions(['key' => 'value']);
 
         $array = $config->toArray();
@@ -243,8 +269,11 @@ class ModelConfigTest extends TestCase
         $this->assertTrue($array[ModelConfig::KEY_LOGPROBS]);
         $this->assertEquals(10, $array[ModelConfig::KEY_TOP_LOGPROBS]);
         $this->assertCount(1, $array[ModelConfig::KEY_TOOLS]);
+        $this->assertEquals('remote', $array[ModelConfig::KEY_OUTPUT_FILE_TYPE]);
         $this->assertEquals('application/json', $array[ModelConfig::KEY_OUTPUT_MIME_TYPE]);
         $this->assertEquals(['type' => 'object'], $array[ModelConfig::KEY_OUTPUT_SCHEMA]);
+        $this->assertEquals('portrait', $array[ModelConfig::KEY_OUTPUT_MEDIA_ORIENTATION]);
+        $this->assertEquals('9:16', $array[ModelConfig::KEY_OUTPUT_MEDIA_ASPECT_RATIO]);
         $this->assertEquals(['key' => 'value'], $array[ModelConfig::KEY_CUSTOM_OPTIONS]);
     }
 
@@ -320,6 +349,9 @@ class ModelConfigTest extends TestCase
             ],
             ModelConfig::KEY_OUTPUT_MIME_TYPE => 'application/json',
             ModelConfig::KEY_OUTPUT_SCHEMA => ['type' => 'array', 'items' => ['type' => 'string']],
+            ModelConfig::KEY_OUTPUT_FILE_TYPE => 'inline',
+            ModelConfig::KEY_OUTPUT_MEDIA_ORIENTATION => 'landscape',
+            ModelConfig::KEY_OUTPUT_MEDIA_ASPECT_RATIO => '16:9',
             ModelConfig::KEY_CUSTOM_OPTIONS => ['custom' => true]
         ];
 
@@ -343,6 +375,9 @@ class ModelConfigTest extends TestCase
         $this->assertCount(1, $config->getTools());
         $this->assertEquals('application/json', $config->getOutputMimeType());
         $this->assertEquals(['type' => 'array', 'items' => ['type' => 'string']], $config->getOutputSchema());
+        $this->assertEquals(FileTypeEnum::inline(), $config->getOutputFileType());
+        $this->assertEquals(MediaOrientationEnum::landscape(), $config->getOutputMediaOrientation());
+        $this->assertEquals('16:9', $config->getOutputMediaAspectRatio());
         $this->assertEquals(['custom' => true], $config->getCustomOptions());
     }
 
@@ -374,6 +409,9 @@ class ModelConfigTest extends TestCase
         $original->setMaxTokens(1500);
         $original->setStopSequences(['END', 'STOP']);
         $original->setLogprobs(true);
+        $original->setOutputFileType(FileTypeEnum::inline());
+        $original->setOutputMediaOrientation(MediaOrientationEnum::square());
+        $original->setOutputMediaAspectRatio('1:1');
         $original->setCustomOptions(['test' => 'value']);
 
         $array = $original->toArray();
@@ -384,6 +422,9 @@ class ModelConfigTest extends TestCase
         $this->assertEquals($original->getMaxTokens(), $restored->getMaxTokens());
         $this->assertEquals($original->getStopSequences(), $restored->getStopSequences());
         $this->assertEquals($original->getLogprobs(), $restored->getLogprobs());
+        $this->assertEquals($original->getOutputFileType(), $restored->getOutputFileType());
+        $this->assertEquals($original->getOutputMediaOrientation(), $restored->getOutputMediaOrientation());
+        $this->assertEquals($original->getOutputMediaAspectRatio(), $restored->getOutputMediaAspectRatio());
         $this->assertEquals($original->getCustomOptions(), $restored->getCustomOptions());
     }
 


### PR DESCRIPTION
This PR adds model config params for:
* `outputFileType` (`inline` or `remote`)
* `outputMediaOrientation` (`square`, `landscape`, or `portrait`)
* `outputMediaAspectRatio` (a string like `3:2` or `16:9` etc.)

The `outputMediaAspectRatio` is a more specific version of `outputMediaOrientation`, but both are valid to have. Some use-cases may require a specific aspect ratio, while for others purely the orientation (without a precise aspect ratio) may be sufficient.

Aside: Other than common sense for why these are relevant for e.g. image generation, I came across a concrete need while working on #39, specifically in https://github.com/WordPress/php-ai-client/pull/39/commits/d9b32fcc66e2ca662f1efce2ed460dffc43dbbba.