### PR TITLE
Adds usingModelConfig method to PromptBuilder

### DIFF
--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -219,10 +219,10 @@ class PromptBuilder
         // Convert both configs to arrays
         $builderConfigArray = $this->modelConfig->toArray();
         $providedConfigArray = $config->toArray();
-        
+
         // Merge arrays with builder config taking precedence
         $mergedArray = array_merge($providedConfigArray, $builderConfigArray);
-        
+
         // Create new config from merged array
         $this->modelConfig = ModelConfig::fromArray($mergedArray);
 

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -204,6 +204,32 @@ class PromptBuilder
     }
 
     /**
+     * Sets the model configuration.
+     *
+     * Merges the provided configuration with the builder's configuration,
+     * with builder configuration taking precedence.
+     *
+     * @since n.e.x.t
+     *
+     * @param ModelConfig $config The model configuration to merge.
+     * @return self
+     */
+    public function usingModelConfig(ModelConfig $config): self
+    {
+        // Convert both configs to arrays
+        $builderConfigArray = $this->modelConfig->toArray();
+        $providedConfigArray = $config->toArray();
+        
+        // Merge arrays with builder config taking precedence
+        $mergedArray = array_merge($providedConfigArray, $builderConfigArray);
+        
+        // Create new config from merged array
+        $this->modelConfig = ModelConfig::fromArray($mergedArray);
+
+        return $this;
+    }
+
+    /**
      * Sets the provider to use for generation.
      *
      * @since n.e.x.t

--- a/src/Providers/Models/DTO/ModelConfig.php
+++ b/src/Providers/Models/DTO/ModelConfig.php
@@ -909,7 +909,9 @@ class ModelConfig extends AbstractDataTransferObject
             $data[self::KEY_OUTPUT_MEDIA_ASPECT_RATIO] = $this->outputMediaAspectRatio;
         }
 
-        $data[self::KEY_CUSTOM_OPTIONS] = $this->customOptions;
+        if (!empty($this->customOptions)) {
+            $data[self::KEY_CUSTOM_OPTIONS] = $this->customOptions;
+        }
 
         return $data;
     }

--- a/tests/unit/Builders/PromptBuilderTest.php
+++ b/tests/unit/Builders/PromptBuilderTest.php
@@ -650,37 +650,37 @@ class PromptBuilderTest extends TestCase
     public function testUsingModelConfig(): void
     {
         $builder = new PromptBuilder($this->registry);
-        
+
         // Set some initial config values on the builder
         $builder->usingSystemInstruction('Builder instruction')
                 ->usingMaxTokens(500)
                 ->usingTemperature(0.5);
-        
+
         // Create a config to merge
         $config = new ModelConfig();
         $config->setSystemInstruction('Config instruction');
         $config->setMaxTokens(1000);
         $config->setTopP(0.9);
         $config->setTopK(40);
-        
+
         $result = $builder->usingModelConfig($config);
-        
+
         // Assert fluent interface
         $this->assertSame($builder, $result);
-        
+
         // Get the merged config
         $reflection = new \ReflectionClass($builder);
         $configProperty = $reflection->getProperty('modelConfig');
         $configProperty->setAccessible(true);
-        
+
         /** @var ModelConfig $mergedConfig */
         $mergedConfig = $configProperty->getValue($builder);
-        
+
         // Assert builder values take precedence
         $this->assertEquals('Builder instruction', $mergedConfig->getSystemInstruction());
         $this->assertEquals(500, $mergedConfig->getMaxTokens());
         $this->assertEquals(0.5, $mergedConfig->getTemperature());
-        
+
         // Assert config values are used when builder doesn't have them
         $this->assertEquals(0.9, $mergedConfig->getTopP());
         $this->assertEquals(40, $mergedConfig->getTopK());
@@ -694,42 +694,42 @@ class PromptBuilderTest extends TestCase
     public function testUsingModelConfigWithCustomOptions(): void
     {
         $builder = new PromptBuilder($this->registry);
-        
+
         // Create a config with custom options
         $config = new ModelConfig();
         $config->setCustomOption('stopSequences', ['CONFIG_STOP']);
         $config->setCustomOption('otherOption', 'value');
-        
+
         $builder->usingModelConfig($config);
-        
+
         // Get the merged config
         $reflection = new \ReflectionClass($builder);
         $configProperty = $reflection->getProperty('modelConfig');
         $configProperty->setAccessible(true);
-        
+
         /** @var ModelConfig $mergedConfig */
         $mergedConfig = $configProperty->getValue($builder);
         $customOptions = $mergedConfig->getCustomOptions();
-        
+
         // Assert config custom options are preserved
         $this->assertArrayHasKey('stopSequences', $customOptions);
         $this->assertIsArray($customOptions['stopSequences']);
         $this->assertEquals(['CONFIG_STOP'], $customOptions['stopSequences']);
         $this->assertArrayHasKey('otherOption', $customOptions);
         $this->assertEquals('value', $customOptions['otherOption']);
-        
+
         // Now set a builder value that overrides one of the custom options
         $builder->usingStopSequences('STOP');
-        
+
         // Get the config again
         $mergedConfig = $configProperty->getValue($builder);
         $customOptions = $mergedConfig->getCustomOptions();
-        
+
         // Assert builder's stop sequences override the config's
         $this->assertArrayHasKey('stopSequences', $customOptions);
         $this->assertIsArray($customOptions['stopSequences']);
         $this->assertEquals(['STOP'], $customOptions['stopSequences']);
-        
+
         // Assert other custom options are still preserved
         $this->assertArrayHasKey('otherOption', $customOptions);
         $this->assertEquals('value', $customOptions['otherOption']);

--- a/tests/unit/Builders/PromptBuilderTest.php
+++ b/tests/unit/Builders/PromptBuilderTest.php
@@ -643,6 +643,99 @@ class PromptBuilderTest extends TestCase
     }
 
     /**
+     * Tests usingModelConfig method.
+     *
+     * @return void
+     */
+    public function testUsingModelConfig(): void
+    {
+        $builder = new PromptBuilder($this->registry);
+        
+        // Set some initial config values on the builder
+        $builder->usingSystemInstruction('Builder instruction')
+                ->usingMaxTokens(500)
+                ->usingTemperature(0.5);
+        
+        // Create a config to merge
+        $config = new ModelConfig();
+        $config->setSystemInstruction('Config instruction');
+        $config->setMaxTokens(1000);
+        $config->setTopP(0.9);
+        $config->setTopK(40);
+        
+        $result = $builder->usingModelConfig($config);
+        
+        // Assert fluent interface
+        $this->assertSame($builder, $result);
+        
+        // Get the merged config
+        $reflection = new \ReflectionClass($builder);
+        $configProperty = $reflection->getProperty('modelConfig');
+        $configProperty->setAccessible(true);
+        
+        /** @var ModelConfig $mergedConfig */
+        $mergedConfig = $configProperty->getValue($builder);
+        
+        // Assert builder values take precedence
+        $this->assertEquals('Builder instruction', $mergedConfig->getSystemInstruction());
+        $this->assertEquals(500, $mergedConfig->getMaxTokens());
+        $this->assertEquals(0.5, $mergedConfig->getTemperature());
+        
+        // Assert config values are used when builder doesn't have them
+        $this->assertEquals(0.9, $mergedConfig->getTopP());
+        $this->assertEquals(40, $mergedConfig->getTopK());
+    }
+
+    /**
+     * Tests usingModelConfig with custom options.
+     *
+     * @return void
+     */
+    public function testUsingModelConfigWithCustomOptions(): void
+    {
+        $builder = new PromptBuilder($this->registry);
+        
+        // Create a config with custom options
+        $config = new ModelConfig();
+        $config->setCustomOption('stopSequences', ['CONFIG_STOP']);
+        $config->setCustomOption('otherOption', 'value');
+        
+        $builder->usingModelConfig($config);
+        
+        // Get the merged config
+        $reflection = new \ReflectionClass($builder);
+        $configProperty = $reflection->getProperty('modelConfig');
+        $configProperty->setAccessible(true);
+        
+        /** @var ModelConfig $mergedConfig */
+        $mergedConfig = $configProperty->getValue($builder);
+        $customOptions = $mergedConfig->getCustomOptions();
+        
+        // Assert config custom options are preserved
+        $this->assertArrayHasKey('stopSequences', $customOptions);
+        $this->assertIsArray($customOptions['stopSequences']);
+        $this->assertEquals(['CONFIG_STOP'], $customOptions['stopSequences']);
+        $this->assertArrayHasKey('otherOption', $customOptions);
+        $this->assertEquals('value', $customOptions['otherOption']);
+        
+        // Now set a builder value that overrides one of the custom options
+        $builder->usingStopSequences('STOP');
+        
+        // Get the config again
+        $mergedConfig = $configProperty->getValue($builder);
+        $customOptions = $mergedConfig->getCustomOptions();
+        
+        // Assert builder's stop sequences override the config's
+        $this->assertArrayHasKey('stopSequences', $customOptions);
+        $this->assertIsArray($customOptions['stopSequences']);
+        $this->assertEquals(['STOP'], $customOptions['stopSequences']);
+        
+        // Assert other custom options are still preserved
+        $this->assertArrayHasKey('otherOption', $customOptions);
+        $this->assertEquals('value', $customOptions['otherOption']);
+    }
+
+    /**
      * Tests usingProvider method.
      *
      * @return void

--- a/tests/unit/Providers/Models/DTO/ModelConfigTest.php
+++ b/tests/unit/Providers/Models/DTO/ModelConfigTest.php
@@ -340,16 +340,16 @@ class ModelConfigTest extends TestCase
         // Test with empty custom options (default)
         $config = new ModelConfig();
         $config->setTemperature(0.7);
-        
+
         $array = $config->toArray();
         $this->assertArrayNotHasKey(ModelConfig::KEY_CUSTOM_OPTIONS, $array);
-        
+
         // Test with non-empty custom options
         $config->setCustomOption('key1', 'value1');
         $array = $config->toArray();
         $this->assertArrayHasKey(ModelConfig::KEY_CUSTOM_OPTIONS, $array);
         $this->assertEquals(['key1' => 'value1'], $array[ModelConfig::KEY_CUSTOM_OPTIONS]);
-        
+
         // Test with multiple custom options
         $config->setCustomOption('key2', ['nested' => 'value']);
         $array = $config->toArray();
@@ -358,7 +358,7 @@ class ModelConfigTest extends TestCase
             'key1' => 'value1',
             'key2' => ['nested' => 'value']
         ], $array[ModelConfig::KEY_CUSTOM_OPTIONS]);
-        
+
         // Test resetting custom options to empty
         $config->setCustomOptions([]);
         $array = $config->toArray();

--- a/tests/unit/Providers/Models/DTO/ModelConfigTest.php
+++ b/tests/unit/Providers/Models/DTO/ModelConfigTest.php
@@ -304,9 +304,8 @@ class ModelConfigTest extends TestCase
         $array = $config->toArray();
 
         $this->assertIsArray($array);
-        $this->assertCount(1, $array);
-        $this->assertArrayHasKey(ModelConfig::KEY_CUSTOM_OPTIONS, $array);
-        $this->assertEquals([], $array[ModelConfig::KEY_CUSTOM_OPTIONS]);
+        $this->assertCount(0, $array);
+        $this->assertArrayNotHasKey(ModelConfig::KEY_CUSTOM_OPTIONS, $array);
     }
 
     /**
@@ -323,12 +322,47 @@ class ModelConfigTest extends TestCase
         $array = $config->toArray();
 
         $this->assertIsArray($array);
-        $this->assertCount(3, $array);
+        $this->assertCount(2, $array);
         $this->assertEquals(0.5, $array[ModelConfig::KEY_TEMPERATURE]);
         $this->assertEquals(100, $array[ModelConfig::KEY_MAX_TOKENS]);
-        $this->assertEquals([], $array[ModelConfig::KEY_CUSTOM_OPTIONS]);
+        $this->assertArrayNotHasKey(ModelConfig::KEY_CUSTOM_OPTIONS, $array);
         $this->assertArrayNotHasKey(ModelConfig::KEY_SYSTEM_INSTRUCTION, $array);
         $this->assertArrayNotHasKey(ModelConfig::KEY_TOP_P, $array);
+    }
+
+    /**
+     * Tests custom options are only included when not empty.
+     *
+     * @return void
+     */
+    public function testToArrayCustomOptionsOnlyIncludedWhenNotEmpty(): void
+    {
+        // Test with empty custom options (default)
+        $config = new ModelConfig();
+        $config->setTemperature(0.7);
+        
+        $array = $config->toArray();
+        $this->assertArrayNotHasKey(ModelConfig::KEY_CUSTOM_OPTIONS, $array);
+        
+        // Test with non-empty custom options
+        $config->setCustomOption('key1', 'value1');
+        $array = $config->toArray();
+        $this->assertArrayHasKey(ModelConfig::KEY_CUSTOM_OPTIONS, $array);
+        $this->assertEquals(['key1' => 'value1'], $array[ModelConfig::KEY_CUSTOM_OPTIONS]);
+        
+        // Test with multiple custom options
+        $config->setCustomOption('key2', ['nested' => 'value']);
+        $array = $config->toArray();
+        $this->assertArrayHasKey(ModelConfig::KEY_CUSTOM_OPTIONS, $array);
+        $this->assertEquals([
+            'key1' => 'value1',
+            'key2' => ['nested' => 'value']
+        ], $array[ModelConfig::KEY_CUSTOM_OPTIONS]);
+        
+        // Test resetting custom options to empty
+        $config->setCustomOptions([]);
+        $array = $config->toArray();
+        $this->assertArrayNotHasKey(ModelConfig::KEY_CUSTOM_OPTIONS, $array);
     }
 
     /**


### PR DESCRIPTION
This adds a `PromptBuilder::usingModelConfig` method, which receives and merges a config into the builder. This also fixes an issue that custom options in the model config were also included in `toArray()`, when they should be optional as the other keys.

As a note, I decided _not_ to worry about merging the custom options array at this point. The reason being the `PromptBuilder` will not have custom options, so if the config introduced has custom options then they'll be preserved.