### PR TITLE
Fixes Function Call and Declaration DTOs

### DIFF
--- a/src/Tools/DTO/FunctionCall.php
+++ b/src/Tools/DTO/FunctionCall.php
@@ -15,7 +15,7 @@ use WordPress\AiClient\Common\AbstractDataTransferObject;
  *
  * @since n.e.x.t
  *
- * @phpstan-type FunctionCallArrayShape array{id?: string, name?: string, args?: array<string, mixed>}
+ * @phpstan-type FunctionCallArrayShape array{id?: string, name?: string, args?: mixed}
  *
  * @extends AbstractDataTransferObject<FunctionCallArrayShape>
  */
@@ -35,9 +35,9 @@ class FunctionCall extends AbstractDataTransferObject
     private ?string $name;
 
     /**
-     * @var array<string, mixed> The arguments to pass to the function.
+     * @var mixed The arguments to pass to the function.
      */
-    private array $args;
+    private $args;
 
     /**
      * Constructor.
@@ -46,10 +46,10 @@ class FunctionCall extends AbstractDataTransferObject
      *
      * @param string|null $id Unique identifier for this function call.
      * @param string|null $name The name of the function to call.
-     * @param array<string, mixed> $args The arguments to pass to the function.
+     * @param mixed $args The arguments to pass to the function.
      * @throws InvalidArgumentException If neither id nor name is provided.
      */
-    public function __construct(?string $id = null, ?string $name = null, array $args = [])
+    public function __construct(?string $id = null, ?string $name = null, $args = null)
     {
         if ($id === null && $name === null) {
             throw new InvalidArgumentException('At least one of id or name must be provided.');
@@ -89,9 +89,9 @@ class FunctionCall extends AbstractDataTransferObject
      *
      * @since n.e.x.t
      *
-     * @return array<string, mixed> The function arguments.
+     * @return mixed The function arguments.
      */
-    public function getArgs(): array
+    public function getArgs()
     {
         return $this->args;
     }
@@ -115,9 +115,8 @@ class FunctionCall extends AbstractDataTransferObject
                     'description' => 'The name of the function to call.',
                 ],
                 self::KEY_ARGS => [
-                    'type' => 'object',
+                    'type' => ['string', 'number', 'boolean', 'object', 'array', 'null'],
                     'description' => 'The arguments to pass to the function.',
-                    'additionalProperties' => true,
                 ],
             ],
             'oneOf' => [
@@ -150,7 +149,7 @@ class FunctionCall extends AbstractDataTransferObject
             $data[self::KEY_NAME] = $this->name;
         }
 
-        if (!empty($this->args)) {
+        if ($this->args !== null) {
             $data[self::KEY_ARGS] = $this->args;
         }
 
@@ -167,7 +166,7 @@ class FunctionCall extends AbstractDataTransferObject
         return new self(
             $array[self::KEY_ID] ?? null,
             $array[self::KEY_NAME] ?? null,
-            $array[self::KEY_ARGS] ?? []
+            $array[self::KEY_ARGS] ?? null
         );
     }
 }

--- a/src/Tools/DTO/FunctionDeclaration.php
+++ b/src/Tools/DTO/FunctionDeclaration.php
@@ -14,7 +14,11 @@ use WordPress\AiClient\Common\AbstractDataTransferObject;
  *
  * @since n.e.x.t
  *
- * @phpstan-type FunctionDeclarationArrayShape array{name: string, description: string, parameters?: mixed}
+ * @phpstan-type FunctionDeclarationArrayShape array{
+ *     name: string,
+ *     description: string,
+ *     parameters?: array<string, mixed>
+ * }
  *
  * @extends AbstractDataTransferObject<FunctionDeclarationArrayShape>
  */
@@ -34,9 +38,9 @@ class FunctionDeclaration extends AbstractDataTransferObject
     private string $description;
 
     /**
-     * @var mixed|null The JSON schema for the function parameters.
+     * @var array<string, mixed>|null The JSON schema for the function parameters.
      */
-    private $parameters;
+    private ?array $parameters;
 
     /**
      * Constructor.
@@ -45,9 +49,9 @@ class FunctionDeclaration extends AbstractDataTransferObject
      *
      * @param string $name The name of the function.
      * @param string $description A description of what the function does.
-     * @param mixed $parameters The JSON schema for the function parameters.
+     * @param array<string, mixed>|null $parameters The JSON schema for the function parameters.
      */
-    public function __construct(string $name, string $description, $parameters = null)
+    public function __construct(string $name, string $description, ?array $parameters = null)
     {
         $this->name = $name;
         $this->description = $description;
@@ -83,9 +87,9 @@ class FunctionDeclaration extends AbstractDataTransferObject
      *
      * @since n.e.x.t
      *
-     * @return mixed|null The parameters schema.
+     * @return array<string, mixed>|null The parameters schema.
      */
-    public function getParameters()
+    public function getParameters(): ?array
     {
         return $this->parameters;
     }
@@ -109,8 +113,9 @@ class FunctionDeclaration extends AbstractDataTransferObject
                     'description' => 'A description of what the function does.',
                 ],
                 self::KEY_PARAMETERS => [
-                    'type' => ['string', 'number', 'boolean', 'object', 'array', 'null'],
+                    'type' => 'object',
                     'description' => 'The JSON schema for the function parameters.',
+                    'additionalProperties' => true,
                 ],
             ],
             'required' => [self::KEY_NAME, self::KEY_DESCRIPTION],

--- a/tests/unit/Tools/DTO/FunctionCallTest.php
+++ b/tests/unit/Tools/DTO/FunctionCallTest.php
@@ -76,7 +76,7 @@ class FunctionCallTest extends TestCase
 
         $this->assertEquals('func_123', $functionCall->getId());
         $this->assertEquals('getTime', $functionCall->getName());
-        $this->assertEquals([], $functionCall->getArgs());
+        $this->assertNull($functionCall->getArgs());
     }
 
     /**
@@ -118,9 +118,14 @@ class FunctionCallTest extends TestCase
         $this->assertEquals('string', $schema['properties'][FunctionCall::KEY_NAME]['type']);
         $this->assertArrayHasKey('description', $schema['properties'][FunctionCall::KEY_NAME]);
 
-        // Check args property
-        $this->assertEquals('object', $schema['properties'][FunctionCall::KEY_ARGS]['type']);
-        $this->assertTrue($schema['properties'][FunctionCall::KEY_ARGS]['additionalProperties']);
+        // Check args property - can be any type
+        $this->assertIsArray($schema['properties'][FunctionCall::KEY_ARGS]['type']);
+        $this->assertContains('string', $schema['properties'][FunctionCall::KEY_ARGS]['type']);
+        $this->assertContains('number', $schema['properties'][FunctionCall::KEY_ARGS]['type']);
+        $this->assertContains('boolean', $schema['properties'][FunctionCall::KEY_ARGS]['type']);
+        $this->assertContains('object', $schema['properties'][FunctionCall::KEY_ARGS]['type']);
+        $this->assertContains('array', $schema['properties'][FunctionCall::KEY_ARGS]['type']);
+        $this->assertContains('null', $schema['properties'][FunctionCall::KEY_ARGS]['type']);
 
         // Check oneOf for required fields
         $this->assertArrayHasKey('oneOf', $schema);
@@ -243,7 +248,7 @@ class FunctionCallTest extends TestCase
         $this->assertInstanceOf(FunctionCall::class, $functionCall);
         $this->assertNull($functionCall->getId());
         $this->assertEquals('minimal', $functionCall->getName());
-        $this->assertEquals([], $functionCall->getArgs());
+        $this->assertNull($functionCall->getArgs());
     }
 
     /**

--- a/tests/unit/Tools/DTO/FunctionDeclarationTest.php
+++ b/tests/unit/Tools/DTO/FunctionDeclarationTest.php
@@ -80,12 +80,7 @@ class FunctionDeclarationTest extends TestCase
     {
         return [
             'null' => [null],
-            'string' => ['simple string parameter'],
-            'number' => [42],
-            'float' => [3.14],
-            'boolean' => [true],
             'array' => [['key' => 'value']],
-            'object' => [(object) ['property' => 'value']],
             'complex schema' => [[
                 'type' => 'object',
                 'properties' => [
@@ -127,14 +122,9 @@ class FunctionDeclarationTest extends TestCase
         $this->assertArrayHasKey('description', $schema['properties'][FunctionDeclaration::KEY_DESCRIPTION]);
 
         // Check parameters property allows multiple types
-        $paramTypes = $schema['properties'][FunctionDeclaration::KEY_PARAMETERS]['type'];
-        $this->assertIsArray($paramTypes);
-        $this->assertContains('string', $paramTypes);
-        $this->assertContains('number', $paramTypes);
-        $this->assertContains('boolean', $paramTypes);
-        $this->assertContains('object', $paramTypes);
-        $this->assertContains('array', $paramTypes);
-        $this->assertContains('null', $paramTypes);
+        // Parameters should be object type (for JSON schema)
+        $this->assertEquals('object', $schema['properties'][FunctionDeclaration::KEY_PARAMETERS]['type']);
+        $this->assertTrue($schema['properties'][FunctionDeclaration::KEY_PARAMETERS]['additionalProperties']);
 
         // Check required fields - parameters should NOT be required
         $this->assertArrayHasKey('required', $schema);


### PR DESCRIPTION
The `$args` in the `FunctionCall` and `FunctionDeclaration` DTOs are swapped. The Function Call args can be anything based on what the AI is told. But the Function Declaration args should be a schema. This PR corrects that.