### PR TITLE
Allow retrieving all registered provider IDs from registry

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -419,6 +419,7 @@ direction LR
     namespace AiClientNamespace.Providers {
         class ProviderRegistry {
             +registerProvider(string $className) void
+            +getRegisteredProviderIds() string[]
             +hasProvider(string $idOrClassName) bool
             +getProviderClassName(string $id) string
             +isProviderConfigured(string $idOrClassName) bool

--- a/src/Providers/ProviderRegistry.php
+++ b/src/Providers/ProviderRegistry.php
@@ -114,6 +114,18 @@ class ProviderRegistry implements WithHttpTransporterInterface
     }
 
     /**
+     * Gets a list of all registered provider IDs.
+     *
+     * @since 0.1.0
+     *
+     * @return list<string> List of registered provider IDs.
+     */
+    public function getRegisteredProviderIds(): array
+    {
+        return array_keys($this->providerClassNames);
+    }
+
+    /**
      * Checks if a provider is registered.
      *
      * @since 0.1.0

--- a/src/Providers/ProviderRegistry.php
+++ b/src/Providers/ProviderRegistry.php
@@ -118,7 +118,7 @@ class ProviderRegistry implements WithHttpTransporterInterface
      *
      * @since 0.1.0
      *
-     * @return list<string> List of registered provider IDs.
+     * @return list<class-string<ProviderInterface> List of registered provider IDs.
      */
     public function getRegisteredProviderIds(): array
     {

--- a/src/Providers/ProviderRegistry.php
+++ b/src/Providers/ProviderRegistry.php
@@ -118,7 +118,7 @@ class ProviderRegistry implements WithHttpTransporterInterface
      *
      * @since 0.1.0
      *
-     * @return list<class-string<ProviderInterface>> List of registered provider IDs.
+     * @return list<string> List of registered provider IDs.
      */
     public function getRegisteredProviderIds(): array
     {

--- a/src/Providers/ProviderRegistry.php
+++ b/src/Providers/ProviderRegistry.php
@@ -118,7 +118,7 @@ class ProviderRegistry implements WithHttpTransporterInterface
      *
      * @since 0.1.0
      *
-     * @return list<class-string<ProviderInterface> List of registered provider IDs.
+     * @return list<class-string<ProviderInterface>> List of registered provider IDs.
      */
     public function getRegisteredProviderIds(): array
     {

--- a/tests/unit/Providers/ProviderRegistryTest.php
+++ b/tests/unit/Providers/ProviderRegistryTest.php
@@ -67,6 +67,21 @@ class ProviderRegistryTest extends TestCase
     }
 
     /**
+     * Tests that getRegisteredProviderIds returns the correct provider IDs.
+     *
+     * @return void
+     */
+    public function testGetRegisteredProviderIds(): void
+    {
+        $this->registry->registerProvider(MockProvider::class);
+
+        $this->assertEquals(['mock'], $this->registry->getRegisteredProviderIds());
+
+        // To test with multiple providers, we would need another mock provider class.
+        // For now, this covers the basic functionality.
+    }
+
+    /**
      * Tests hasProvider with unregistered provider.
      *
      * @return void


### PR DESCRIPTION
Our registry so far does not allow this, but it's a crucial requirement IMO. Code needs to be able to cycle through all registered providers, e.g. in our WordPress specific package this need is already relevant.