### PR TITLE
Enhance AiClient::isConfigured() to support provider ID and class name

### DIFF
--- a/src/AiClient.php
+++ b/src/AiClient.php
@@ -128,10 +128,9 @@ class AiClient
      *
      * @param ProviderAvailabilityInterface|string|class-string<ProviderInterface> $availabilityOrIdOrClassName
      *        The provider availability instance, provider ID, or provider class name.
-     * @param ProviderRegistry|null $registry Optional custom registry. If null, uses default.
      * @return bool True if the provider is configured and available, false otherwise.
      */
-    public static function isConfigured($availabilityOrIdOrClassName, ?ProviderRegistry $registry = null): bool
+    public static function isConfigured($availabilityOrIdOrClassName): bool
     {
         // Handle direct ProviderAvailabilityInterface (backward compatibility)
         if ($availabilityOrIdOrClassName instanceof ProviderAvailabilityInterface) {
@@ -140,8 +139,7 @@ class AiClient
 
         // Handle string input (provider ID or class name) via registry
         if (is_string($availabilityOrIdOrClassName)) {
-            $registry = $registry ?? self::defaultRegistry();
-            return $registry->isProviderConfigured($availabilityOrIdOrClassName);
+            return self::defaultRegistry()->isProviderConfigured($availabilityOrIdOrClassName);
         }
 
         throw new \InvalidArgumentException(

--- a/src/AiClient.php
+++ b/src/AiClient.php
@@ -125,6 +125,7 @@ class AiClient
      * injected into availability instances.
      *
      * @since 0.1.0
+     * @since n.e.x.t Now supports being passed a provider ID or class name.
      *
      * @param ProviderAvailabilityInterface|string|class-string<ProviderInterface> $availabilityOrIdOrClassName
      *        The provider availability instance, provider ID, or provider class name.

--- a/src/AiClient.php
+++ b/src/AiClient.php
@@ -9,6 +9,7 @@ use WordPress\AiClient\ProviderImplementations\Anthropic\AnthropicProvider;
 use WordPress\AiClient\ProviderImplementations\Google\GoogleProvider;
 use WordPress\AiClient\ProviderImplementations\OpenAi\OpenAiProvider;
 use WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface;
+use WordPress\AiClient\Providers\Contracts\ProviderInterface;
 use WordPress\AiClient\Providers\Http\HttpTransporterFactory;
 use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
@@ -114,14 +115,44 @@ class AiClient
     /**
      * Checks if a provider is configured and available for use.
      *
+     * Supports multiple input formats for developer convenience:
+     * - ProviderAvailabilityInterface: Direct availability check (backward compatible)
+     * - string (provider ID): e.g., AiClient::isConfigured('openai')
+     * - string (class name): e.g., AiClient::isConfigured(OpenAiProvider::class)
+     *
+     * When using string input, this method leverages the ProviderRegistry's centralized
+     * dependency management, ensuring HttpTransporter and authentication are properly
+     * injected into availability instances.
+     *
      * @since 0.1.0
      *
-     * @param ProviderAvailabilityInterface $availability The provider availability instance to check.
+     * @param ProviderAvailabilityInterface|string|class-string<ProviderInterface> $availabilityOrIdOrClassName
+     *        The provider availability instance, provider ID, or provider class name.
+     * @param ProviderRegistry|null $registry Optional custom registry. If null, uses default.
      * @return bool True if the provider is configured and available, false otherwise.
      */
-    public static function isConfigured(ProviderAvailabilityInterface $availability): bool
+    public static function isConfigured($availabilityOrIdOrClassName, ?ProviderRegistry $registry = null): bool
     {
-        return $availability->isConfigured();
+        // Handle direct ProviderAvailabilityInterface (backward compatibility)
+        if ($availabilityOrIdOrClassName instanceof ProviderAvailabilityInterface) {
+            return $availabilityOrIdOrClassName->isConfigured();
+        }
+
+        // Handle string input (provider ID or class name) via registry
+        if (is_string($availabilityOrIdOrClassName)) {
+            $registry = $registry ?? self::defaultRegistry();
+            return $registry->isProviderConfigured($availabilityOrIdOrClassName);
+        }
+
+        throw new \InvalidArgumentException(
+            'Parameter must be a ProviderAvailabilityInterface instance, provider ID string, or provider class name. ' .
+            sprintf(
+                'Received: %s',
+                is_object($availabilityOrIdOrClassName)
+                    ? get_class($availabilityOrIdOrClassName)
+                    : gettype($availabilityOrIdOrClassName)
+            )
+        );
     }
 
     /**

--- a/src/AiClient.php
+++ b/src/AiClient.php
@@ -116,7 +116,7 @@ class AiClient
      * Checks if a provider is configured and available for use.
      *
      * Supports multiple input formats for developer convenience:
-     * - ProviderAvailabilityInterface: Direct availability check (backward compatible)
+     * - ProviderAvailabilityInterface: Direct availability check
      * - string (provider ID): e.g., AiClient::isConfigured('openai')
      * - string (class name): e.g., AiClient::isConfigured(OpenAiProvider::class)
      *

--- a/tests/unit/AiClientTest.php
+++ b/tests/unit/AiClientTest.php
@@ -248,35 +248,31 @@ class AiClientTest extends TestCase
     }
 
     /**
-     * Tests isConfigured method with provider ID string leverages registry.
+     * Tests isConfigured method with provider ID string leverages default registry.
      */
     public function testIsConfiguredWithProviderIdString(): void
     {
-        $mockRegistry = $this->createMock(ProviderRegistry::class);
-        $mockRegistry->expects($this->once())
-            ->method('isProviderConfigured')
-            ->with('openai')
-            ->willReturn(true);
+        // This test will use the actual default registry since we can't easily mock static methods
+        // The default registry should have providers registered, so we test the delegation path
+        $result = AiClient::isConfigured('openai');
 
-        $result = AiClient::isConfigured('openai', $mockRegistry);
-
-        $this->assertTrue($result);
+        // The result will be false because no actual API keys are configured in tests,
+        // but the important thing is that no exception is thrown and the registry delegation works
+        $this->assertIsBool($result);
     }
 
     /**
-     * Tests isConfigured method with provider class name leverages registry.
+     * Tests isConfigured method with provider class name leverages default registry.
      */
     public function testIsConfiguredWithProviderClassName(): void
     {
-        $mockRegistry = $this->createMock(ProviderRegistry::class);
-        $mockRegistry->expects($this->once())
-            ->method('isProviderConfigured')
-            ->with(OpenAiProvider::class)
-            ->willReturn(false);
+        // This test will use the actual default registry since we can't easily mock static methods
+        // The default registry should have providers registered, so we test the delegation path
+        $result = AiClient::isConfigured(OpenAiProvider::class);
 
-        $result = AiClient::isConfigured(OpenAiProvider::class, $mockRegistry);
-
-        $this->assertFalse($result);
+        // The result will be false because no actual API keys are configured in tests,
+        // but the important thing is that no exception is thrown and the registry delegation works
+        $this->assertIsBool($result);
     }
 
     /**
@@ -378,17 +374,13 @@ class AiClientTest extends TestCase
         $result = AiClient::isConfigured($mockAvailability);
         $this->assertTrue($result);
 
-        // Should work with registry parameter (but registry should be ignored for interface input)
-        $mockRegistry = $this->createMock(ProviderRegistry::class);
-        $mockRegistry->expects($this->never())
-            ->method('isProviderConfigured'); // Registry should not be called for interface input
-
+        // Should work in all cases with interface input
         $mockAvailability2 = $this->createMock(ProviderAvailabilityInterface::class);
         $mockAvailability2->expects($this->once())
             ->method('isConfigured')
             ->willReturn(false);
 
-        $result2 = AiClient::isConfigured($mockAvailability2, $mockRegistry);
+        $result2 = AiClient::isConfigured($mockAvailability2);
         $this->assertFalse($result2);
     }
 

--- a/tests/unit/AiClientTest.php
+++ b/tests/unit/AiClientTest.php
@@ -276,34 +276,6 @@ class AiClientTest extends TestCase
     }
 
     /**
-     * Tests isConfigured method with provider ID uses default registry when none provided.
-     */
-    public function testIsConfiguredWithProviderIdUsesDefaultRegistry(): void
-    {
-        // This test will use the actual default registry since we can't easily mock static methods
-        // The default registry should have providers registered, so we test the delegation path
-        $result = AiClient::isConfigured('openai');
-
-        // The result will be false because no actual API keys are configured in tests,
-        // but the important thing is that no exception is thrown and the registry delegation works
-        $this->assertIsBool($result);
-    }
-
-    /**
-     * Tests isConfigured method with provider class name uses default registry when none provided.
-     */
-    public function testIsConfiguredWithProviderClassNameUsesDefaultRegistry(): void
-    {
-        // This test will use the actual default registry since we can't easily mock static methods
-        // The default registry should have providers registered, so we test the delegation path
-        $result = AiClient::isConfigured(OpenAiProvider::class);
-
-        // The result will be false because no actual API keys are configured in tests,
-        // but the important thing is that no exception is thrown and the registry delegation works
-        $this->assertIsBool($result);
-    }
-
-    /**
      * Tests isConfigured method throws exception for invalid parameter types.
      */
     public function testIsConfiguredThrowsExceptionForInvalidParameterTypes(): void

--- a/tests/unit/AiClientTest.php
+++ b/tests/unit/AiClientTest.php
@@ -12,6 +12,7 @@ use WordPress\AiClient\Messages\DTO\UserMessage;
 use WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WordPress\AiClient\Providers\ProviderRegistry;
+use WordPress\AiClient\ProviderImplementations\OpenAi\OpenAiProvider;
 use WordPress\AiClient\Tests\traits\MockModelCreationTrait;
 
 /**
@@ -244,6 +245,150 @@ class AiClientTest extends TestCase
         $result = AiClient::isConfigured($mockAvailability);
 
         $this->assertFalse($result);
+    }
+
+    /**
+     * Tests isConfigured method with provider ID string leverages registry.
+     */
+    public function testIsConfiguredWithProviderIdString(): void
+    {
+        $mockRegistry = $this->createMock(ProviderRegistry::class);
+        $mockRegistry->expects($this->once())
+            ->method('isProviderConfigured')
+            ->with('openai')
+            ->willReturn(true);
+
+        $result = AiClient::isConfigured('openai', $mockRegistry);
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Tests isConfigured method with provider class name leverages registry.
+     */
+    public function testIsConfiguredWithProviderClassName(): void
+    {
+        $mockRegistry = $this->createMock(ProviderRegistry::class);
+        $mockRegistry->expects($this->once())
+            ->method('isProviderConfigured')
+            ->with(OpenAiProvider::class)
+            ->willReturn(false);
+
+        $result = AiClient::isConfigured(OpenAiProvider::class, $mockRegistry);
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Tests isConfigured method with provider ID uses default registry when none provided.
+     */
+    public function testIsConfiguredWithProviderIdUsesDefaultRegistry(): void
+    {
+        // This test will use the actual default registry since we can't easily mock static methods
+        // The default registry should have providers registered, so we test the delegation path
+        $result = AiClient::isConfigured('openai');
+
+        // The result will be false because no actual API keys are configured in tests,
+        // but the important thing is that no exception is thrown and the registry delegation works
+        $this->assertIsBool($result);
+    }
+
+    /**
+     * Tests isConfigured method with provider class name uses default registry when none provided.
+     */
+    public function testIsConfiguredWithProviderClassNameUsesDefaultRegistry(): void
+    {
+        // This test will use the actual default registry since we can't easily mock static methods
+        // The default registry should have providers registered, so we test the delegation path
+        $result = AiClient::isConfigured(OpenAiProvider::class);
+
+        // The result will be false because no actual API keys are configured in tests,
+        // but the important thing is that no exception is thrown and the registry delegation works
+        $this->assertIsBool($result);
+    }
+
+    /**
+     * Tests isConfigured method throws exception for invalid parameter types.
+     */
+    public function testIsConfiguredThrowsExceptionForInvalidParameterTypes(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Parameter must be a ProviderAvailabilityInterface instance, provider ID string, or provider class name. ' .
+            'Received: integer'
+        );
+
+        AiClient::isConfigured(123);
+    }
+
+    /**
+     * Data provider for invalid isConfigured parameter types.
+     *
+     * @return array<string, array{mixed, string}>
+     */
+    public function invalidIsConfiguredParameterTypesProvider(): array
+    {
+        return [
+            'integer parameter' => [123, 'integer'],
+            'array parameter' => [['invalid_array'], 'array'],
+            'object parameter' => [new \stdClass(), 'stdClass'],
+            'boolean parameter' => [true, 'boolean'],
+            'null parameter' => [null, 'NULL'],
+        ];
+    }
+
+    /**
+     * Tests that isConfigured rejects all invalid parameter types consistently.
+     *
+     * @dataProvider invalidIsConfiguredParameterTypesProvider
+     * @param mixed $invalidParam
+     */
+    public function testIsConfiguredRejectsInvalidParameterTypes($invalidParam, string $expectedType): void
+    {
+        try {
+            AiClient::isConfigured($invalidParam);
+            $this->fail("Expected InvalidArgumentException for isConfigured with $expectedType");
+        } catch (\InvalidArgumentException $e) {
+            $this->assertStringContainsString(
+                'Parameter must be a ProviderAvailabilityInterface instance, provider ID string, or provider class name.',
+                $e->getMessage(),
+                "isConfigured should reject invalid parameter type: $expectedType"
+            );
+            $this->assertStringContainsString(
+                "Received: $expectedType",
+                $e->getMessage(),
+                "isConfigured should include received type in error message"
+            );
+        }
+    }
+
+    /**
+     * Tests backward compatibility - isConfigured still works with ProviderAvailabilityInterface.
+     */
+    public function testIsConfiguredBackwardCompatibility(): void
+    {
+        // Test that the original interface-based approach still works exactly as before
+        $mockAvailability = $this->createMock(ProviderAvailabilityInterface::class);
+        $mockAvailability->expects($this->once())
+            ->method('isConfigured')
+            ->willReturn(true);
+
+        // Should work without registry parameter
+        $result = AiClient::isConfigured($mockAvailability);
+        $this->assertTrue($result);
+
+        // Should work with registry parameter (but registry should be ignored for interface input)
+        $mockRegistry = $this->createMock(ProviderRegistry::class);
+        $mockRegistry->expects($this->never())
+            ->method('isProviderConfigured'); // Registry should not be called for interface input
+
+        $mockAvailability2 = $this->createMock(ProviderAvailabilityInterface::class);
+        $mockAvailability2->expects($this->once())
+            ->method('isConfigured')
+            ->willReturn(false);
+
+        $result2 = AiClient::isConfigured($mockAvailability2, $mockRegistry);
+        $this->assertFalse($result2);
     }
 
     /**

--- a/tests/unit/AiClientTest.php
+++ b/tests/unit/AiClientTest.php
@@ -9,10 +9,10 @@ use RuntimeException;
 use WordPress\AiClient\AiClient;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\UserMessage;
+use WordPress\AiClient\ProviderImplementations\OpenAi\OpenAiProvider;
 use WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WordPress\AiClient\Providers\ProviderRegistry;
-use WordPress\AiClient\ProviderImplementations\OpenAi\OpenAiProvider;
 use WordPress\AiClient\Tests\traits\MockModelCreationTrait;
 
 /**
@@ -350,7 +350,8 @@ class AiClientTest extends TestCase
             $this->fail("Expected InvalidArgumentException for isConfigured with $expectedType");
         } catch (\InvalidArgumentException $e) {
             $this->assertStringContainsString(
-                'Parameter must be a ProviderAvailabilityInterface instance, provider ID string, or provider class name.',
+                'Parameter must be a ProviderAvailabilityInterface instance, provider ID string, ' .
+                'or provider class name.',
                 $e->getMessage(),
                 "isConfigured should reject invalid parameter type: $expectedType"
             );


### PR DESCRIPTION
This PR enhances the `AiClient::isConfigured()` method to support multiple input formats for improved developer experience, while preserving 100% backward compatibility and maintaining the critical centralized dependency management architecture.

**Changes Made**

  **Enhanced API Support**

  The method now supports three input patterns:

  ```
// Existing pattern (backward compatible)
  AiClient::isConfigured($availability) // ProviderAvailabilityInterface
 
  // New convenient patterns
  AiClient::isConfigured('openai')              // By  provider ID
  AiClient::isConfigured(OpenAiProvider::class) // By  provider class name
```

  **Implementation Details**

  - Preserves Centralized Architecture: Leverages the existing` ProviderRegistry::isProviderConfigured()` method
  - Automatic Dependency Injection: `HttpTransporter` instances are properly managed by the registry


Fixes #57 
