### PR TITLE
Fix provider model preference tuple order to have provider ID be first

### DIFF
--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -249,9 +249,9 @@ class PromptBuilder
                     );
                 }
 
-                [$modelIdentifier, $providerId] = $preferredModel;
+                [$providerId, $modelId] = $preferredModel;
 
-                $modelId = $this->normalizePreferenceIdentifier($modelIdentifier);
+                $modelId = $this->normalizePreferenceIdentifier($modelId);
                 $providerId = $this->normalizePreferenceIdentifier(
                     $providerId,
                     'Model preference provider identifiers cannot be empty.'

--- a/tests/unit/Builders/PromptBuilderTest.php
+++ b/tests/unit/Builders/PromptBuilderTest.php
@@ -654,9 +654,16 @@ class PromptBuilderTest extends TestCase
     public function testUsingModelPreferenceWithProviderTupleSelectsModel(): void
     {
         $result = $this->createTestResult('Tuple preferred result');
+        $firstMetadata = $this->createTextModelMetadataWithInputSupport('first-model');
         $preferredMetadata = $this->createTextModelMetadataWithInputSupport('preferred-model');
         $otherMetadata = $this->createTextModelMetadataWithInputSupport('other-model');
         $model = $this->createMockTextGenerationModel($result, $preferredMetadata);
+
+        $firstProviderMetadata = new ProviderMetadata(
+            'first-provider',
+            'First Provider',
+            ProviderTypeEnum::cloud()
+        );
 
         $preferredProviderMetadata = new ProviderMetadata(
             'preferred-provider',
@@ -674,6 +681,7 @@ class PromptBuilderTest extends TestCase
             ->method('findModelsMetadataForSupport')
             ->with($this->isInstanceOf(ModelRequirements::class))
             ->willReturn([
+                new ProviderModelsMetadata($firstProviderMetadata, [$firstMetadata]),
                 new ProviderModelsMetadata($preferredProviderMetadata, [$preferredMetadata]),
                 new ProviderModelsMetadata($otherProviderMetadata, [$otherMetadata]),
             ]);
@@ -687,7 +695,7 @@ class PromptBuilderTest extends TestCase
             ->method('findProviderModelsMetadataForSupport');
 
         $builder = new PromptBuilder($this->registry, 'Test prompt');
-        $builder->usingModelPreference(['preferred-model', 'preferred-provider']);
+        $builder->usingModelPreference(['preferred-provider', 'preferred-model']);
 
         $actualResult = $builder->generateTextResult();
 
@@ -707,7 +715,7 @@ class PromptBuilderTest extends TestCase
         $builder = new PromptBuilder($this->registry, 'Test prompt');
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Model preference provider identifiers cannot be empty.');
+        $this->expectExceptionMessage('Model preference identifiers cannot be empty.');
 
         $builder->usingModelPreference(['mock', $model]);
     }


### PR DESCRIPTION
See https://github.com/WordPress/php-ai-client/pull/112#issuecomment-3416697304 for what this fixes.

It also fixes a problem in the unit test which was actually passing regardless of whether model ID or provider ID came first. That's because the expected preferred model was also the first one registered, so it would be returned regardless. Including another model that's registered before that makes the test actually meaningful (i.e. pass/fail as expected).