### PR TITLE
Allow message parts to have channel, to separate regular content from thought / reasoning content

### DIFF
--- a/src/Messages/DTO/MessagePart.php
+++ b/src/Messages/DTO/MessagePart.php
@@ -298,11 +298,6 @@ class MessagePart extends AbstractDataTransferObject
     public static function fromArray(array $array): self
     {
         if (isset($array[self::KEY_CHANNEL])) {
-            if (!MessagePartChannelEnum::isValidValue($array[self::KEY_CHANNEL])) {
-                throw new InvalidArgumentException(
-                    sprintf('Invalid channel value: %s', $array[self::KEY_CHANNEL])
-                );
-            }
             $channel = MessagePartChannelEnum::from($array[self::KEY_CHANNEL]);
         } else {
             $channel = null;

--- a/src/Messages/DTO/MessagePart.php
+++ b/src/Messages/DTO/MessagePart.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use RuntimeException;
 use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Files\DTO\File;
+use WordPress\AiClient\Messages\Enums\MessagePartChannelEnum;
 use WordPress\AiClient\Messages\Enums\MessagePartTypeEnum;
 use WordPress\AiClient\Tools\DTO\FunctionCall;
 use WordPress\AiClient\Tools\DTO\FunctionResponse;
@@ -25,6 +26,7 @@ use WordPress\AiClient\Tools\DTO\FunctionResponse;
  * @phpstan-import-type FunctionResponseArrayShape from FunctionResponse
  *
  * @phpstan-type MessagePartArrayShape array{
+ *     channel: string,
  *     type: string,
  *     text?: string,
  *     file?: FileArrayShape,
@@ -36,11 +38,18 @@ use WordPress\AiClient\Tools\DTO\FunctionResponse;
  */
 class MessagePart extends AbstractDataTransferObject
 {
+    public const KEY_CHANNEL = 'channel';
     public const KEY_TYPE = 'type';
     public const KEY_TEXT = 'text';
     public const KEY_FILE = 'file';
     public const KEY_FUNCTION_CALL = 'functionCall';
     public const KEY_FUNCTION_RESPONSE = 'functionResponse';
+
+    /**
+     * @var MessagePartChannelEnum The channel this message part belongs to.
+     */
+    private MessagePartChannelEnum $channel;
+
     /**
      * @var MessagePartTypeEnum The type of this message part.
      */
@@ -72,10 +81,13 @@ class MessagePart extends AbstractDataTransferObject
      * @since n.e.x.t
      *
      * @param mixed $content The content of this message part.
+     * @param MessagePartChannelEnum|null $channel The channel this part belongs to. Defaults to CONTENT.
      * @throws InvalidArgumentException If an unsupported content type is provided.
      */
-    public function __construct($content)
+    public function __construct($content, ?MessagePartChannelEnum $channel = null)
     {
+        $this->channel = $channel ?? MessagePartChannelEnum::content();
+
         if (is_string($content)) {
             $this->type = MessagePartTypeEnum::text();
             $this->text = $content;
@@ -98,6 +110,18 @@ class MessagePart extends AbstractDataTransferObject
                 )
             );
         }
+    }
+
+    /**
+     * Gets the channel this message part belongs to.
+     *
+     * @since n.e.x.t
+     *
+     * @return MessagePartChannelEnum The channel.
+     */
+    public function getChannel(): MessagePartChannelEnum
+    {
+        return $this->channel;
     }
 
     /**
@@ -167,11 +191,18 @@ class MessagePart extends AbstractDataTransferObject
      */
     public static function getJsonSchema(): array
     {
+        $channelSchema = [
+            'type' => 'string',
+            'enum' => MessagePartChannelEnum::getValues(),
+            'description' => 'The channel this message part belongs to.',
+        ];
+
         return [
             'oneOf' => [
                 [
                     'type' => 'object',
                     'properties' => [
+                        self::KEY_CHANNEL => $channelSchema,
                         self::KEY_TYPE => [
                             'type' => 'string',
                             'const' => MessagePartTypeEnum::text()->value,
@@ -187,6 +218,7 @@ class MessagePart extends AbstractDataTransferObject
                 [
                     'type' => 'object',
                     'properties' => [
+                        self::KEY_CHANNEL => $channelSchema,
                         self::KEY_TYPE => [
                             'type' => 'string',
                             'const' => MessagePartTypeEnum::file()->value,
@@ -199,6 +231,7 @@ class MessagePart extends AbstractDataTransferObject
                 [
                     'type' => 'object',
                     'properties' => [
+                        self::KEY_CHANNEL => $channelSchema,
                         self::KEY_TYPE => [
                             'type' => 'string',
                             'const' => MessagePartTypeEnum::functionCall()->value,
@@ -211,6 +244,7 @@ class MessagePart extends AbstractDataTransferObject
                 [
                     'type' => 'object',
                     'properties' => [
+                        self::KEY_CHANNEL => $channelSchema,
                         self::KEY_TYPE => [
                             'type' => 'string',
                             'const' => MessagePartTypeEnum::functionResponse()->value,
@@ -233,7 +267,10 @@ class MessagePart extends AbstractDataTransferObject
      */
     public function toArray(): array
     {
-        $data = [self::KEY_TYPE => $this->type->value];
+        $data = [
+            self::KEY_CHANNEL => $this->channel->value,
+            self::KEY_TYPE => $this->type->value,
+        ];
 
         if ($this->text !== null) {
             $data[self::KEY_TEXT] = $this->text;
@@ -260,15 +297,26 @@ class MessagePart extends AbstractDataTransferObject
      */
     public static function fromArray(array $array): self
     {
+        if (isset($array[self::KEY_CHANNEL])) {
+            if (!MessagePartChannelEnum::isValidValue($array[self::KEY_CHANNEL])) {
+                throw new InvalidArgumentException(
+                    sprintf('Invalid channel value: %s', $array[self::KEY_CHANNEL])
+                );
+            }
+            $channel = MessagePartChannelEnum::from($array[self::KEY_CHANNEL]);
+        } else {
+            $channel = null;
+        }
+
         // Check which properties are set to determine how to construct the MessagePart
         if (isset($array[self::KEY_TEXT])) {
-            return new self($array[self::KEY_TEXT]);
+            return new self($array[self::KEY_TEXT], $channel);
         } elseif (isset($array[self::KEY_FILE])) {
-            return new self(File::fromArray($array[self::KEY_FILE]));
+            return new self(File::fromArray($array[self::KEY_FILE]), $channel);
         } elseif (isset($array[self::KEY_FUNCTION_CALL])) {
-            return new self(FunctionCall::fromArray($array[self::KEY_FUNCTION_CALL]));
+            return new self(FunctionCall::fromArray($array[self::KEY_FUNCTION_CALL]), $channel);
         } elseif (isset($array[self::KEY_FUNCTION_RESPONSE])) {
-            return new self(FunctionResponse::fromArray($array[self::KEY_FUNCTION_RESPONSE]));
+            return new self(FunctionResponse::fromArray($array[self::KEY_FUNCTION_RESPONSE]), $channel);
         } else {
             throw new InvalidArgumentException(
                 'MessagePart requires one of: text, file, functionCall, or functionResponse.'

--- a/src/Messages/Enums/MessagePartChannelEnum.php
+++ b/src/Messages/Enums/MessagePartChannelEnum.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Messages\Enums;
+
+use WordPress\AiClient\Common\AbstractEnum;
+
+/**
+ * Enum for message part channels.
+ *
+ * @since n.e.x.t
+ *
+ * @method static self content() Creates an instance for CONTENT channel.
+ * @method static self thought() Creates an instance for THOUGHT channel.
+ * @method bool isContent() Checks if the channel is CONTENT.
+ * @method bool isThought() Checks if the channel is THOUGHT.
+ */
+class MessagePartChannelEnum extends AbstractEnum
+{
+    /**
+     * Regular (primary) content.
+     */
+    public const CONTENT = 'content';
+
+    /**
+     * Model thinking or reasoning.
+     */
+    public const THOUGHT = 'thought';
+}

--- a/tests/unit/Messages/DTO/MessagePartTest.php
+++ b/tests/unit/Messages/DTO/MessagePartTest.php
@@ -10,6 +10,7 @@ use stdClass;
 use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Files\Enums\FileTypeEnum;
 use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\Enums\MessagePartChannelEnum;
 use WordPress\AiClient\Messages\Enums\MessagePartTypeEnum;
 use WordPress\AiClient\Tools\DTO\FunctionCall;
 use WordPress\AiClient\Tools\DTO\FunctionResponse;
@@ -31,6 +32,7 @@ class MessagePartTest extends TestCase
 
         $this->assertEquals(MessagePartTypeEnum::text(), $part->getType());
         $this->assertEquals($text, $part->getText());
+        $this->assertEquals(MessagePartChannelEnum::content(), $part->getChannel());
         $this->assertNull($part->getFile());
         $this->assertNull($part->getFunctionCall());
         $this->assertNull($part->getFunctionResponse());
@@ -47,6 +49,7 @@ class MessagePartTest extends TestCase
         $part = new MessagePart($file);
 
         $this->assertEquals(MessagePartTypeEnum::file(), $part->getType());
+        $this->assertEquals(MessagePartChannelEnum::content(), $part->getChannel());
         $this->assertNull($part->getText());
         $this->assertSame($file, $part->getFile());
         $this->assertNull($part->getFunctionCall());
@@ -64,6 +67,7 @@ class MessagePartTest extends TestCase
         $part = new MessagePart($functionCall);
 
         $this->assertEquals(MessagePartTypeEnum::functionCall(), $part->getType());
+        $this->assertEquals(MessagePartChannelEnum::content(), $part->getChannel());
         $this->assertNull($part->getText());
         $this->assertNull($part->getFile());
         $this->assertSame($functionCall, $part->getFunctionCall());
@@ -81,6 +85,7 @@ class MessagePartTest extends TestCase
         $part = new MessagePart($functionResponse);
 
         $this->assertEquals(MessagePartTypeEnum::functionResponse(), $part->getType());
+        $this->assertEquals(MessagePartChannelEnum::content(), $part->getChannel());
         $this->assertNull($part->getText());
         $this->assertNull($part->getFile());
         $this->assertNull($part->getFunctionCall());
@@ -97,6 +102,7 @@ class MessagePartTest extends TestCase
         $part = new MessagePart('');
 
         $this->assertEquals(MessagePartTypeEnum::text(), $part->getType());
+        $this->assertEquals(MessagePartChannelEnum::content(), $part->getChannel());
         $this->assertEquals('', $part->getText());
     }
 
@@ -260,8 +266,10 @@ class MessagePartTest extends TestCase
         $json = $part->toArray();
 
         $this->assertIsArray($json);
+        $this->assertArrayHasKey(MessagePart::KEY_CHANNEL, $json);
         $this->assertArrayHasKey(MessagePart::KEY_TYPE, $json);
         $this->assertArrayHasKey(MessagePart::KEY_TEXT, $json);
+        $this->assertEquals(MessagePartChannelEnum::content()->value, $json[MessagePart::KEY_CHANNEL]);
         $this->assertEquals(MessagePartTypeEnum::text()->value, $json[MessagePart::KEY_TYPE]);
         $this->assertEquals('Hello, world!', $json[MessagePart::KEY_TEXT]);
 
@@ -283,8 +291,10 @@ class MessagePartTest extends TestCase
         $json = $part->toArray();
 
         $this->assertIsArray($json);
+        $this->assertArrayHasKey(MessagePart::KEY_CHANNEL, $json);
         $this->assertArrayHasKey(MessagePart::KEY_TYPE, $json);
         $this->assertArrayHasKey(MessagePart::KEY_FILE, $json);
+        $this->assertEquals(MessagePartChannelEnum::content()->value, $json[MessagePart::KEY_CHANNEL]);
         $this->assertEquals(MessagePartTypeEnum::file()->value, $json[MessagePart::KEY_TYPE]);
         $this->assertIsArray($json[MessagePart::KEY_FILE]);
     }
@@ -297,6 +307,7 @@ class MessagePartTest extends TestCase
     public function testFromArrayWithText(): void
     {
         $json = [
+            MessagePart::KEY_CHANNEL => MessagePartChannelEnum::thought()->value,
             MessagePart::KEY_TYPE => MessagePartTypeEnum::text()->value,
             MessagePart::KEY_TEXT => 'Test message'
         ];
@@ -304,6 +315,7 @@ class MessagePartTest extends TestCase
         $part = MessagePart::fromArray($json);
 
         $this->assertEquals(MessagePartTypeEnum::text(), $part->getType());
+        $this->assertEquals(MessagePartChannelEnum::thought(), $part->getChannel());
         $this->assertEquals('Test message', $part->getText());
     }
 
@@ -315,6 +327,7 @@ class MessagePartTest extends TestCase
     public function testFromArrayWithFile(): void
     {
         $json = [
+            MessagePart::KEY_CHANNEL => MessagePartChannelEnum::content()->value,
             MessagePart::KEY_TYPE => MessagePartTypeEnum::file()->value,
             MessagePart::KEY_FILE => [
                 File::KEY_FILE_TYPE => FileTypeEnum::remote()->value,
@@ -326,6 +339,7 @@ class MessagePartTest extends TestCase
         $part = MessagePart::fromArray($json);
 
         $this->assertEquals(MessagePartTypeEnum::file(), $part->getType());
+        $this->assertEquals(MessagePartChannelEnum::content(), $part->getChannel());
         $this->assertInstanceOf(File::class, $part->getFile());
         $this->assertEquals('https://example.com/image.jpg', $part->getFile()->getUrl());
     }
@@ -338,10 +352,11 @@ class MessagePartTest extends TestCase
     public function testArrayRoundTrip(): void
     {
         // Test with text
-        $textPart = new MessagePart('Test text');
+        $textPart = new MessagePart('Test text', MessagePartChannelEnum::thought());
         $textJson = $textPart->toArray();
         $restoredText = MessagePart::fromArray($textJson);
         $this->assertEquals($textPart->getText(), $restoredText->getText());
+        $this->assertEquals($textPart->getChannel(), $restoredText->getChannel());
 
         // Test with file
         $file = new File('https://example.com/doc.pdf', 'application/pdf');
@@ -350,15 +365,17 @@ class MessagePartTest extends TestCase
         $restoredFile = MessagePart::fromArray($fileJson);
         $this->assertEquals($file->getUrl(), $restoredFile->getFile()->getUrl());
         $this->assertEquals($file->getMimeType(), $restoredFile->getFile()->getMimeType());
+        $this->assertEquals($filePart->getChannel(), $restoredFile->getChannel());
 
         // Test with function call
         $functionCall = new FunctionCall('id_123', 'getData', ['key' => 'value']);
-        $funcPart = new MessagePart($functionCall);
+        $funcPart = new MessagePart($functionCall, MessagePartChannelEnum::thought());
         $funcJson = $funcPart->toArray();
         $restoredFunc = MessagePart::fromArray($funcJson);
         $this->assertEquals($functionCall->getId(), $restoredFunc->getFunctionCall()->getId());
         $this->assertEquals($functionCall->getName(), $restoredFunc->getFunctionCall()->getName());
         $this->assertEquals($functionCall->getArgs(), $restoredFunc->getFunctionCall()->getArgs());
+        $this->assertEquals($funcPart->getChannel(), $restoredFunc->getChannel());
     }
 
     /**
@@ -374,5 +391,50 @@ class MessagePartTest extends TestCase
             \WordPress\AiClient\Common\Contracts\WithArrayTransformationInterface::class,
             $part
         );
+    }
+
+    /**
+     * Tests creating MessagePart with different channels.
+     *
+     * @return void
+     */
+    public function testCreateWithDifferentChannels(): void
+    {
+        // Default channel is CONTENT
+        $part1 = new MessagePart('Some content');
+        $this->assertEquals(MessagePartChannelEnum::content(), $part1->getChannel());
+        $this->assertTrue($part1->getChannel()->isContent());
+        $this->assertFalse($part1->getChannel()->isThought());
+
+        // Explicitly set CONTENT channel
+        $part2 = new MessagePart('Some content', MessagePartChannelEnum::content());
+        $this->assertEquals(MessagePartChannelEnum::content(), $part2->getChannel());
+        $this->assertTrue($part2->getChannel()->isContent());
+        $this->assertFalse($part2->getChannel()->isThought());
+
+        // Explicitly set THOUGHT channel
+        $part3 = new MessagePart('Some thought', MessagePartChannelEnum::thought());
+        $this->assertEquals(MessagePartChannelEnum::thought(), $part3->getChannel());
+        $this->assertFalse($part3->getChannel()->isContent());
+        $this->assertTrue($part3->getChannel()->isThought());
+    }
+
+    /**
+     * Tests fromArray with an invalid channel value.
+     *
+     * @return void
+     */
+    public function testFromArrayWithInvalidChannel(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid channel value: invalid_channel');
+
+        $json = [
+            MessagePart::KEY_CHANNEL => 'invalid_channel',
+            MessagePart::KEY_TYPE => MessagePartTypeEnum::text()->value,
+            MessagePart::KEY_TEXT => 'Test message'
+        ];
+
+        MessagePart::fromArray($json);
     }
 }

--- a/tests/unit/Messages/DTO/MessagePartTest.php
+++ b/tests/unit/Messages/DTO/MessagePartTest.php
@@ -427,7 +427,9 @@ class MessagePartTest extends TestCase
     public function testFromArrayWithInvalidChannel(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid channel value: invalid_channel');
+        $this->expectExceptionMessage(
+            'invalid_channel is not a valid backing value for enum ' . MessagePartChannelEnum::class
+        );
 
         $json = [
             MessagePart::KEY_CHANNEL => 'invalid_channel',


### PR DESCRIPTION
As the title says, it's crucial to make a distinction (mostly for model generated content), whether it's regular output or thinking / reasoning. This PR adds that distinction to message parts within a single message.

This is in line with how API providers typically handle it (a single message may contain both kinds of parts/content).