### PR TITLE
Docs: Correct grammar error in Message definition (GLOSSARY.md)

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -9,7 +9,7 @@ This glossary defines common terms relevant for the PHP AI Client and related pr
 * **Generative AI**: Overarching term describing AI models that generate content as requested in a prompt.
 * **Implementer API**: The API used by people that want to _implement_ AI features in their own software/products.
 * **MCP**: The "Model Context Protocol", a proposed standard for connecting AI assistants to the systems where data lives.
-* **Message**: A single message, either a user prompt, a model response, or a system prompt—optionally containing of multiple message parts.
+* **Message**: A single message, either a user prompt, a model response, or a system prompt—optionally consisting of multiple message parts.
 * **Message part**: A part of a message, such as a piece of text, a URL, a file, or a function call.
 * **Modality**: The type or format of input provided to, or output received from, an AI model. Examples include text, image, audio, and video.
 * **Model**: A specific AI model that supports arbitrary AI features and modalities. Examples include content generation, classification, embedding.


### PR DESCRIPTION
## Description

This PR fixes a grammatical error in the glossary documentation.

## Changes

- Fixed the **Message** definition in `docs/GLOSSARY.md`
- Changed "optionally containing of multiple message parts" to "optionally consisting of multiple message parts"

## Rationale

The phrase "containing of" is grammatically incorrect. The correct phrasing is either:
- "consisting of" (used in this fix)
- "containing" (without "of")

Since we want to convey that a message is composed/made up of parts, "consisting of" is the more appropriate choice.

## Type of Change

- [x] Documentation fix
- [x] Typo/grammar correction

## Checklist

- [x] The change follows the project's coding standards
- [x] Documentation has been updated appropriately
- [x] No tests are needed (documentation-only change)