### PR TITLE
Adds AbstractApiProvider class

### DIFF
--- a/src/ProviderImplementations/Anthropic/AnthropicModelMetadataDirectory.php
+++ b/src/ProviderImplementations/Anthropic/AnthropicModelMetadataDirectory.php
@@ -55,7 +55,7 @@ class AnthropicModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetad
     {
         return new Request(
             $method,
-            AnthropicProvider::BASE_URI . '/' . ltrim($path, '/'),
+            AnthropicProvider::url($path),
             $headers,
             $data
         );

--- a/src/ProviderImplementations/Anthropic/AnthropicProvider.php
+++ b/src/ProviderImplementations/Anthropic/AnthropicProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace WordPress\AiClient\ProviderImplementations\Anthropic;
 
 use WordPress\AiClient\Common\Exception\RuntimeException;
-use WordPress\AiClient\Providers\AbstractProvider;
+use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiProvider;
 use WordPress\AiClient\Providers\ApiBasedImplementation\ListModelsApiBasedProviderAvailability;
 use WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface;
 use WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface;
@@ -19,9 +19,17 @@ use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
  *
  * @since 0.1.0
  */
-class AnthropicProvider extends AbstractProvider
+class AnthropicProvider extends AbstractApiProvider
 {
-    public const BASE_URI = 'https://api.anthropic.com/v1';
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    protected static function baseUrl(): string
+    {
+        return 'https://api.anthropic.com/v1';
+    }
 
     /**
      * {@inheritDoc}

--- a/src/ProviderImplementations/Anthropic/AnthropicTextGenerationModel.php
+++ b/src/ProviderImplementations/Anthropic/AnthropicTextGenerationModel.php
@@ -24,7 +24,7 @@ class AnthropicTextGenerationModel extends AbstractOpenAiCompatibleTextGeneratio
     {
         return new Request(
             $method,
-            AnthropicProvider::BASE_URI . '/' . ltrim($path, '/'),
+            AnthropicProvider::url($path),
             $headers,
             $data
         );

--- a/src/ProviderImplementations/Google/GoogleImageGenerationModel.php
+++ b/src/ProviderImplementations/Google/GoogleImageGenerationModel.php
@@ -22,7 +22,7 @@ class GoogleImageGenerationModel extends AbstractOpenAiCompatibleImageGeneration
     {
         return new Request(
             $method,
-            GoogleProvider::url("openai/{$path}"),
+            GoogleProvider::url('openai' . ltrim($path, '/')),
             $headers,
             $data
         );

--- a/src/ProviderImplementations/Google/GoogleImageGenerationModel.php
+++ b/src/ProviderImplementations/Google/GoogleImageGenerationModel.php
@@ -22,7 +22,7 @@ class GoogleImageGenerationModel extends AbstractOpenAiCompatibleImageGeneration
     {
         return new Request(
             $method,
-            GoogleProvider::BASE_URI . '/openai/' . ltrim($path, '/'),
+            GoogleProvider::url("openai/{$path}"),
             $headers,
             $data
         );

--- a/src/ProviderImplementations/Google/GoogleModelMetadataDirectory.php
+++ b/src/ProviderImplementations/Google/GoogleModelMetadataDirectory.php
@@ -71,7 +71,7 @@ class GoogleModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
         }
         return new Request(
             $method,
-            GoogleProvider::BASE_URI . '/' . ltrim($path, '/'),
+            GoogleProvider::url($path),
             $headers,
             $data
         );

--- a/src/ProviderImplementations/Google/GoogleProvider.php
+++ b/src/ProviderImplementations/Google/GoogleProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace WordPress\AiClient\ProviderImplementations\Google;
 
 use WordPress\AiClient\Common\Exception\RuntimeException;
-use WordPress\AiClient\Providers\AbstractProvider;
+use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiProvider;
 use WordPress\AiClient\Providers\ApiBasedImplementation\ListModelsApiBasedProviderAvailability;
 use WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface;
 use WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface;
@@ -19,9 +19,17 @@ use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
  *
  * @since 0.1.0
  */
-class GoogleProvider extends AbstractProvider
+class GoogleProvider extends AbstractApiProvider
 {
-    public const BASE_URI = 'https://generativelanguage.googleapis.com/v1beta';
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    protected static function baseUrl(): string
+    {
+        return 'https://generativelanguage.googleapis.com/v1beta';
+    }
 
     /**
      * {@inheritDoc}

--- a/src/ProviderImplementations/Google/GoogleTextGenerationModel.php
+++ b/src/ProviderImplementations/Google/GoogleTextGenerationModel.php
@@ -24,7 +24,7 @@ class GoogleTextGenerationModel extends AbstractOpenAiCompatibleTextGenerationMo
     {
         return new Request(
             $method,
-            GoogleProvider::url("openai/{$path}"),
+            GoogleProvider::url('openai' . ltrim($path, '/')),
             $headers,
             $data
         );

--- a/src/ProviderImplementations/Google/GoogleTextGenerationModel.php
+++ b/src/ProviderImplementations/Google/GoogleTextGenerationModel.php
@@ -24,7 +24,7 @@ class GoogleTextGenerationModel extends AbstractOpenAiCompatibleTextGenerationMo
     {
         return new Request(
             $method,
-            GoogleProvider::BASE_URI . '/openai/' . ltrim($path, '/'),
+            GoogleProvider::url("openai/{$path}"),
             $headers,
             $data
         );

--- a/src/ProviderImplementations/OpenAi/OpenAiImageGenerationModel.php
+++ b/src/ProviderImplementations/OpenAi/OpenAiImageGenerationModel.php
@@ -22,7 +22,7 @@ class OpenAiImageGenerationModel extends AbstractOpenAiCompatibleImageGeneration
     {
         return new Request(
             $method,
-            OpenAiProvider::BASE_URI . '/' . ltrim($path, '/'),
+            OpenAiProvider::url($path),
             $headers,
             $data
         );

--- a/src/ProviderImplementations/OpenAi/OpenAiModelMetadataDirectory.php
+++ b/src/ProviderImplementations/OpenAi/OpenAiModelMetadataDirectory.php
@@ -37,7 +37,7 @@ class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
     {
         return new Request(
             $method,
-            OpenAiProvider::BASE_URI . '/' . ltrim($path, '/'),
+            OpenAiProvider::url($path),
             $headers,
             $data
         );

--- a/src/ProviderImplementations/OpenAi/OpenAiProvider.php
+++ b/src/ProviderImplementations/OpenAi/OpenAiProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace WordPress\AiClient\ProviderImplementations\OpenAi;
 
 use WordPress\AiClient\Common\Exception\RuntimeException;
-use WordPress\AiClient\Providers\AbstractProvider;
+use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiProvider;
 use WordPress\AiClient\Providers\ApiBasedImplementation\ListModelsApiBasedProviderAvailability;
 use WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface;
 use WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface;
@@ -19,9 +19,17 @@ use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
  *
  * @since 0.1.0
  */
-class OpenAiProvider extends AbstractProvider
+class OpenAiProvider extends AbstractApiProvider
 {
-    public const BASE_URI = 'https://api.openai.com/v1';
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    protected static function baseUrl(): string
+    {
+        return 'https://api.openai.com/v1';
+    }
 
     /**
      * {@inheritDoc}

--- a/src/ProviderImplementations/OpenAi/OpenAiTextGenerationModel.php
+++ b/src/ProviderImplementations/OpenAi/OpenAiTextGenerationModel.php
@@ -24,7 +24,7 @@ class OpenAiTextGenerationModel extends AbstractOpenAiCompatibleTextGenerationMo
     {
         return new Request(
             $method,
-            OpenAiProvider::BASE_URI . '/' . ltrim($path, '/'),
+            OpenAiProvider::url($path),
             $headers,
             $data
         );

--- a/src/Providers/ApiBasedImplementation/AbstractApiProvider.php
+++ b/src/Providers/ApiBasedImplementation/AbstractApiProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Providers\ApiBasedImplementation;
+
+use WordPress\AiClient\Providers\AbstractProvider;
+
+/**
+ * Base class for API-based providers.
+ *
+ * This abstract class provides URL construction utilities for providers that
+ * communicate with REST APIs. It standardizes the pattern of combining a base
+ * URL with endpoint paths.
+ *
+ * @since n.e.x.t
+ */
+abstract class AbstractApiProvider extends AbstractProvider
+{
+    /**
+     * Gets the base URL for the provider's API.
+     *
+     * The base URL should include the protocol and domain, and may include
+     * the API version path (e.g., "https://api.example.com/v1").
+     *
+     * @since n.e.x.t
+     *
+     * @return string The base URL for the provider's API.
+     */
+    abstract protected static function baseUrl(): string;
+
+    /**
+     * Constructs a full URL by combining the base URL with an optional path.
+     *
+     * This method ensures proper URL construction by:
+     * - Using the provider's base URL
+     * - Trimming leading slashes from the path to prevent double-slashes
+     * - Joining the base URL and path with a single forward slash
+     *
+     * @since n.e.x.t
+     *
+     * @param string $path Optional path to append to the base URL. Default empty string.
+     * @return string The complete URL.
+     */
+    public static function url(string $path = ''): string
+    {
+        if ($path === '') {
+            return static::baseUrl();
+        }
+
+        return static::baseUrl() . '/' . ltrim($path, '/');
+    }
+}


### PR DESCRIPTION
Resolves #68 

This adds an `AbstractApiProvider` class, which provides a convenient way for API urls to be constructed, cleaning up a bunch of duplicate path constructing code.

I went with an abstract `baseUrl` method instead of using a constant that gets overridden so that it's clearer to extending classes and doesn't fail at runtime.