### PR TITLE
Adds PromptBuilder preferred model support

### DIFF
--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -226,7 +226,8 @@ class PromptBuilder
      *
      * @since n.e.x.t
      *
-     * @param string|ModelInterface|array{0:string,1:string} ...$preferredModels The preferred models as model IDs, model instances, or [provider ID, model ID] tuples.
+     * @param string|ModelInterface|array{0:string,1:string} ...$preferredModels The preferred models as model IDs,
+     * model instances, or [provider ID, model ID] tuples.
      * @return self
      *
      * @throws InvalidArgumentException When a preferred model has an invalid type or identifier.
@@ -1127,9 +1128,37 @@ class PromptBuilder
             return $this->model;
         }
 
-        /** @var list<array{0:string,1:ModelMetadata}> $candidateModels */
-        $candidateModels = [];
+        // Retrieve the models which satisfy the requirements.
+        $candidateModels = $this->getCandidateModels($requirements);
 
+        // Find the model which matches the preference, if any.
+        $selectedModel = $this->findModelByPreference($candidateModels);
+
+        if ($selectedModel === null) {
+            // No preference matched; fall back to the first candidate discovered.
+            [$providerId, $modelMetadata] = $candidateModels[0];
+            $selectedModel = $this->registry->getProviderModel(
+                $providerId,
+                $modelMetadata->getId(),
+                $this->modelConfig
+            );
+        }
+
+        return $selectedModel;
+    }
+
+    /**
+     * Builds the list of candidate provider/model combinations that satisfy the requirements.
+     *
+     * @since n.e.x.t
+     *
+     * @param ModelRequirements $requirements The requirements derived from the prompt.
+     * @return list<array{0:string,1:ModelMetadata}> The candidate provider/model tuples.
+     *
+     * @throws InvalidArgumentException If no suitable models are found.
+     */
+    private function getCandidateModels(ModelRequirements $requirements): array
+    {
         if ($this->providerIdOrClassName === null) {
             // No provider locked in, gather all models across providers that meet requirements.
             $providerModelsMetadata = $this->registry->findModelsMetadataForSupport($requirements);
@@ -1149,51 +1178,60 @@ class PromptBuilder
                 );
             }
 
+            $candidateModels = [];
             foreach ($providerModelsMetadata as $providerModels) {
                 $providerId = $providerModels->getProvider()->getId();
                 foreach ($providerModels->getModels() as $modelMetadata) {
                     $candidateModels[] = [$providerId, $modelMetadata];
                 }
             }
-        } else {
-            // Provider forced, only consider models from that provider.
-            $modelsMetadata = $this->registry->findProviderModelsMetadataForSupport(
-                $this->providerIdOrClassName,
-                $requirements
-            );
 
-            if (empty($modelsMetadata)) {
-                throw new InvalidArgumentException(
-                    sprintf(
-                        'No models found for %s that support the required capabilities and options for this prompt. ' .
-                        'Required capabilities: %s. Required options: %s',
-                        $this->providerIdOrClassName,
-                        implode(', ', array_map(function ($cap) {
-                            return $cap->value;
-                        }, $requirements->getRequiredCapabilities())),
-                        implode(', ', array_map(function ($opt) {
-                            return $opt->getName()->value . '=' . json_encode($opt->getValue());
-                        }, $requirements->getRequiredOptions()))
-                    )
-                );
-            }
-
-            foreach ($modelsMetadata as $modelMetadata) {
-                $candidateModels[] = [$this->providerIdOrClassName, $modelMetadata];
-            }
+            return $candidateModels;
         }
 
-        $selectedModel = null;
-        $selectedPreferenceIndex = null;
+        // Provider set, only consider models from that provider.
+        $modelsMetadata = $this->registry->findProviderModelsMetadataForSupport(
+            $this->providerIdOrClassName,
+            $requirements
+        );
 
+        if (empty($modelsMetadata)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'No models found for %s that support the required capabilities and options for this prompt. ' .
+                    'Required capabilities: %s. Required options: %s',
+                    $this->providerIdOrClassName,
+                    implode(', ', array_map(function ($cap) {
+                        return $cap->value;
+                    }, $requirements->getRequiredCapabilities())),
+                    implode(', ', array_map(function ($opt) {
+                        return $opt->getName()->value . '=' . json_encode($opt->getValue());
+                    }, $requirements->getRequiredOptions()))
+                )
+            );
+        }
+
+        $candidateModels = [];
+        foreach ($modelsMetadata as $modelMetadata) {
+            $candidateModels[] = [$this->providerIdOrClassName, $modelMetadata];
+        }
+
+        return $candidateModels;
+    }
+
+    /**
+     * Finds a preferred model among the given candidates.
+     *
+     * @since n.e.x.t
+     *
+     * @param list<array{0:string,1:ModelMetadata}> $candidateModels Candidate provider/model tuples.
+     * @return ModelInterface|null The model matching the highest-priority preference, or null if none.
+     */
+    private function findModelByPreference(array $candidateModels): ?ModelInterface
+    {
         foreach ($candidateModels as [$providerId, $modelMetadata]) {
             foreach ($this->modelPreference as $preferenceIndex => $preferredModel) {
-                if ($selectedPreferenceIndex !== null && $preferenceIndex >= $selectedPreferenceIndex) {
-                    continue;
-                }
-
                 if (is_array($preferredModel)) {
-                    // [provider ID, model ID] tuple
                     [$preferredProviderId, $preferredModelId] = $preferredModel;
                     if (
                         $providerId !== $preferredProviderId ||
@@ -1202,14 +1240,12 @@ class PromptBuilder
                         continue;
                     }
 
-                    $selectedModel = $this->registry->getProviderModel(
+                    return $this->registry->getProviderModel(
                         $providerId,
                         $modelMetadata->getId(),
                         $this->modelConfig
                     );
-                    $selectedPreferenceIndex = $preferenceIndex;
                 } elseif ($preferredModel instanceof ModelInterface) {
-                    // Model instance
                     $preferredProviderId = $preferredModel->providerMetadata()->getId();
                     $preferredModelId = $preferredModel->metadata()->getId();
 
@@ -1220,44 +1256,25 @@ class PromptBuilder
                         continue;
                     }
 
-                    $selectedModel = $preferredModel;
-                    $selectedPreferenceIndex = $preferenceIndex;
+                    $preferredModel->setConfig($this->modelConfig);
+                    $this->registry->bindModelDependencies($preferredModel);
+
+                    return $preferredModel;
                 } else {
-                    // Model ID
                     if ($modelMetadata->getId() !== $preferredModel) {
                         continue;
                     }
 
-                    $selectedModel = $this->registry->getProviderModel(
+                    return $this->registry->getProviderModel(
                         $providerId,
                         $modelMetadata->getId(),
                         $this->modelConfig
                     );
-                    $selectedPreferenceIndex = $preferenceIndex;
                 }
-
-                if ($selectedPreferenceIndex === 0) {
-                    break 2;
-                }
-
-                break;
             }
         }
 
-        if ($selectedModel === null) {
-            // No preference matched; fall back to the first candidate discovered.
-            [$providerId, $modelMetadata] = $candidateModels[0];
-            $selectedModel = $this->registry->getProviderModel(
-                $providerId,
-                $modelMetadata->getId(),
-                $this->modelConfig
-            );
-        }
-
-        $selectedModel->setConfig($this->modelConfig);
-        $this->registry->bindModelDependencies($selectedModel);
-
-        return $selectedModel;
+        return null;
     }
 
     /**

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -61,7 +61,7 @@ class PromptBuilder
     protected ?ModelInterface $model = null;
 
     /**
-     * @var list<ModelInterface|string> Preferred models to evaluate in order.
+     * @var list<ModelInterface|string|array{0:string,1:string}> Preferred models to evaluate in order.
      */
     protected array $modelPreference = [];
 
@@ -226,7 +226,7 @@ class PromptBuilder
      *
      * @since n.e.x.t
      *
-     * @param mixed ...$preferredModels The preferred models as model IDs or instances.
+     * @param string|ModelInterface|array{0:string,1:string} ...$preferredModels The preferred models as model IDs, model instances, or [provider ID, model ID] tuples.
      * @return self
      *
      * @throws InvalidArgumentException When a preferred model has an invalid type or identifier.
@@ -240,6 +240,37 @@ class PromptBuilder
         $normalizedModels = [];
 
         foreach ($preferredModels as $preferredModel) {
+            if (is_array($preferredModel)) {
+                if (!array_is_list($preferredModel) || count($preferredModel) !== 2) {
+                    throw new InvalidArgumentException(
+                        'Model preference tuple must contain provider ID and model identifier.'
+                    );
+                }
+
+                [$providerId, $modelIdentifier] = $preferredModel;
+
+                if (!is_string($providerId)) {
+                    throw new InvalidArgumentException('Model preference provider identifiers cannot be empty.');
+                }
+                $providerId = trim($providerId);
+                if ($providerId === '') {
+                    throw new InvalidArgumentException('Model preference provider identifiers cannot be empty.');
+                }
+
+                if (!is_string($modelIdentifier)) {
+                    throw new InvalidArgumentException(
+                        'Model preference tuple must contain provider ID and model identifier.'
+                    );
+                }
+                $modelIdentifier = trim($modelIdentifier);
+                if ($modelIdentifier === '') {
+                    throw new InvalidArgumentException('Model preference identifiers cannot be empty.');
+                }
+
+                $normalizedModels[] = [$providerId, $modelIdentifier];
+                continue;
+            }
+
             if ($preferredModel instanceof ModelInterface) {
                 $normalizedModels[] = $preferredModel;
                 continue;
@@ -255,7 +286,7 @@ class PromptBuilder
             }
 
             throw new InvalidArgumentException(
-                'Model preferences must be model identifiers or instances of ModelInterface.'
+                'Model preferences must be model identifiers, instances of ModelInterface, or provider/model tuples.'
             );
         }
 
@@ -1153,35 +1184,63 @@ class PromptBuilder
         }
 
         $selectedModel = null;
+        $selectedPreferenceIndex = null;
 
-        foreach ($this->modelPreference as $preferredModel) {
-            if ($preferredModel instanceof ModelInterface) {
-                // Check if the explicitly provided preferred model is among the supported candidates.
-                $preferredProviderId = $preferredModel->providerMetadata()->getId();
-                $preferredModelId = $preferredModel->metadata()->getId();
-
-                foreach ($candidateModels as [$providerId, $modelMetadata]) {
-                    if ($providerId === $preferredProviderId && $modelMetadata->getId() === $preferredModelId) {
-                        $selectedModel = $this->prepareExplicitModel($preferredModel);
-                        break 2;
-                    }
-                }
-
-                continue;
-            }
-
-            // Otherwise treat the preference as a model identifier and match it against candidates.
-            foreach ($candidateModels as [$providerId, $modelMetadata]) {
-                if ($modelMetadata->getId() !== $preferredModel) {
+        foreach ($candidateModels as [$providerId, $modelMetadata]) {
+            foreach ($this->modelPreference as $preferenceIndex => $preferredModel) {
+                if ($selectedPreferenceIndex !== null && $preferenceIndex >= $selectedPreferenceIndex) {
                     continue;
                 }
 
-                $selectedModel = $this->registry->getProviderModel(
-                    $providerId,
-                    $modelMetadata->getId(),
-                    $this->modelConfig
-                );
-                break 2;
+                if (is_array($preferredModel)) {
+                    // [provider ID, model ID] tuple
+                    [$preferredProviderId, $preferredModelId] = $preferredModel;
+                    if (
+                        $providerId !== $preferredProviderId ||
+                        $modelMetadata->getId() !== $preferredModelId
+                    ) {
+                        continue;
+                    }
+
+                    $selectedModel = $this->registry->getProviderModel(
+                        $providerId,
+                        $modelMetadata->getId(),
+                        $this->modelConfig
+                    );
+                    $selectedPreferenceIndex = $preferenceIndex;
+                } elseif ($preferredModel instanceof ModelInterface) {
+                    // Model instance
+                    $preferredProviderId = $preferredModel->providerMetadata()->getId();
+                    $preferredModelId = $preferredModel->metadata()->getId();
+
+                    if (
+                        $providerId !== $preferredProviderId ||
+                        $modelMetadata->getId() !== $preferredModelId
+                    ) {
+                        continue;
+                    }
+
+                    $selectedModel = $preferredModel;
+                    $selectedPreferenceIndex = $preferenceIndex;
+                } else {
+                    // Model ID
+                    if ($modelMetadata->getId() !== $preferredModel) {
+                        continue;
+                    }
+
+                    $selectedModel = $this->registry->getProviderModel(
+                        $providerId,
+                        $modelMetadata->getId(),
+                        $this->modelConfig
+                    );
+                    $selectedPreferenceIndex = $preferenceIndex;
+                }
+
+                if ($selectedPreferenceIndex === 0) {
+                    break 2;
+                }
+
+                break;
             }
         }
 
@@ -1195,29 +1254,10 @@ class PromptBuilder
             );
         }
 
+        $selectedModel->setConfig($this->modelConfig);
+        $this->registry->bindModelDependencies($selectedModel);
+
         return $selectedModel;
-    }
-
-    /**
-     * Prepares an explicitly provided model for usage by merging configuration and binding dependencies.
-     *
-     * @since n.e.x.t
-     *
-     * @param ModelInterface $model The model to prepare.
-     * @return ModelInterface The prepared model instance.
-     */
-    private function prepareExplicitModel(ModelInterface $model): ModelInterface
-    {
-        $modelConfigArray = $model->getConfig()->toArray();
-        $builderConfigArray = $this->modelConfig->toArray();
-        $mergedConfigArray = array_merge($modelConfigArray, $builderConfigArray);
-
-        $this->modelConfig = ModelConfig::fromArray($mergedConfigArray);
-
-        $model->setConfig($this->modelConfig);
-        $this->registry->bindModelDependencies($model);
-
-        return $model;
     }
 
     /**

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -1214,7 +1214,7 @@ class PromptBuilder
             $providerModelKey = $this->createProviderModelPreferenceKey($providerId, $modelId);
             $map[$providerModelKey] = [$providerId, $modelId];
 
-            // Add model-only key (when merging multiple maps, the + operator preserves first occurrence)
+            // Add model-only key
             $modelKey = $this->createModelPreferenceKey($modelId);
             $map[$modelKey] = [$providerId, $modelId];
         }

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -258,28 +258,32 @@ class PromptBuilder
                     'Model preference provider identifiers cannot be empty.'
                 );
 
-                $key = $this->createProviderModelPreferenceKey($providerId, $modelId);
-                $preferenceMap[$key] = [$modelId, $providerId];
+                $prefKey = $this->createProviderModelPreferenceKey($providerId, $modelId);
+                $preferenceMap[$prefKey] = [$modelId, $providerId];
+                continue;
+            }
 
-            } elseif ($preferredModel instanceof ModelInterface) {
+            if ($preferredModel instanceof ModelInterface) {
                 // Model instance
                 $modelId = $preferredModel->metadata()->getId();
                 $providerId = $preferredModel->providerMetadata()->getId();
                 $providerModelKey = $this->createProviderModelPreferenceKey($providerId, $modelId);
                 $preferenceMap[$providerModelKey] = [$modelId, $providerId];
+                continue;
+            }
 
-            } elseif (is_string($preferredModel)) {
+            if (is_string($preferredModel)) {
                 // Model ID
                 $modelId = $this->normalizePreferenceIdentifier($preferredModel);
                 $modelKey = $this->createModelPreferenceKey($modelId);
                 $preferenceMap[$modelKey] = $modelId;
-
-            } else {
-                // Invalid type
-                throw new InvalidArgumentException(
-                    'Model preferences must be model identifiers, instances of ModelInterface, or provider/model tuples.'
-                );
+                continue;
             }
+
+            // Invalid type
+            throw new InvalidArgumentException(
+                'Model preferences must be model identifiers, instances of ModelInterface, or provider/model tuples.'
+            );
         }
 
         $this->modelPreferenceMap = $preferenceMap;

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -1178,6 +1178,7 @@ class PromptBuilder
             foreach ($providerModelsMetadata as $providerModels) {
                 $providerId = $providerModels->getProvider()->getId();
                 $providerMap = $this->generateMapFromCandidates($providerId, $providerModels->getModels());
+
                 // Use + operator to merge, preserving keys from $candidateMap (first provider wins for model-only keys)
                 $candidateMap = $candidateMap + $providerMap;
             }
@@ -1191,7 +1192,10 @@ class PromptBuilder
             $requirements
         );
 
-        return $this->generateMapFromCandidates($this->providerIdOrClassName, $modelsMetadata);
+        // Ensure we pass the provider ID, not the class name
+        $providerId = $this->registry->getProviderId($this->providerIdOrClassName);
+
+        return $this->generateMapFromCandidates($providerId, $modelsMetadata);
     }
 
     /**

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -257,19 +257,18 @@ class PromptBuilder
                     'Model preference provider identifiers cannot be empty.'
                 );
 
-                $prefKey = $this->createProviderModelPreferenceKey($providerId, $modelId);
-                $preferenceKeys[] = $prefKey;
+                $preferenceKey = $this->createProviderModelPreferenceKey($providerId, $modelId);
             } elseif ($preferredModel instanceof ModelInterface) {
                 // Model instance
                 $modelId = $preferredModel->metadata()->getId();
                 $providerId = $preferredModel->providerMetadata()->getId();
-                $providerModelKey = $this->createProviderModelPreferenceKey($providerId, $modelId);
-                $preferenceKeys[] = $providerModelKey;
+
+                $preferenceKey = $this->createProviderModelPreferenceKey($providerId, $modelId);
             } elseif (is_string($preferredModel)) {
                 // Model ID
                 $modelId = $this->normalizePreferenceIdentifier($preferredModel);
-                $modelKey = $this->createModelPreferenceKey($modelId);
-                $preferenceKeys[] = $modelKey;
+
+                $preferenceKey = $this->createModelPreferenceKey($modelId);
             } else {
                 // Invalid type
                 throw new InvalidArgumentException(
@@ -277,6 +276,8 @@ class PromptBuilder
                     'or provider/model tuples.'
                 );
             }
+
+            $preferenceKeys[] = $preferenceKey;
         }
 
         $this->modelPreferenceKeys = $preferenceKeys;

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -13,8 +13,10 @@ use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\UserMessage;
 use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 use WordPress\AiClient\Messages\Enums\ModalityEnum;
+use WordPress\AiClient\Providers\DTO\ProviderModelsMetadata;
 use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 use WordPress\AiClient\Providers\Models\DTO\ModelRequirements;
 use WordPress\AiClient\Providers\Models\DTO\RequiredOption;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
@@ -62,7 +64,7 @@ class PromptBuilder
     /**
      * @var list<ModelInterface|string> Preferred models to evaluate in order.
      */
-    protected array $modelPreferences = [];
+    protected array $modelPreference = [];
 
     /**
      * @var string|null The provider ID or class name.
@@ -236,11 +238,11 @@ class PromptBuilder
             throw new InvalidArgumentException('At least one model preference must be provided.');
         }
 
-        $normalizedPreferences = [];
+        $normalizedModels = [];
 
         foreach ($preferredModels as $preferredModel) {
             if ($preferredModel instanceof ModelInterface) {
-                $normalizedPreferences[] = $preferredModel;
+                $normalizedModels[] = $preferredModel;
                 continue;
             }
 
@@ -249,7 +251,7 @@ class PromptBuilder
                 if ($trimmed === '') {
                     throw new InvalidArgumentException('Model preference identifiers cannot be empty.');
                 }
-                $normalizedPreferences[] = $trimmed;
+                $normalizedModels[] = $trimmed;
                 continue;
             }
 
@@ -258,7 +260,7 @@ class PromptBuilder
             );
         }
 
-        $this->modelPreferences = $normalizedPreferences;
+        $this->modelPreference = $normalizedModels;
 
         return $this;
     }
@@ -1073,40 +1075,6 @@ class PromptBuilder
     }
 
     /**
-     * Gets the first preferred model that can be instantiated.
-     *
-     * @since n.e.x.t
-     *
-     * @return ModelInterface|null The instantiated preferred model, or null if none found.
-     */
-    private function getAvailablePreferredModel(): ?ModelInterface
-    {
-        if ($this->modelPreferences === []) {
-            return null;
-        }
-
-        foreach ($this->modelPreferences as $preferredModel) {
-            if ($preferredModel instanceof ModelInterface) {
-                return $preferredModel;
-            }
-
-            $providerIds = $this->providerIdOrClassName !== null
-                ? [$this->providerIdOrClassName]
-                : $this->registry->getRegisteredProviderIds();
-
-            foreach ($providerIds as $providerId) {
-                try {
-                    return $this->registry->getProviderModel($providerId, $preferredModel);
-                } catch (InvalidArgumentException $exception) {
-                    continue;
-                }
-            }
-        }
-
-        return null;
-    }
-
-    /**
      * Gets the model to use for generation.
      *
      * If a model has been explicitly set, validates it meets requirements and returns it.
@@ -1122,17 +1090,18 @@ class PromptBuilder
     {
         $requirements = ModelRequirements::fromPromptData($capability, $this->messages, $this->modelConfig);
 
-        $explicitModel = $this->model ?? $this->getAvailablePreferredModel();
-
-        if ($explicitModel !== null) {
-            $explicitModel->setConfig($this->modelConfig);
-            $this->registry->bindModelDependencies($explicitModel);
-            $this->model = $explicitModel;
-            return $explicitModel;
+        if ($this->model !== null) {
+            // Explicit model was provided via usingModel(); just update config and bind dependencies.
+            $this->model->setConfig($this->modelConfig);
+            $this->registry->bindModelDependencies($this->model);
+            return $this->model;
         }
 
-        // Find a suitable model based on requirements
+        /** @var list<array{0:string,1:ModelMetadata}> $candidateModels */
+        $candidateModels = [];
+
         if ($this->providerIdOrClassName === null) {
+            // No provider locked in, gather all models across providers that meet requirements.
             $providerModelsMetadata = $this->registry->findModelsMetadataForSupport($requirements);
 
             if (empty($providerModelsMetadata)) {
@@ -1150,10 +1119,14 @@ class PromptBuilder
                 );
             }
 
-            $firstProviderModels = $providerModelsMetadata[0];
-            $provider = $firstProviderModels->getProvider()->getId();
-            $modelMetadata = $firstProviderModels->getModels()[0];
+            foreach ($providerModelsMetadata as $providerModels) {
+                $providerId = $providerModels->getProvider()->getId();
+                foreach ($providerModels->getModels() as $modelMetadata) {
+                    $candidateModels[] = [$providerId, $modelMetadata];
+                }
+            }
         } else {
+            // Provider forced, only consider models from that provider.
             $modelsMetadata = $this->registry->findProviderModelsMetadataForSupport(
                 $this->providerIdOrClassName,
                 $requirements
@@ -1175,16 +1148,77 @@ class PromptBuilder
                 );
             }
 
-            $provider = $this->providerIdOrClassName;
-            $modelMetadata = $modelsMetadata[0];
+            foreach ($modelsMetadata as $modelMetadata) {
+                $candidateModels[] = [$this->providerIdOrClassName, $modelMetadata];
+            }
         }
 
-        // Get the model instance from the provider
-        return $this->registry->getProviderModel(
-            $provider,
-            $modelMetadata->getId(),
-            $this->modelConfig
-        );
+        $selectedModel = null;
+
+        foreach ($this->modelPreference as $preferredModel) {
+            if ($preferredModel instanceof ModelInterface) {
+                // Check if the explicitly provided preferred model is among the supported candidates.
+                $preferredProviderId = $preferredModel->providerMetadata()->getId();
+                $preferredModelId = $preferredModel->metadata()->getId();
+
+                foreach ($candidateModels as [$providerId, $modelMetadata]) {
+                    if ($providerId === $preferredProviderId && $modelMetadata->getId() === $preferredModelId) {
+                        $selectedModel = $this->prepareExplicitModel($preferredModel);
+                        break 2;
+                    }
+                }
+
+                continue;
+            }
+
+            // Otherwise treat the preference as a model identifier and match it against candidates.
+            foreach ($candidateModels as [$providerId, $modelMetadata]) {
+                if ($modelMetadata->getId() !== $preferredModel) {
+                    continue;
+                }
+
+                $selectedModel = $this->registry->getProviderModel(
+                    $providerId,
+                    $modelMetadata->getId(),
+                    $this->modelConfig
+                );
+                break 2;
+            }
+        }
+
+        if ($selectedModel === null) {
+            // No preference matched; fall back to the first candidate discovered.
+            [$providerId, $modelMetadata] = $candidateModels[0];
+            $selectedModel = $this->registry->getProviderModel(
+                $providerId,
+                $modelMetadata->getId(),
+                $this->modelConfig
+            );
+        }
+
+        return $selectedModel;
+    }
+
+    /**
+     * Prepares an explicitly provided model for usage by merging configuration and binding dependencies.
+     *
+     * @since n.e.x.t
+     *
+     * @param ModelInterface $model The model to prepare.
+     * @return ModelInterface The prepared model instance.
+     */
+    private function prepareExplicitModel(ModelInterface $model): ModelInterface
+    {
+        $modelConfigArray = $model->getConfig()->toArray();
+        $builderConfigArray = $this->modelConfig->toArray();
+        $mergedConfigArray = array_merge($modelConfigArray, $builderConfigArray);
+
+        $this->modelConfig = ModelConfig::fromArray($mergedConfigArray);
+
+        $model->setConfig($this->modelConfig);
+        $this->registry->bindModelDependencies($model);
+
+        return $model;
     }
 
     /**

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -61,10 +61,9 @@ class PromptBuilder
     protected ?ModelInterface $model = null;
 
     /**
-     * @var array<string, string|array{0:string,1:string}> Preferred model map keyed by preference key with
-     * provider-model mappings.
+     * @var list<string> Ordered list of preference keys to check when selecting a model.
      */
-    protected array $modelPreferenceMap = [];
+    protected array $modelPreferenceKeys = [];
 
     /**
      * @var string|null The provider ID or class name.
@@ -239,7 +238,7 @@ class PromptBuilder
             throw new InvalidArgumentException('At least one model preference must be provided.');
         }
 
-        $preferenceMap = [];
+        $preferenceKeys = [];
 
         foreach ($preferredModels as $preferredModel) {
             if (is_array($preferredModel)) {
@@ -259,34 +258,28 @@ class PromptBuilder
                 );
 
                 $prefKey = $this->createProviderModelPreferenceKey($providerId, $modelId);
-                $preferenceMap[$prefKey] = [$modelId, $providerId];
-                continue;
-            }
-
-            if ($preferredModel instanceof ModelInterface) {
+                $preferenceKeys[] = $prefKey;
+            } elseif ($preferredModel instanceof ModelInterface) {
                 // Model instance
                 $modelId = $preferredModel->metadata()->getId();
                 $providerId = $preferredModel->providerMetadata()->getId();
                 $providerModelKey = $this->createProviderModelPreferenceKey($providerId, $modelId);
-                $preferenceMap[$providerModelKey] = [$modelId, $providerId];
-                continue;
-            }
-
-            if (is_string($preferredModel)) {
+                $preferenceKeys[] = $providerModelKey;
+            } elseif (is_string($preferredModel)) {
                 // Model ID
                 $modelId = $this->normalizePreferenceIdentifier($preferredModel);
                 $modelKey = $this->createModelPreferenceKey($modelId);
-                $preferenceMap[$modelKey] = $modelId;
-                continue;
+                $preferenceKeys[] = $modelKey;
+            } else {
+                // Invalid type
+                throw new InvalidArgumentException(
+                    'Model preferences must be model identifiers, instances of ModelInterface, ' .
+                    'or provider/model tuples.'
+                );
             }
-
-            // Invalid type
-            throw new InvalidArgumentException(
-                'Model preferences must be model identifiers, instances of ModelInterface, or provider/model tuples.'
-            );
         }
 
-        $this->modelPreferenceMap = $preferenceMap;
+        $this->modelPreferenceKeys = $preferenceKeys;
 
         return $this;
     }
@@ -1123,18 +1116,51 @@ class PromptBuilder
             return $this->model;
         }
 
-        // Retrieve the models which satisfy the requirements.
-        $candidateModels = $this->getCandidateModels($requirements);
+        // Retrieve the candidate models map which satisfies the requirements.
+        $candidateMap = $this->getCandidateModelsMap($requirements);
 
-        // Find the model which matches the preference, if any.
-        $selectedModel = $this->findModelByPreference($candidateModels);
+        if (empty($candidateMap)) {
+            $message = sprintf(
+                'No models found that support %s for this prompt.',
+                $capability->value
+            );
+
+            if ($this->providerIdOrClassName !== null) {
+                $message = sprintf(
+                    'No models found for provider "%s" that support %s for this prompt.',
+                    $this->providerIdOrClassName,
+                    $capability->value
+                );
+            }
+
+            throw new InvalidArgumentException($message);
+        }
+
+        // Check if any preferred models match the candidates, in priority order.
+        $selectedModel = null;
+        if (!empty($this->modelPreferenceKeys)) {
+            // Find preferences that match available candidates, preserving preference order.
+            $matchingPreferences = array_intersect_key(
+                array_flip($this->modelPreferenceKeys),
+                $candidateMap
+            );
+
+            if (!empty($matchingPreferences)) {
+                // Get the first matching preference key
+                $firstMatchKey = key($matchingPreferences);
+                [$providerId, $modelId] = $candidateMap[$firstMatchKey];
+
+                $selectedModel = $this->registry->getProviderModel($providerId, $modelId, $this->modelConfig);
+            }
+        }
 
         if ($selectedModel === null) {
             // No preference matched; fall back to the first candidate discovered.
-            [$providerId, $modelMetadata] = $candidateModels[0];
+            [$providerId, $modelId] = reset($candidateMap);
+
             $selectedModel = $this->registry->getProviderModel(
                 $providerId,
-                $modelMetadata->getId(),
+                $modelId,
                 $this->modelConfig
             );
         }
@@ -1143,45 +1169,28 @@ class PromptBuilder
     }
 
     /**
-     * Builds the list of candidate provider/model combinations that satisfy the requirements.
+     * Builds a map of candidate models that satisfy the requirements for efficient lookup.
      *
      * @since n.e.x.t
      *
      * @param ModelRequirements $requirements The requirements derived from the prompt.
-     * @return list<array{0:string,1:ModelMetadata}> The candidate provider/model tuples.
-     *
-     * @throws InvalidArgumentException If no suitable models are found.
+     * @return array<string, array{0:string,1:string}> Map of preference keys to [providerId, modelId] tuples.
      */
-    private function getCandidateModels(ModelRequirements $requirements): array
+    private function getCandidateModelsMap(ModelRequirements $requirements): array
     {
         if ($this->providerIdOrClassName === null) {
             // No provider locked in, gather all models across providers that meet requirements.
             $providerModelsMetadata = $this->registry->findModelsMetadataForSupport($requirements);
 
-            if (empty($providerModelsMetadata)) {
-                throw new InvalidArgumentException(
-                    sprintf(
-                        'No models found that support the required capabilities and options for this prompt. ' .
-                        'Required capabilities: %s. Required options: %s',
-                        implode(', ', array_map(function ($cap) {
-                            return $cap->value;
-                        }, $requirements->getRequiredCapabilities())),
-                        implode(', ', array_map(function ($opt) {
-                            return $opt->getName()->value . '=' . json_encode($opt->getValue());
-                        }, $requirements->getRequiredOptions()))
-                    )
-                );
-            }
-
-            $candidateModels = [];
+            $candidateMap = [];
             foreach ($providerModelsMetadata as $providerModels) {
                 $providerId = $providerModels->getProvider()->getId();
-                foreach ($providerModels->getModels() as $modelMetadata) {
-                    $candidateModels[] = [$providerId, $modelMetadata];
-                }
+                $providerMap = $this->generateMapFromCandidates($providerId, $providerModels->getModels());
+                // Use + operator to merge, preserving keys from $candidateMap (first provider wins for model-only keys)
+                $candidateMap = $candidateMap + $providerMap;
             }
 
-            return $candidateModels;
+            return $candidateMap;
         }
 
         // Provider set, only consider models from that provider.
@@ -1190,59 +1199,35 @@ class PromptBuilder
             $requirements
         );
 
-        if (empty($modelsMetadata)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'No models found for %s that support the required capabilities and options for this prompt. ' .
-                    'Required capabilities: %s. Required options: %s',
-                    $this->providerIdOrClassName,
-                    implode(', ', array_map(function ($cap) {
-                        return $cap->value;
-                    }, $requirements->getRequiredCapabilities())),
-                    implode(', ', array_map(function ($opt) {
-                        return $opt->getName()->value . '=' . json_encode($opt->getValue());
-                    }, $requirements->getRequiredOptions()))
-                )
-            );
-        }
-
-        $candidateModels = [];
-        foreach ($modelsMetadata as $modelMetadata) {
-            $candidateModels[] = [$this->providerIdOrClassName, $modelMetadata];
-        }
-
-        return $candidateModels;
+        return $this->generateMapFromCandidates($this->providerIdOrClassName, $modelsMetadata);
     }
 
     /**
-     * Finds a preferred model among the given candidates.
+     * Generates a candidate map from model metadata with both provider-specific and model-only keys.
      *
      * @since n.e.x.t
      *
-     * @param list<array{0:string,1:ModelMetadata}> $candidateModels Candidate provider/model tuples.
-     * @return ModelInterface|null The model matching the highest-priority preference, or null if none.
+     * @param string $providerId The provider ID.
+     * @param list<ModelMetadata> $modelsMetadata The models metadata to map.
+     * @return array<string, array{0:string,1:string}> Map of preference keys to [providerId, modelId] tuples.
      */
-    private function findModelByPreference(array $candidateModels): ?ModelInterface
+    private function generateMapFromCandidates(string $providerId, array $modelsMetadata): array
     {
-        if ($this->modelPreferenceMap === []) {
-            return null;
-        }
+        $map = [];
 
-        foreach ($candidateModels as [$providerId, $modelMetadata]) {
+        foreach ($modelsMetadata as $modelMetadata) {
             $modelId = $modelMetadata->getId();
 
+            // Add provider-specific key
             $providerModelKey = $this->createProviderModelPreferenceKey($providerId, $modelId);
-            if (isset($this->modelPreferenceMap[$providerModelKey])) {
-                return $this->registry->getProviderModel($providerId, $modelId, $this->modelConfig);
-            }
+            $map[$providerModelKey] = [$providerId, $modelId];
 
+            // Add model-only key (when merging multiple maps, the + operator preserves first occurrence)
             $modelKey = $this->createModelPreferenceKey($modelId);
-            if (isset($this->modelPreferenceMap[$modelKey])) {
-                return $this->registry->getProviderModel($providerId, $modelId, $this->modelConfig);
-            }
+            $map[$modelKey] = [$providerId, $modelId];
         }
 
-        return null;
+        return $map;
     }
 
     /**

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -60,6 +60,11 @@ class PromptBuilder
     protected ?ModelInterface $model = null;
 
     /**
+     * @var list<ModelInterface|string> Preferred models to evaluate in order.
+     */
+    protected array $modelPreferences = [];
+
+    /**
      * @var string|null The provider ID or class name.
      */
     protected ?string $providerIdOrClassName = null;
@@ -211,6 +216,49 @@ class PromptBuilder
         $mergedConfigArray = array_merge($modelConfigArray, $builderConfigArray);
 
         $this->modelConfig = ModelConfig::fromArray($mergedConfigArray);
+
+        return $this;
+    }
+
+    /**
+     * Sets preferred models to evaluate in order.
+     *
+     * @since n.e.x.t
+     *
+     * @param mixed ...$preferredModels The preferred models as model IDs or instances.
+     * @return self
+     *
+     * @throws InvalidArgumentException When a preferred model has an invalid type or identifier.
+     */
+    public function usingModelPreference(...$preferredModels): self
+    {
+        if ($preferredModels === []) {
+            throw new InvalidArgumentException('At least one model preference must be provided.');
+        }
+
+        $normalizedPreferences = [];
+
+        foreach ($preferredModels as $preferredModel) {
+            if ($preferredModel instanceof ModelInterface) {
+                $normalizedPreferences[] = $preferredModel;
+                continue;
+            }
+
+            if (is_string($preferredModel)) {
+                $trimmed = trim($preferredModel);
+                if ($trimmed === '') {
+                    throw new InvalidArgumentException('Model preference identifiers cannot be empty.');
+                }
+                $normalizedPreferences[] = $trimmed;
+                continue;
+            }
+
+            throw new InvalidArgumentException(
+                'Model preferences must be model identifiers or instances of ModelInterface.'
+            );
+        }
+
+        $this->modelPreferences = $normalizedPreferences;
 
         return $this;
     }
@@ -1025,6 +1073,40 @@ class PromptBuilder
     }
 
     /**
+     * Gets the first preferred model that can be instantiated.
+     *
+     * @since n.e.x.t
+     *
+     * @return ModelInterface|null The instantiated preferred model, or null if none found.
+     */
+    private function getAvailablePreferredModel(): ?ModelInterface
+    {
+        if ($this->modelPreferences === []) {
+            return null;
+        }
+
+        foreach ($this->modelPreferences as $preferredModel) {
+            if ($preferredModel instanceof ModelInterface) {
+                return $preferredModel;
+            }
+
+            $providerIds = $this->providerIdOrClassName !== null
+                ? [$this->providerIdOrClassName]
+                : $this->registry->getRegisteredProviderIds();
+
+            foreach ($providerIds as $providerId) {
+                try {
+                    return $this->registry->getProviderModel($providerId, $preferredModel);
+                } catch (InvalidArgumentException $exception) {
+                    continue;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Gets the model to use for generation.
      *
      * If a model has been explicitly set, validates it meets requirements and returns it.
@@ -1040,11 +1122,13 @@ class PromptBuilder
     {
         $requirements = ModelRequirements::fromPromptData($capability, $this->messages, $this->modelConfig);
 
-        // If a model has been explicitly set, return it
-        if ($this->model !== null) {
-            $this->model->setConfig($this->modelConfig);
-            $this->registry->bindModelDependencies($this->model);
-            return $this->model;
+        $explicitModel = $this->model ?? $this->getAvailablePreferredModel();
+
+        if ($explicitModel !== null) {
+            $explicitModel->setConfig($this->modelConfig);
+            $this->registry->bindModelDependencies($explicitModel);
+            $this->model = $explicitModel;
+            return $explicitModel;
         }
 
         // Find a suitable model based on requirements

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -1138,7 +1138,6 @@ class PromptBuilder
         }
 
         // Check if any preferred models match the candidates, in priority order.
-        $selectedModel = null;
         if (!empty($this->modelPreferenceKeys)) {
             // Find preferences that match available candidates, preserving preference order.
             $matchingPreferences = array_intersect_key(
@@ -1151,22 +1150,14 @@ class PromptBuilder
                 $firstMatchKey = key($matchingPreferences);
                 [$providerId, $modelId] = $candidateMap[$firstMatchKey];
 
-                $selectedModel = $this->registry->getProviderModel($providerId, $modelId, $this->modelConfig);
+                return $this->registry->getProviderModel($providerId, $modelId, $this->modelConfig);
             }
         }
 
-        if ($selectedModel === null) {
-            // No preference matched; fall back to the first candidate discovered.
-            [$providerId, $modelId] = reset($candidateMap);
+        // No preference matched; fall back to the first candidate discovered.
+        [$providerId, $modelId] = reset($candidateMap);
 
-            $selectedModel = $this->registry->getProviderModel(
-                $providerId,
-                $modelId,
-                $this->modelConfig
-            );
-        }
-
-        return $selectedModel;
+        return $this->registry->getProviderModel($providerId, $modelId, $this->modelConfig);
     }
 
     /**

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -61,9 +61,10 @@ class PromptBuilder
     protected ?ModelInterface $model = null;
 
     /**
-     * @var list<ModelInterface|string|array{0:string,1:string}> Preferred models to evaluate in order.
+     * @var array<string, string|array{0:string,1:string}> Preferred model map keyed by preference key with
+     * provider-model mappings.
      */
-    protected array $modelPreference = [];
+    protected array $modelPreferenceMap = [];
 
     /**
      * @var string|null The provider ID or class name.
@@ -227,7 +228,7 @@ class PromptBuilder
      * @since n.e.x.t
      *
      * @param string|ModelInterface|array{0:string,1:string} ...$preferredModels The preferred models as model IDs,
-     * model instances, or [provider ID, model ID] tuples.
+     * model instances, or [model ID, provider ID] tuples.
      * @return self
      *
      * @throws InvalidArgumentException When a preferred model has an invalid type or identifier.
@@ -238,68 +239,58 @@ class PromptBuilder
             throw new InvalidArgumentException('At least one model preference must be provided.');
         }
 
-        $normalizedModels = [];
+        $preferenceMap = [];
 
         foreach ($preferredModels as $preferredModel) {
             if (is_array($preferredModel)) {
+                // [model identifier, provider ID] tuple
                 if (!array_is_list($preferredModel) || count($preferredModel) !== 2) {
                     throw new InvalidArgumentException(
-                        'Model preference tuple must contain provider ID and model identifier.'
+                        'Model preference tuple must contain model identifier and provider ID.'
                     );
                 }
 
-                [$providerId, $modelIdentifier] = $preferredModel;
+                [$modelIdentifier, $providerId] = $preferredModel;
 
-                if (!is_string($providerId)) {
-                    throw new InvalidArgumentException('Model preference provider identifiers cannot be empty.');
-                }
-                $providerId = trim($providerId);
-                if ($providerId === '') {
-                    throw new InvalidArgumentException('Model preference provider identifiers cannot be empty.');
-                }
+                $modelId = $this->normalizePreferenceIdentifier($modelIdentifier);
+                $providerId = $this->normalizePreferenceIdentifier(
+                    $providerId,
+                    'Model preference provider identifiers cannot be empty.'
+                );
 
-                if (!is_string($modelIdentifier)) {
-                    throw new InvalidArgumentException(
-                        'Model preference tuple must contain provider ID and model identifier.'
-                    );
-                }
-                $modelIdentifier = trim($modelIdentifier);
-                if ($modelIdentifier === '') {
-                    throw new InvalidArgumentException('Model preference identifiers cannot be empty.');
-                }
+                $key = $this->createProviderModelPreferenceKey($providerId, $modelId);
+                $preferenceMap[$key] = [$modelId, $providerId];
 
-                $normalizedModels[] = [$providerId, $modelIdentifier];
-                continue;
+            } elseif ($preferredModel instanceof ModelInterface) {
+                // Model instance
+                $modelId = $preferredModel->metadata()->getId();
+                $providerId = $preferredModel->providerMetadata()->getId();
+                $providerModelKey = $this->createProviderModelPreferenceKey($providerId, $modelId);
+                $preferenceMap[$providerModelKey] = [$modelId, $providerId];
+
+            } elseif (is_string($preferredModel)) {
+                // Model ID
+                $modelId = $this->normalizePreferenceIdentifier($preferredModel);
+                $modelKey = $this->createModelPreferenceKey($modelId);
+                $preferenceMap[$modelKey] = $modelId;
+
+            } else {
+                // Invalid type
+                throw new InvalidArgumentException(
+                    'Model preferences must be model identifiers, instances of ModelInterface, or provider/model tuples.'
+                );
             }
-
-            if ($preferredModel instanceof ModelInterface) {
-                $normalizedModels[] = $preferredModel;
-                continue;
-            }
-
-            if (is_string($preferredModel)) {
-                $trimmed = trim($preferredModel);
-                if ($trimmed === '') {
-                    throw new InvalidArgumentException('Model preference identifiers cannot be empty.');
-                }
-                $normalizedModels[] = $trimmed;
-                continue;
-            }
-
-            throw new InvalidArgumentException(
-                'Model preferences must be model identifiers, instances of ModelInterface, or provider/model tuples.'
-            );
         }
 
-        $this->modelPreference = $normalizedModels;
+        $this->modelPreferenceMap = $preferenceMap;
 
         return $this;
     }
 
     /**
-     * Sets the model configuration.
-     *
-     * Merges the provided configuration with the builder's configuration,
+         * Sets the model configuration.
+         *
+         * Merges the provided configuration with the builder's configuration,
      * with builder configuration taking precedence.
      *
      * @since 0.1.0
@@ -1229,52 +1220,79 @@ class PromptBuilder
      */
     private function findModelByPreference(array $candidateModels): ?ModelInterface
     {
+        if ($this->modelPreferenceMap === []) {
+            return null;
+        }
+
         foreach ($candidateModels as [$providerId, $modelMetadata]) {
-            foreach ($this->modelPreference as $preferenceIndex => $preferredModel) {
-                if (is_array($preferredModel)) {
-                    [$preferredProviderId, $preferredModelId] = $preferredModel;
-                    if (
-                        $providerId !== $preferredProviderId ||
-                        $modelMetadata->getId() !== $preferredModelId
-                    ) {
-                        continue;
-                    }
+            $modelId = $modelMetadata->getId();
 
-                    return $this->registry->getProviderModel(
-                        $providerId,
-                        $modelMetadata->getId(),
-                        $this->modelConfig
-                    );
-                } elseif ($preferredModel instanceof ModelInterface) {
-                    $preferredProviderId = $preferredModel->providerMetadata()->getId();
-                    $preferredModelId = $preferredModel->metadata()->getId();
+            $providerModelKey = $this->createProviderModelPreferenceKey($providerId, $modelId);
+            if (isset($this->modelPreferenceMap[$providerModelKey])) {
+                return $this->registry->getProviderModel($providerId, $modelId, $this->modelConfig);
+            }
 
-                    if (
-                        $providerId !== $preferredProviderId ||
-                        $modelMetadata->getId() !== $preferredModelId
-                    ) {
-                        continue;
-                    }
-
-                    $preferredModel->setConfig($this->modelConfig);
-                    $this->registry->bindModelDependencies($preferredModel);
-
-                    return $preferredModel;
-                } else {
-                    if ($modelMetadata->getId() !== $preferredModel) {
-                        continue;
-                    }
-
-                    return $this->registry->getProviderModel(
-                        $providerId,
-                        $modelMetadata->getId(),
-                        $this->modelConfig
-                    );
-                }
+            $modelKey = $this->createModelPreferenceKey($modelId);
+            if (isset($this->modelPreferenceMap[$modelKey])) {
+                return $this->registry->getProviderModel($providerId, $modelId, $this->modelConfig);
             }
         }
 
         return null;
+    }
+
+    /**
+     * Normalizes and validates a preference identifier string.
+     *
+     * @since n.e.x.t
+     *
+     * @param mixed $value The value to normalize.
+     * @param string $emptyMessage The message for empty or invalid values.
+     * @return string The normalized identifier.
+     *
+     * @throws InvalidArgumentException If the value is not a non-empty string.
+     */
+    private function normalizePreferenceIdentifier(
+        $value,
+        string $emptyMessage = 'Model preference identifiers cannot be empty.'
+    ): string {
+        if (!is_string($value)) {
+            throw new InvalidArgumentException($emptyMessage);
+        }
+
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            throw new InvalidArgumentException($emptyMessage);
+        }
+
+        return $trimmed;
+    }
+
+    /**
+     * Creates a preference key for a provider/model combination.
+     *
+     * @since n.e.x.t
+     *
+     * @param string $providerId The provider identifier.
+     * @param string $modelId The model identifier.
+     * @return string The generated preference key.
+     */
+    private function createProviderModelPreferenceKey(string $providerId, string $modelId): string
+    {
+        return 'providerModel::' . $providerId . '::' . $modelId;
+    }
+
+    /**
+     * Creates a preference key for a model identifier.
+     *
+     * @since n.e.x.t
+     *
+     * @param string $modelId The model identifier.
+     * @return string The generated preference key.
+     */
+    private function createModelPreferenceKey(string $modelId): string
+    {
+        return 'model::' . $modelId;
     }
 
     /**

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -13,7 +13,6 @@ use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\UserMessage;
 use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 use WordPress\AiClient\Messages\Enums\ModalityEnum;
-use WordPress\AiClient\Providers\DTO\ProviderModelsMetadata;
 use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;

--- a/src/Providers/ProviderRegistry.php
+++ b/src/Providers/ProviderRegistry.php
@@ -160,6 +160,37 @@ class ProviderRegistry implements WithHttpTransporterInterface
     }
 
     /**
+     * Gets the provider ID for a registered provider.
+     *
+     * @since n.e.x.t
+     *
+     * @param string|class-string<ProviderInterface> $idOrClassName The provider ID or class name.
+     * @return string The provider ID.
+     * @throws InvalidArgumentException If the provider is not registered.
+     */
+    public function getProviderId(string $idOrClassName): string
+    {
+        // If it's already an ID, return it
+        if (isset($this->providerClassNames[$idOrClassName])) {
+            return $idOrClassName;
+        }
+
+        // If it's a class name, find its ID
+        if (isset($this->registeredClassNames[$idOrClassName])) {
+            foreach ($this->providerClassNames as $id => $className) {
+                if ($className === $idOrClassName) {
+                    return $id;
+                }
+            }
+        }
+
+        // Not found
+        throw new InvalidArgumentException(
+            sprintf('Provider not registered: %s', $idOrClassName)
+        );
+    }
+
+    /**
      * Checks if a provider is properly configured.
      *
      * @since 0.1.0

--- a/tests/unit/AiClientTest.php
+++ b/tests/unit/AiClientTest.php
@@ -395,7 +395,7 @@ class AiClientTest extends TestCase
 
         // This should delegate to PromptBuilder's intelligent discovery
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('No models found that support the required capabilities');
+        $this->expectExceptionMessage('No models found that support text_generation for this prompt.');
 
         AiClient::generateResult($prompt, null, $this->createMockEmptyRegistry());
     }
@@ -441,7 +441,7 @@ class AiClientTest extends TestCase
         $config->setMaxTokens(100);
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('No models found that support the required capabilities');
+        $this->expectExceptionMessage('No models found that support text_generation for this prompt.');
 
         AiClient::generateResult($prompt, $config, $this->createMockEmptyRegistry());
     }
@@ -613,7 +613,7 @@ class AiClientTest extends TestCase
                 $this->fail("Expected InvalidArgumentException for configuration $index");
             } catch (\InvalidArgumentException $e) {
                 $this->assertStringContainsString(
-                    'No models found that support the required capabilities',
+                    'No models found that support text_generation for this prompt.',
                     $e->getMessage(),
                     "Configuration $index should delegate to PromptBuilder properly"
                 );
@@ -630,7 +630,7 @@ class AiClientTest extends TestCase
         $emptyConfig = new ModelConfig();
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('No models found that support the required capabilities');
+        $this->expectExceptionMessage('No models found that support text_generation for this prompt.');
 
         AiClient::generateResult($prompt, $emptyConfig, $this->createMockEmptyRegistry());
     }

--- a/tests/unit/Builders/PromptBuilderTest.php
+++ b/tests/unit/Builders/PromptBuilderTest.php
@@ -646,6 +646,72 @@ class PromptBuilderTest extends TestCase
     }
 
     /**
+     * Tests usingModelPreference supports provider/model tuple with string identifier.
+     *
+     * @return void
+     */
+    public function testUsingModelPreferenceWithProviderTupleSelectsModel(): void
+    {
+        $result = $this->createTestResult('Tuple preferred result');
+        $preferredMetadata = $this->createTextModelMetadataWithInputSupport('preferred-model');
+        $otherMetadata = $this->createTextModelMetadataWithInputSupport('other-model');
+        $model = $this->createMockTextGenerationModel($result, $preferredMetadata);
+
+        $preferredProviderMetadata = new ProviderMetadata(
+            'preferred-provider',
+            'Preferred Provider',
+            ProviderTypeEnum::cloud()
+        );
+
+        $otherProviderMetadata = new ProviderMetadata(
+            'other-provider',
+            'Other Provider',
+            ProviderTypeEnum::cloud()
+        );
+
+        $this->registry->expects($this->once())
+            ->method('findModelsMetadataForSupport')
+            ->with($this->isInstanceOf(ModelRequirements::class))
+            ->willReturn([
+                new ProviderModelsMetadata($preferredProviderMetadata, [$preferredMetadata]),
+                new ProviderModelsMetadata($otherProviderMetadata, [$otherMetadata]),
+            ]);
+
+        $this->registry->expects($this->once())
+            ->method('getProviderModel')
+            ->with('preferred-provider', 'preferred-model', $this->isInstanceOf(ModelConfig::class))
+            ->willReturn($model);
+
+        $this->registry->expects($this->never())
+            ->method('findProviderModelsMetadataForSupport');
+
+        $builder = new PromptBuilder($this->registry, 'Test prompt');
+        $builder->usingModelPreference(['preferred-provider', 'preferred-model']);
+
+        $actualResult = $builder->generateTextResult();
+
+        $this->assertSame($result, $actualResult);
+    }
+
+    /**
+     * Tests usingModelPreference rejects provider/model tuples that contain a model instance.
+     *
+     * @return void
+     */
+    public function testUsingModelPreferenceWithProviderTupleModelInstanceThrowsException(): void
+    {
+        $metadata = $this->createTextModelMetadataWithInputSupport('preferred-model');
+        $model = $this->createMockTextGenerationModel($this->createTestResult(), $metadata);
+
+        $builder = new PromptBuilder($this->registry, 'Test prompt');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Model preference tuple must contain provider ID and model identifier.');
+
+        $builder->usingModelPreference(['mock', $model]);
+    }
+
+    /**
      * Tests usingModelPreference selects the first available model ID for the configured provider.
      *
      * @return void
@@ -738,8 +804,9 @@ class PromptBuilderTest extends TestCase
         $this->registry->expects($this->never())
             ->method('findProviderModelsMetadataForSupport');
 
-        $this->registry->expects($this->never())
-            ->method('bindModelDependencies');
+        $this->registry->expects($this->once())
+            ->method('bindModelDependencies')
+            ->with($model);
 
         $builder = new PromptBuilder($this->registry, 'Test prompt');
         $builder->usingModelPreference('unavailable-model');
@@ -759,9 +826,24 @@ class PromptBuilderTest extends TestCase
         $builder = new PromptBuilder($this->registry);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Model preferences must be model identifiers or instances of ModelInterface.');
+        $this->expectExceptionMessage('Model preferences must be model identifiers, instances of ModelInterface, or provider/model tuples.');
 
         $builder->usingModelPreference(123);
+    }
+
+    /**
+     * Tests usingModelPreference rejects malformed preference tuples.
+     *
+     * @return void
+     */
+    public function testUsingModelPreferenceWithInvalidTupleThrowsException(): void
+    {
+        $builder = new PromptBuilder($this->registry);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Model preference tuple must contain provider ID and model identifier.');
+
+        $builder->usingModelPreference(['provider' => 'test', 'model' => 'id']);
     }
 
     /**

--- a/tests/unit/Builders/PromptBuilderTest.php
+++ b/tests/unit/Builders/PromptBuilderTest.php
@@ -814,6 +814,51 @@ class PromptBuilderTest extends TestCase
     }
 
     /**
+     * Tests usingModelPreference respects priority order when multiple preferred models are available.
+     *
+     * @return void
+     */
+    public function testUsingModelPreferenceRespectsOrderWhenMultipleAvailable(): void
+    {
+        $result = $this->createTestResult('Second choice result');
+        $secondChoiceMetadata = $this->createTextModelMetadataWithInputSupport('second-choice');
+        $thirdChoiceMetadata = $this->createTextModelMetadataWithInputSupport('third-choice');
+        $providerMetadata = $this->createTestProviderMetadata();
+
+        $model = $this->createMockTextGenerationModel($result, $secondChoiceMetadata);
+
+        // Make both second-choice and third-choice available (but not first-choice)
+        $providerModelsMetadata = new ProviderModelsMetadata(
+            $providerMetadata,
+            [$thirdChoiceMetadata, $secondChoiceMetadata]  // Order shouldn't matter
+        );
+
+        $this->registry->expects($this->once())
+            ->method('findModelsMetadataForSupport')
+            ->with($this->isInstanceOf(ModelRequirements::class))
+            ->willReturn([$providerModelsMetadata]);
+
+        // Should select 'second-choice' (respecting preference order), not 'third-choice'
+        $this->registry->expects($this->once())
+            ->method('getProviderModel')
+            ->with($providerMetadata->getId(), 'second-choice', $this->isInstanceOf(ModelConfig::class))
+            ->willReturn($model);
+
+        $this->registry->expects($this->never())
+            ->method('findProviderModelsMetadataForSupport');
+
+        $builder = new PromptBuilder($this->registry, 'Test prompt');
+        // Preferences in order: first-choice, second-choice, third-choice
+        // Available: second-choice, third-choice
+        // Expected: second-choice (respects priority)
+        $builder->usingModelPreference('first-choice', 'second-choice', 'third-choice');
+
+        $actualResult = $builder->generateTextResult();
+
+        $this->assertSame($result, $actualResult);
+    }
+
+    /**
      * Tests usingModelPreference rejects invalid preference types.
      *
      * @return void
@@ -3003,7 +3048,9 @@ class PromptBuilderTest extends TestCase
         $builder->usingProvider('test-provider');
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('No models found for test-provider that support the required capabilities');
+        $this->expectExceptionMessage(
+            'No models found for provider "test-provider" that support text_generation for this prompt.'
+        );
 
         $builder->generateResult();
     }

--- a/tests/unit/Builders/PromptBuilderTest.php
+++ b/tests/unit/Builders/PromptBuilderTest.php
@@ -620,13 +620,14 @@ class PromptBuilderTest extends TestCase
         $providerMetadata = $model->providerMetadata();
 
         $this->registry->expects($this->once())
-            ->method('bindModelDependencies')
-            ->with($model);
-
-        $this->registry->expects($this->once())
             ->method('findModelsMetadataForSupport')
             ->with($this->isInstanceOf(ModelRequirements::class))
             ->willReturn([new ProviderModelsMetadata($providerMetadata, [$metadata])]);
+
+        $this->registry->expects($this->once())
+            ->method('getProviderModel')
+            ->with($providerMetadata->getId(), 'preferred-model', $this->isInstanceOf(ModelConfig::class))
+            ->willReturn($model);
 
         $this->registry->expects($this->never())
             ->method('findProviderModelsMetadataForSupport');
@@ -686,7 +687,7 @@ class PromptBuilderTest extends TestCase
             ->method('findProviderModelsMetadataForSupport');
 
         $builder = new PromptBuilder($this->registry, 'Test prompt');
-        $builder->usingModelPreference(['preferred-provider', 'preferred-model']);
+        $builder->usingModelPreference(['preferred-model', 'preferred-provider']);
 
         $actualResult = $builder->generateTextResult();
 
@@ -706,7 +707,7 @@ class PromptBuilderTest extends TestCase
         $builder = new PromptBuilder($this->registry, 'Test prompt');
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Model preference tuple must contain provider ID and model identifier.');
+        $this->expectExceptionMessage('Model preference provider identifiers cannot be empty.');
 
         $builder->usingModelPreference(['mock', $model]);
     }
@@ -839,7 +840,7 @@ class PromptBuilderTest extends TestCase
         $builder = new PromptBuilder($this->registry);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Model preference tuple must contain provider ID and model identifier.');
+        $this->expectExceptionMessage('Model preference tuple must contain model identifier and provider ID.');
 
         $builder->usingModelPreference(['provider' => 'test', 'model' => 'id']);
     }

--- a/tests/unit/Builders/PromptBuilderTest.php
+++ b/tests/unit/Builders/PromptBuilderTest.php
@@ -9,7 +9,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use WordPress\AiClient\Builders\PromptBuilder;
-use WordPress\AiClient\Common\Exception\InvalidArgumentException as AiInvalidArgumentException;
 use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Files\Enums\FileTypeEnum;
 use WordPress\AiClient\Messages\DTO\Message;
@@ -618,13 +617,16 @@ class PromptBuilderTest extends TestCase
         $result = $this->createTestResult('Preferred model result');
         $metadata = $this->createTextModelMetadataWithInputSupport('preferred-model');
         $model = $this->createMockTextGenerationModel($result, $metadata);
+        $providerMetadata = $model->providerMetadata();
 
         $this->registry->expects($this->once())
             ->method('bindModelDependencies')
             ->with($model);
 
-        $this->registry->expects($this->never())
-            ->method('findModelsMetadataForSupport');
+        $this->registry->expects($this->once())
+            ->method('findModelsMetadataForSupport')
+            ->with($this->isInstanceOf(ModelRequirements::class))
+            ->willReturn([new ProviderModelsMetadata($providerMetadata, [$metadata])]);
 
         $this->registry->expects($this->never())
             ->method('findProviderModelsMetadataForSupport');
@@ -640,7 +642,7 @@ class PromptBuilderTest extends TestCase
         $modelProperty = $reflection->getProperty('model');
         $modelProperty->setAccessible(true);
 
-        $this->assertSame($model, $modelProperty->getValue($builder));
+        $this->assertNull($modelProperty->getValue($builder));
     }
 
     /**
@@ -655,16 +657,17 @@ class PromptBuilderTest extends TestCase
         $model = $this->createMockTextGenerationModel($result, $metadata);
 
         $this->registry->expects($this->once())
+            ->method('findProviderModelsMetadataForSupport')
+            ->with('test-provider', $this->isInstanceOf(ModelRequirements::class))
+            ->willReturn([$metadata]);
+
+        $this->registry->expects($this->once())
             ->method('getProviderModel')
-            ->with('test-provider', 'preferred-id', $this->isNull())
+            ->with('test-provider', 'preferred-id', $this->isInstanceOf(ModelConfig::class))
             ->willReturn($model);
 
         $this->registry->expects($this->never())
             ->method('findModelsMetadataForSupport');
-
-        $this->registry->expects($this->once())
-            ->method('bindModelDependencies')
-            ->with($model);
 
         $builder = new PromptBuilder($this->registry, 'Test prompt');
         $builder->usingProvider('test-provider');
@@ -686,23 +689,18 @@ class PromptBuilderTest extends TestCase
         $metadata = $this->createTextModelMetadataWithInputSupport('fallback-id');
         $model = $this->createMockTextGenerationModel($result, $metadata);
 
-        $this->registry->expects($this->exactly(2))
+        $this->registry->expects($this->once())
+            ->method('findProviderModelsMetadataForSupport')
+            ->with('test-provider', $this->isInstanceOf(ModelRequirements::class))
+            ->willReturn([$metadata]);
+
+        $this->registry->expects($this->once())
             ->method('getProviderModel')
-            ->withConsecutive(
-                ['test-provider', 'missing-id', $this->isNull()],
-                ['test-provider', 'fallback-id', $this->isNull()]
-            )
-            ->willReturnOnConsecutiveCalls(
-                $this->throwException(new AiInvalidArgumentException('missing model')),
-                $model
-            );
+            ->with('test-provider', 'fallback-id', $this->isInstanceOf(ModelConfig::class))
+            ->willReturn($model);
 
         $this->registry->expects($this->never())
             ->method('findModelsMetadataForSupport');
-
-        $this->registry->expects($this->once())
-            ->method('bindModelDependencies')
-            ->with($model);
 
         $builder = new PromptBuilder($this->registry, 'Test prompt');
         $builder->usingProvider('test-provider');
@@ -728,24 +726,14 @@ class PromptBuilderTest extends TestCase
         $model = $this->createMockTextGenerationModel($result, $metadata);
 
         $this->registry->expects($this->once())
-            ->method('getRegisteredProviderIds')
-            ->willReturn([$providerMetadata->getId()]);
-
-        $this->registry->expects($this->once())
             ->method('findModelsMetadataForSupport')
             ->with($this->isInstanceOf(ModelRequirements::class))
             ->willReturn([$providerModelsMetadata]);
 
-        $this->registry->expects($this->exactly(2))
+        $this->registry->expects($this->once())
             ->method('getProviderModel')
-            ->withConsecutive(
-                [$providerMetadata->getId(), 'unavailable-model', $this->isNull()],
-                [$providerMetadata->getId(), 'discovered-id', $this->isInstanceOf(ModelConfig::class)]
-            )
-            ->willReturnOnConsecutiveCalls(
-                $this->throwException(new AiInvalidArgumentException('missing model')),
-                $model
-            );
+            ->with($providerMetadata->getId(), 'discovered-id', $this->isInstanceOf(ModelConfig::class))
+            ->willReturn($model);
 
         $this->registry->expects($this->never())
             ->method('findProviderModelsMetadataForSupport');

--- a/tests/unit/Builders/PromptBuilderTest.php
+++ b/tests/unit/Builders/PromptBuilderTest.php
@@ -804,10 +804,6 @@ class PromptBuilderTest extends TestCase
         $this->registry->expects($this->never())
             ->method('findProviderModelsMetadataForSupport');
 
-        $this->registry->expects($this->once())
-            ->method('bindModelDependencies')
-            ->with($model);
-
         $builder = new PromptBuilder($this->registry, 'Test prompt');
         $builder->usingModelPreference('unavailable-model');
 
@@ -826,7 +822,9 @@ class PromptBuilderTest extends TestCase
         $builder = new PromptBuilder($this->registry);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Model preferences must be model identifiers, instances of ModelInterface, or provider/model tuples.');
+        $this->expectExceptionMessage(
+            'Model preferences must be model identifiers, instances of ModelInterface, or provider/model tuples.'
+        );
 
         $builder->usingModelPreference(123);
     }

--- a/tests/unit/Builders/PromptBuilderTest.php
+++ b/tests/unit/Builders/PromptBuilderTest.php
@@ -2767,25 +2767,6 @@ class PromptBuilderTest extends TestCase
         $this->assertTrue($outputModalities[0]->isImage());
     }
 
-    /**
-     * Tests generateAudioResult method creates proper operation.
-     *
-     * @return void
-     */
-    public function testGenerateAudioResultCreatesProperOperation(): void
-    {
-        $this->markTestSkipped('generateAudioResult method does not exist yet');
-    }
-
-    /**
-     * Tests generateVideoResult method creates proper operation.
-     *
-     * @return void
-     */
-    public function testGenerateVideoResultCreatesProperOperation(): void
-    {
-        $this->markTestSkipped('generateVideoResult method does not exist yet');
-    }
 
     /**
      * Tests generateImage shorthand method returns file directly.
@@ -2820,45 +2801,7 @@ class PromptBuilderTest extends TestCase
         $this->assertSame($file, $generatedFile);
     }
 
-    /**
-     * Tests generateAudio shorthand method returns file directly.
-     *
-     * @return void
-     */
-    public function testGenerateAudioReturnsFileDirectly(): void
-    {
-        $this->markTestSkipped('generateAudio method does not exist yet');
-    }
 
-    /**
-     * Tests generateVideo shorthand method returns file directly.
-     *
-     * @return void
-     */
-    public function testGenerateVideoReturnsFileDirectly(): void
-    {
-        $this->markTestSkipped('generateVideo method does not exist yet');
-    }
-
-    /**
-     * Tests generation method with multiple output modalities.
-     *
-     * @return void
-     */
-    public function testGenerationWithMultipleOutputModalities(): void
-    {
-        $this->markTestSkipped('Operations-based generation not implemented yet');
-    }
-
-    /**
-     * Tests streaming generation methods.
-     *
-     * @return void
-     */
-    public function testStreamingGenerationMethods(): void
-    {
-        $this->markTestSkipped('Streaming methods do not exist yet');
-    }
 
     /**
      * Tests generateText with no candidates throws exception.
@@ -2918,16 +2861,6 @@ class PromptBuilderTest extends TestCase
         $this->expectExceptionMessage('No text content found in first candidate');
 
         $builder->generateText();
-    }
-
-    /**
-     * Tests chain generation with multiple prompts.
-     *
-     * @return void
-     */
-    public function testChainGenerationWithMultiplePrompts(): void
-    {
-        $this->markTestSkipped('Complex chaining with model response methods not fully implemented yet');
     }
 
 

--- a/tests/unit/Builders/PromptBuilderTest.php
+++ b/tests/unit/Builders/PromptBuilderTest.php
@@ -724,6 +724,11 @@ class PromptBuilderTest extends TestCase
         $model = $this->createMockTextGenerationModel($result, $metadata);
 
         $this->registry->expects($this->once())
+            ->method('getProviderId')
+            ->with('test-provider')
+            ->willReturn('test-provider');
+
+        $this->registry->expects($this->once())
             ->method('findProviderModelsMetadataForSupport')
             ->with('test-provider', $this->isInstanceOf(ModelRequirements::class))
             ->willReturn([$metadata]);
@@ -746,6 +751,44 @@ class PromptBuilderTest extends TestCase
     }
 
     /**
+     * Tests usingModelPreference with provider class name instead of ID.
+     *
+     * @return void
+     */
+    public function testUsingModelPreferenceWithProviderClassName(): void
+    {
+        $result = $this->createTestResult('Preferred with class name');
+        $metadata = $this->createTextModelMetadataWithInputSupport('preferred-id');
+        $model = $this->createMockTextGenerationModel($result, $metadata);
+
+        $this->registry->expects($this->once())
+            ->method('getProviderId')
+            ->with('WordPress\AiClient\TestProvider')
+            ->willReturn('test-provider');
+
+        $this->registry->expects($this->once())
+            ->method('findProviderModelsMetadataForSupport')
+            ->with('WordPress\AiClient\TestProvider', $this->isInstanceOf(ModelRequirements::class))
+            ->willReturn([$metadata]);
+
+        $this->registry->expects($this->once())
+            ->method('getProviderModel')
+            ->with('test-provider', 'preferred-id', $this->isInstanceOf(ModelConfig::class))
+            ->willReturn($model);
+
+        $this->registry->expects($this->never())
+            ->method('findModelsMetadataForSupport');
+
+        $builder = new PromptBuilder($this->registry, 'Test prompt');
+        $builder->usingProvider('WordPress\AiClient\TestProvider');
+        $builder->usingModelPreference('preferred-id', 'secondary-id');
+
+        $actualResult = $builder->generateTextResult();
+
+        $this->assertSame($result, $actualResult);
+    }
+
+    /**
      * Tests usingModelPreference skips unavailable model IDs and falls back to the next preference.
      *
      * @return void
@@ -755,6 +798,11 @@ class PromptBuilderTest extends TestCase
         $result = $this->createTestResult('Fallback model result');
         $metadata = $this->createTextModelMetadataWithInputSupport('fallback-id');
         $model = $this->createMockTextGenerationModel($result, $metadata);
+
+        $this->registry->expects($this->once())
+            ->method('getProviderId')
+            ->with('test-provider')
+            ->willReturn('test-provider');
 
         $this->registry->expects($this->once())
             ->method('findProviderModelsMetadataForSupport')
@@ -3015,6 +3063,11 @@ class PromptBuilderTest extends TestCase
 
         // Mock the registry to return the model when provider is specified
         $this->registry->expects($this->once())
+            ->method('getProviderId')
+            ->with('test-provider')
+            ->willReturn('test-provider');
+
+        $this->registry->expects($this->once())
             ->method('findProviderModelsMetadataForSupport')
             ->with('test-provider', $this->isInstanceOf(ModelRequirements::class))
             ->willReturn([$modelMetadata]);
@@ -3026,6 +3079,43 @@ class PromptBuilderTest extends TestCase
 
         $builder = new PromptBuilder($this->registry, 'Test prompt');
         $builder->usingProvider('test-provider');
+
+        $actualResult = $builder->generateResult();
+        $this->assertSame($result, $actualResult);
+    }
+
+    /**
+     * Tests generateResult with provider class name specified.
+     *
+     * @return void
+     */
+    public function testGenerateResultWithProviderClassName(): void
+    {
+        $result = $this->createMock(GenerativeAiResult::class);
+
+        $modelMetadata = $this->createMock(ModelMetadata::class);
+        $modelMetadata->method('getId')->willReturn('provider-model');
+
+        $model = $this->createMockTextGenerationModel($result, $modelMetadata);
+
+        // Mock the registry to return the provider ID when given a class name
+        $this->registry->expects($this->once())
+            ->method('getProviderId')
+            ->with('WordPress\AiClient\TestProvider')
+            ->willReturn('test-provider');
+
+        $this->registry->expects($this->once())
+            ->method('findProviderModelsMetadataForSupport')
+            ->with('WordPress\AiClient\TestProvider', $this->isInstanceOf(ModelRequirements::class))
+            ->willReturn([$modelMetadata]);
+
+        $this->registry->expects($this->once())
+            ->method('getProviderModel')
+            ->with('test-provider', 'provider-model', $this->isInstanceOf(ModelConfig::class))
+            ->willReturn($model);
+
+        $builder = new PromptBuilder($this->registry, 'Test prompt');
+        $builder->usingProvider('WordPress\AiClient\TestProvider');
 
         $actualResult = $builder->generateResult();
         $this->assertSame($result, $actualResult);

--- a/tests/unit/Builders/PromptBuilderTest.php
+++ b/tests/unit/Builders/PromptBuilderTest.php
@@ -9,6 +9,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use WordPress\AiClient\Builders\PromptBuilder;
+use WordPress\AiClient\Common\Exception\InvalidArgumentException as AiInvalidArgumentException;
 use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Files\Enums\FileTypeEnum;
 use WordPress\AiClient\Messages\DTO\Message;
@@ -18,6 +19,7 @@ use WordPress\AiClient\Messages\DTO\UserMessage;
 use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 use WordPress\AiClient\Messages\Enums\ModalityEnum;
 use WordPress\AiClient\Providers\DTO\ProviderMetadata;
+use WordPress\AiClient\Providers\DTO\ProviderModelsMetadata;
 use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
 use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
@@ -59,6 +61,25 @@ class PromptBuilderTest extends TestCase
     private function createTestProviderMetadata(): ProviderMetadata
     {
         return new ProviderMetadata('test-provider', 'Test Provider', ProviderTypeEnum::cloud());
+    }
+
+    /**
+     * Creates text model metadata supporting any input modalities.
+     *
+     * @param string $id The model identifier.
+     * @return ModelMetadata
+     */
+    private function createTextModelMetadataWithInputSupport(string $id): ModelMetadata
+    {
+        return new ModelMetadata(
+            $id,
+            'Test Text Model',
+            [CapabilityEnum::textGeneration()],
+            [
+                new SupportedOption(OptionEnum::inputModalities()),
+                new SupportedOption(OptionEnum::outputModalities()),
+            ]
+        );
     }
 
     /**
@@ -585,6 +606,204 @@ class PromptBuilderTest extends TestCase
         /** @var ModelInterface $actualModel */
         $actualModel = $modelProperty->getValue($builder);
         $this->assertSame($model, $actualModel);
+    }
+
+    /**
+     * Tests usingModelPreference selects provided model instance when requirements are met.
+     *
+     * @return void
+     */
+    public function testUsingModelPreferenceWithModelInstance(): void
+    {
+        $result = $this->createTestResult('Preferred model result');
+        $metadata = $this->createTextModelMetadataWithInputSupport('preferred-model');
+        $model = $this->createMockTextGenerationModel($result, $metadata);
+
+        $this->registry->expects($this->once())
+            ->method('bindModelDependencies')
+            ->with($model);
+
+        $this->registry->expects($this->never())
+            ->method('findModelsMetadataForSupport');
+
+        $this->registry->expects($this->never())
+            ->method('findProviderModelsMetadataForSupport');
+
+        $builder = new PromptBuilder($this->registry, 'Test prompt');
+        $builder->usingModelPreference($model);
+
+        $actualResult = $builder->generateTextResult();
+
+        $this->assertSame($result, $actualResult);
+
+        $reflection = new \ReflectionClass($builder);
+        $modelProperty = $reflection->getProperty('model');
+        $modelProperty->setAccessible(true);
+
+        $this->assertSame($model, $modelProperty->getValue($builder));
+    }
+
+    /**
+     * Tests usingModelPreference selects the first available model ID for the configured provider.
+     *
+     * @return void
+     */
+    public function testUsingModelPreferencePrefersFirstAvailableModelId(): void
+    {
+        $result = $this->createTestResult('Preferred by ID');
+        $metadata = $this->createTextModelMetadataWithInputSupport('preferred-id');
+        $model = $this->createMockTextGenerationModel($result, $metadata);
+
+        $this->registry->expects($this->once())
+            ->method('getProviderModel')
+            ->with('test-provider', 'preferred-id', $this->isNull())
+            ->willReturn($model);
+
+        $this->registry->expects($this->never())
+            ->method('findModelsMetadataForSupport');
+
+        $this->registry->expects($this->once())
+            ->method('bindModelDependencies')
+            ->with($model);
+
+        $builder = new PromptBuilder($this->registry, 'Test prompt');
+        $builder->usingProvider('test-provider');
+        $builder->usingModelPreference('preferred-id', 'secondary-id');
+
+        $actualResult = $builder->generateTextResult();
+
+        $this->assertSame($result, $actualResult);
+    }
+
+    /**
+     * Tests usingModelPreference skips unavailable model IDs and falls back to the next preference.
+     *
+     * @return void
+     */
+    public function testUsingModelPreferenceSkipsUnavailableModelId(): void
+    {
+        $result = $this->createTestResult('Fallback model result');
+        $metadata = $this->createTextModelMetadataWithInputSupport('fallback-id');
+        $model = $this->createMockTextGenerationModel($result, $metadata);
+
+        $this->registry->expects($this->exactly(2))
+            ->method('getProviderModel')
+            ->withConsecutive(
+                ['test-provider', 'missing-id', $this->isNull()],
+                ['test-provider', 'fallback-id', $this->isNull()]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new AiInvalidArgumentException('missing model')),
+                $model
+            );
+
+        $this->registry->expects($this->never())
+            ->method('findModelsMetadataForSupport');
+
+        $this->registry->expects($this->once())
+            ->method('bindModelDependencies')
+            ->with($model);
+
+        $builder = new PromptBuilder($this->registry, 'Test prompt');
+        $builder->usingProvider('test-provider');
+        $builder->usingModelPreference('missing-id', 'fallback-id');
+
+        $actualResult = $builder->generateTextResult();
+
+        $this->assertSame($result, $actualResult);
+    }
+
+    /**
+     * Tests usingModelPreference falls back to discovery when no preferences are available.
+     *
+     * @return void
+     */
+    public function testUsingModelPreferenceFallsBackToDiscovery(): void
+    {
+        $result = $this->createTestResult('Discovered model result');
+        $metadata = $this->createTextModelMetadataWithInputSupport('discovered-id');
+        $providerMetadata = $this->createTestProviderMetadata();
+        $providerModelsMetadata = new ProviderModelsMetadata($providerMetadata, [$metadata]);
+
+        $model = $this->createMockTextGenerationModel($result, $metadata);
+
+        $this->registry->expects($this->once())
+            ->method('getRegisteredProviderIds')
+            ->willReturn([$providerMetadata->getId()]);
+
+        $this->registry->expects($this->once())
+            ->method('findModelsMetadataForSupport')
+            ->with($this->isInstanceOf(ModelRequirements::class))
+            ->willReturn([$providerModelsMetadata]);
+
+        $this->registry->expects($this->exactly(2))
+            ->method('getProviderModel')
+            ->withConsecutive(
+                [$providerMetadata->getId(), 'unavailable-model', $this->isNull()],
+                [$providerMetadata->getId(), 'discovered-id', $this->isInstanceOf(ModelConfig::class)]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new AiInvalidArgumentException('missing model')),
+                $model
+            );
+
+        $this->registry->expects($this->never())
+            ->method('findProviderModelsMetadataForSupport');
+
+        $this->registry->expects($this->never())
+            ->method('bindModelDependencies');
+
+        $builder = new PromptBuilder($this->registry, 'Test prompt');
+        $builder->usingModelPreference('unavailable-model');
+
+        $actualResult = $builder->generateTextResult();
+
+        $this->assertSame($result, $actualResult);
+    }
+
+    /**
+     * Tests usingModelPreference rejects invalid preference types.
+     *
+     * @return void
+     */
+    public function testUsingModelPreferenceWithInvalidTypeThrowsException(): void
+    {
+        $builder = new PromptBuilder($this->registry);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Model preferences must be model identifiers or instances of ModelInterface.');
+
+        $builder->usingModelPreference(123);
+    }
+
+    /**
+     * Tests usingModelPreference rejects empty preference identifier strings.
+     *
+     * @return void
+     */
+    public function testUsingModelPreferenceWithEmptyIdentifierThrowsException(): void
+    {
+        $builder = new PromptBuilder($this->registry);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Model preference identifiers cannot be empty.');
+
+        $builder->usingModelPreference('   ');
+    }
+
+    /**
+     * Tests usingModelPreference rejects calls without preferences.
+     *
+     * @return void
+     */
+    public function testUsingModelPreferenceWithoutArgumentsThrowsException(): void
+    {
+        $builder = new PromptBuilder($this->registry);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('At least one model preference must be provided.');
+
+        $builder->usingModelPreference();
     }
 
     /**


### PR DESCRIPTION
Resolved #103 

This adds the `PromptBuilder::usingModelPreference()` method which allows the user to provide a list of models _it would like_ to use. If no model is present, then it falls back on the discovery system.