### PR TITLE
Add further popular AI assistant config folders to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,12 @@ vendor/
 ############
 
 .claude/
-CLAUDE.md
 .clinerules/
+.codex/
 .cursor/
+.gemini/
+.windsurf/
+CLAUDE.md
 GEMINI.md
 
 ############

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ vendor/
 ############
 
 .claude/
+.clinerules
 .clinerules/
 .codex/
 .cursor/


### PR DESCRIPTION
This simply adds more popular AI assistant config directories to `.gitignore`, allowing contributors to use them without having to worry about pushing anything by accident.