### PR TITLE
Modify the `toText` and `toTexts` methods of the `GenerativeAiResult` class to only return the content channel

### DIFF
--- a/src/Results/DTO/GenerativeAiResult.php
+++ b/src/Results/DTO/GenerativeAiResult.php
@@ -320,7 +320,7 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
     }
 
     /**
-     * Converts all candidates to text array.
+     * Converts all content candidates to a text array.
      *
      * @since 0.1.0
      *
@@ -332,8 +332,9 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
         foreach ($this->candidates as $candidate) {
             $message = $candidate->getMessage();
             foreach ($message->getParts() as $part) {
+                $channel = $part->getChannel();
                 $text = $part->getText();
-                if ($text !== null) {
+                if (MessagePartChannelEnum::content() === $channel && $text !== null) {
                     $texts[] = $text;
                     break;
                 }

--- a/src/Results/DTO/GenerativeAiResult.php
+++ b/src/Results/DTO/GenerativeAiResult.php
@@ -9,6 +9,7 @@ use RuntimeException;
 use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\Enums\MessagePartChannelEnum;
 use WordPress\AiClient\Providers\DTO\ProviderMetadata;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 use WordPress\AiClient\Results\Contracts\ResultInterface;
@@ -199,7 +200,7 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
     }
 
     /**
-     * Converts the first candidate to text.
+     * Converts the first content candidate to text.
      *
      * @since 0.1.0
      *
@@ -208,15 +209,18 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
      */
     public function toText(): string
     {
-        $message = $this->candidates[0]->getMessage();
-        foreach ($message->getParts() as $part) {
-            $text = $part->getText();
-            if ($text !== null) {
-                return $text;
+        foreach ($this->candidates as $candidate) {
+            $message = $candidate->getMessage();
+            foreach ($message->getParts() as $part) {
+                $channel = $part->getChannel();
+                $text = $part->getText();
+                if (MessagePartChannelEnum::content() === $channel && $text !== null) {
+                    return $text;
+                }
             }
         }
 
-        throw new RuntimeException('No text content found in first candidate');
+        throw new RuntimeException('No text content found in the candidates');
     }
 
     /**

--- a/src/Results/DTO/GenerativeAiResult.php
+++ b/src/Results/DTO/GenerativeAiResult.php
@@ -199,7 +199,9 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
     }
 
     /**
-     * Converts the first content candidate to text.
+     * Converts the first candidate to text.
+     *
+     * Only text from the content channel is considered. Text within model thought or reasoning is ignored.
      *
      * @since 0.1.0
      *
@@ -221,7 +223,9 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
     }
 
     /**
-     * Converts the first content candidate to a file.
+     * Converts the first candidate to a file.
+     *
+     * Only files from the content channel are considered. Files within model thought or reasoning are ignored.
      *
      * @since 0.1.0
      *
@@ -318,7 +322,7 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
     }
 
     /**
-     * Converts all content candidates to a text array.
+     * Converts all candidates to text.
      *
      * @since 0.1.0
      *

--- a/src/Results/DTO/GenerativeAiResult.php
+++ b/src/Results/DTO/GenerativeAiResult.php
@@ -221,7 +221,7 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
     }
 
     /**
-     * Converts the first candidate to a file.
+     * Converts the first content candidate to a file.
      *
      * @since 0.1.0
      *
@@ -232,8 +232,9 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
     {
         $message = $this->candidates[0]->getMessage();
         foreach ($message->getParts() as $part) {
+            $channel = $part->getChannel();
             $file = $part->getFile();
-            if ($file !== null) {
+            if ($channel->isContent() && $file !== null) {
                 return $file;
             }
         }
@@ -353,8 +354,9 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
         foreach ($this->candidates as $candidate) {
             $message = $candidate->getMessage();
             foreach ($message->getParts() as $part) {
+                $channel = $part->getChannel();
                 $file = $part->getFile();
-                if ($file !== null) {
+                if ($channel->isContent() && $file !== null) {
                     $files[] = $file;
                     break;
                 }

--- a/src/Results/DTO/GenerativeAiResult.php
+++ b/src/Results/DTO/GenerativeAiResult.php
@@ -9,7 +9,6 @@ use RuntimeException;
 use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Messages\DTO\Message;
-use WordPress\AiClient\Messages\Enums\MessagePartChannelEnum;
 use WordPress\AiClient\Providers\DTO\ProviderMetadata;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 use WordPress\AiClient\Results\Contracts\ResultInterface;
@@ -209,18 +208,16 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
      */
     public function toText(): string
     {
-        foreach ($this->candidates as $candidate) {
-            $message = $candidate->getMessage();
-            foreach ($message->getParts() as $part) {
-                $channel = $part->getChannel();
-                $text = $part->getText();
-                if (MessagePartChannelEnum::content() === $channel && $text !== null) {
-                    return $text;
-                }
+        $message = $this->candidates[0]->getMessage();
+        foreach ($message->getParts() as $part) {
+            $channel = $part->getChannel();
+            $text = $part->getText();
+            if ($channel->isContent() && $text !== null) {
+                return $text;
             }
         }
 
-        throw new RuntimeException('No text content found in the candidates');
+        throw new RuntimeException('No text content found in first candidate');
     }
 
     /**
@@ -334,7 +331,7 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
             foreach ($message->getParts() as $part) {
                 $channel = $part->getChannel();
                 $text = $part->getText();
-                if (MessagePartChannelEnum::content() === $channel && $text !== null) {
+                if ($channel->isContent() && $text !== null) {
                     $texts[] = $text;
                     break;
                 }

--- a/tests/unit/Builders/PromptBuilderTest.php
+++ b/tests/unit/Builders/PromptBuilderTest.php
@@ -1601,7 +1601,7 @@ class PromptBuilderTest extends TestCase
         $builder->usingModel($model);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('No text content found in the candidates');
+        $this->expectExceptionMessage('No text content found in first candidate');
 
         $builder->generateText();
     }
@@ -1635,7 +1635,7 @@ class PromptBuilderTest extends TestCase
         $builder->usingModel($model);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('No text content found in the candidates');
+        $this->expectExceptionMessage('No text content found in first candidate');
 
         $builder->generateText();
     }
@@ -2534,7 +2534,7 @@ class PromptBuilderTest extends TestCase
         $builder->usingModel($model);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('No text content found in the candidates');
+        $this->expectExceptionMessage('No text content found in first candidate');
 
         $builder->generateText();
     }

--- a/tests/unit/Builders/PromptBuilderTest.php
+++ b/tests/unit/Builders/PromptBuilderTest.php
@@ -1601,7 +1601,7 @@ class PromptBuilderTest extends TestCase
         $builder->usingModel($model);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('No text content found in first candidate');
+        $this->expectExceptionMessage('No text content found in the candidates');
 
         $builder->generateText();
     }
@@ -1635,7 +1635,7 @@ class PromptBuilderTest extends TestCase
         $builder->usingModel($model);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('No text content found in first candidate');
+        $this->expectExceptionMessage('No text content found in the candidates');
 
         $builder->generateText();
     }
@@ -2534,7 +2534,7 @@ class PromptBuilderTest extends TestCase
         $builder->usingModel($model);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('No text content found in first candidate');
+        $this->expectExceptionMessage('No text content found in the candidates');
 
         $builder->generateText();
     }

--- a/tests/unit/Results/DTO/GenerativeAiResultTest.php
+++ b/tests/unit/Results/DTO/GenerativeAiResultTest.php
@@ -11,6 +11,7 @@ use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\ModelMessage;
+use WordPress\AiClient\Messages\Enums\MessagePartChannelEnum;
 use WordPress\AiClient\Messages\Enums\MessagePartTypeEnum;
 use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 use WordPress\AiClient\Providers\DTO\ProviderMetadata;
@@ -187,6 +188,36 @@ class GenerativeAiResultTest extends TestCase
         );
 
         $this->assertEquals($text, $result->toText());
+    }
+
+    /**
+     * Tests toText method with both reasoning_content and content channels.
+     *
+     * @return void
+     */
+    public function testToTextWithReasoningContent(): void
+    {
+        $reasoningContent = 'Let me think about this step by step...';
+        $actualContent = 'This is the final answer.';
+
+        $message = new ModelMessage([
+            new MessagePart($reasoningContent, MessagePartChannelEnum::thought()),
+            new MessagePart($actualContent, MessagePartChannelEnum::content())
+        ]);
+        $candidate = new Candidate($message, FinishReasonEnum::stop());
+        $tokenUsage = new TokenUsage(10, 8, 18);
+
+        $result = new GenerativeAiResult(
+            'result_with_reasoning',
+            [$candidate],
+            $tokenUsage,
+            $this->createTestProviderMetadata(),
+            $this->createTestModelMetadata()
+        );
+
+        // toText() should only return content from the 'content' channel, not 'thought' channel
+        $this->assertEquals($actualContent, $result->toText());
+        $this->assertNotEquals($reasoningContent, $result->toText());
     }
 
     /**
@@ -428,6 +459,50 @@ class GenerativeAiResultTest extends TestCase
         );
 
         $this->assertEquals($texts, $result->toTexts());
+    }
+
+    /**
+     * Tests toTexts method with both reasoning_content and content channels.
+     *
+     * @return void
+     */
+    public function testToTextsWithReasoningContent(): void
+    {
+        $reasoningContent1 = 'Let me think about the first question...';
+        $actualContent1 = 'This is the first answer.';
+        $reasoningContent2 = 'Now for the second question...';
+        $actualContent2 = 'This is the second answer.';
+
+        $message1 = new ModelMessage([
+            new MessagePart($reasoningContent1, MessagePartChannelEnum::thought()),
+            new MessagePart($actualContent1, MessagePartChannelEnum::content())
+        ]);
+        $message2 = new ModelMessage([
+            new MessagePart($reasoningContent2, MessagePartChannelEnum::thought()),
+            new MessagePart($actualContent2, MessagePartChannelEnum::content())
+        ]);
+
+        $candidates = [
+            new Candidate($message1, FinishReasonEnum::stop()),
+            new Candidate($message2, FinishReasonEnum::stop())
+        ];
+        $tokenUsage = new TokenUsage(20, 15, 35);
+
+        $result = new GenerativeAiResult(
+            'result_texts_with_reasoning',
+            $candidates,
+            $tokenUsage,
+            $this->createTestProviderMetadata(),
+            $this->createTestModelMetadata()
+        );
+
+        // toTexts() should only return content from the 'content' channel, not 'thought' channel
+        $expectedTexts = [$actualContent1, $actualContent2];
+        $this->assertEquals($expectedTexts, $result->toTexts());
+
+        // Verify reasoning content is not included
+        $this->assertNotContains($reasoningContent1, $result->toTexts());
+        $this->assertNotContains($reasoningContent2, $result->toTexts());
     }
 
     /**

--- a/tests/unit/Results/DTO/GenerativeAiResultTest.php
+++ b/tests/unit/Results/DTO/GenerativeAiResultTest.php
@@ -243,7 +243,7 @@ class GenerativeAiResultTest extends TestCase
         );
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('No text content found in the candidates');
+        $this->expectExceptionMessage('No text content found in first candidate');
 
         $result->toText();
     }

--- a/tests/unit/Results/DTO/GenerativeAiResultTest.php
+++ b/tests/unit/Results/DTO/GenerativeAiResultTest.php
@@ -212,7 +212,7 @@ class GenerativeAiResultTest extends TestCase
         );
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('No text content found in first candidate');
+        $this->expectExceptionMessage('No text content found in the candidates');
 
         $result->toText();
     }


### PR DESCRIPTION
As described in #89, if you use a reasoning model, the content returned contains both `reasoning_content` and `content` items. The `reasoning_content` is always first in the array and so when `toText` is returned, `reasoning_content` will always be returned instead of `content`.

This PR adjusts the logic of those methods to only return items that are in the `content` channel.

May be worth a discussion on if we:

1. Want methods that allow you to pass in what channel type you want instead of hardcoding that to `content`. Right now if you want the `reasoning_content`, you'd have to parse that out yourself from the response instead of using the built-in helper methods
2. Is there any risk to only returning the `content` channel? For instance, if an LLM for some reason only returns the reasoning result, this new approach will return nothing (or will throw an exception). I debated modifying these methods to fallback to returning the first result if we don't find any result that matches the `content` channel but wasn't sure if we actually wanted it to function that way 