### PR TITLE
Remove duplicate gitignore section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,13 +14,6 @@ vendor/
 .DS_store?
 
 ############
-## IDEs
-############
-
-.idea/
-.vscode/
-
-############
 ## AI Tools
 ############
 
@@ -35,14 +28,14 @@ CLAUDE.md
 GEMINI.md
 
 ############
+## PHPUnit
+############
+
+.phpunit.cache/
+
+############
 ## IDEs
 ############
 
 .idea/
 .vscode/
-
-############
-## PHPUnit
-############
-
-.phpunit.cache/


### PR DESCRIPTION
* The `IDEs` section was in there twice.
* Reshuffle order so that it matches between this repo and https://github.com/WordPress/wp-ai-client