### PR TITLE
Sort models per provider based on reasonable heuristics to avoid random default model

### DIFF
--- a/src/ProviderImplementations/Anthropic/AnthropicModelMetadataDirectory.php
+++ b/src/ProviderImplementations/Anthropic/AnthropicModelMetadataDirectory.php
@@ -180,7 +180,7 @@ class AnthropicModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetad
             return 1;
         }
 
-        // Prefer Claude models with type, version number, and date (e.g. 'claude-sonnet-4') over those without.
+        // Prefer Claude models with type, version number, and date (e.g. 'claude-sonnet-4-5-20250929') over those without.
         $aMatch = preg_match('/^claude-([a-z]+)-(\d(-\d)?)-([0-9]+)$/', $aId, $aMatches);
         $bMatch = preg_match('/^claude-([a-z]+)-(\d(-\d)?)-([0-9]+)$/', $bId, $bMatches);
         if ($aMatch && !$bMatch) {

--- a/src/ProviderImplementations/Anthropic/AnthropicModelMetadataDirectory.php
+++ b/src/ProviderImplementations/Anthropic/AnthropicModelMetadataDirectory.php
@@ -109,7 +109,7 @@ class AnthropicModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetad
 
         $modelsData = (array) $responseData['data'];
 
-        return array_values(
+        $models = array_values(
             array_map(
                 static function (array $modelData) use (
                     $anthropicCapabilities,
@@ -137,5 +137,89 @@ class AnthropicModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetad
                 $modelsData
             )
         );
+
+        usort($models, [$this, 'modelSortCallback']);
+
+        return $models;
+    }
+
+    /**
+     * Callback function for sorting models by ID, to be used with `usort()`.
+     *
+     * This method expresses preferences for certain models or model families within the provider by putting them
+     * earlier in the sorted list. The objective is not to be opinionated about which models are better, but to ensure
+     * that more commonly used, more recent, or flagship models are presented first to users.
+     *
+     * @since n.e.x.t
+     *
+     * @param ModelMetadata $a First model.
+     * @param ModelMetadata $b Second model.
+     * @return int Comparison result.
+     */
+    protected function modelSortCallback(ModelMetadata $a, ModelMetadata $b): int
+    {
+        $aId = $a->getId();
+        $bId = $b->getId();
+
+        // Prefer Claude models over non-Claude models.
+        if (str_starts_with($aId, 'claude-') && !str_starts_with($bId, 'claude-')) {
+            return -1;
+        }
+        if (str_starts_with($bId, 'claude-') && !str_starts_with($aId, 'claude-')) {
+            return 1;
+        }
+
+        /*
+         * Prefer Claude models where the version number isn't the second segment (e.g. 'claude-sonnet-4')
+         * over those where it is (e.g. 'claude-2', 'claude-3-5-sonnet'). The latter is only used for older models.
+         */
+        if (!preg_match('/^claude-\d/', $aId) && preg_match('/^claude-\d/', $bId)) {
+            return -1;
+        }
+        if (!preg_match('/^claude-\d/', $bId) && preg_match('/^claude-\d/', $aId)) {
+            return 1;
+        }
+
+        // Prefer Claude models with type, version number, and date (e.g. 'claude-sonnet-4') over those without.
+        $aMatch = preg_match('/^claude-([a-z]+)-(\d(-\d)?)-([0-9]+)$/', $aId, $aMatches);
+        $bMatch = preg_match('/^claude-([a-z]+)-(\d(-\d)?)-([0-9]+)$/', $bId, $bMatches);
+        if ($aMatch && !$bMatch) {
+            return -1;
+        }
+        if ($bMatch && !$aMatch) {
+            return 1;
+        }
+        if ($aMatch && $bMatch) {
+            // Prefer later model versions.
+            $aVersion = str_replace('-', '.', $aMatches[2]);
+            $bVersion = str_replace('-', '.', $bMatches[2]);
+            if (version_compare($aVersion, $bVersion, '>')) {
+                return -1;
+            }
+            if (version_compare($bVersion, $aVersion, '>')) {
+                return 1;
+            }
+
+            // Prefer 'sonnet' models over other types.
+            if ($aMatches[1] === 'sonnet' && $bMatches[1] !== 'sonnet') {
+                return -1;
+            }
+            if ($bMatches[1] === 'sonnet' && $aMatches[1] !== 'sonnet') {
+                return 1;
+            }
+
+            // Prefer later release dates.
+            $aDate = (int) $aMatches[4];
+            $bDate = (int) $bMatches[4];
+            if ($aDate > $bDate) {
+                return -1;
+            }
+            if ($bDate > $aDate) {
+                return 1;
+            }
+        }
+
+        // Fallback: Sort alphabetically.
+        return strcmp($a->getId(), $b->getId());
     }
 }

--- a/src/ProviderImplementations/Anthropic/AnthropicModelMetadataDirectory.php
+++ b/src/ProviderImplementations/Anthropic/AnthropicModelMetadataDirectory.php
@@ -180,9 +180,12 @@ class AnthropicModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetad
             return 1;
         }
 
-        // Prefer Claude models with type, version number, and date (e.g. 'claude-sonnet-4-5-20250929') over those without.
-        $aMatch = preg_match('/^claude-([a-z]+)-(\d(-\d)?)-([0-9]+)$/', $aId, $aMatches);
-        $bMatch = preg_match('/^claude-([a-z]+)-(\d(-\d)?)-([0-9]+)$/', $bId, $bMatches);
+        /*
+         * Prefer Claude models with type and version number (e.g. 'claude-sonnet-4', 'claude-sonnet-4-5-20250929')
+         * over those without. An optional date suffix may also be present.
+         */
+        $aMatch = preg_match('/^claude-([a-z]+)-(\d(-\d)?)(-[0-9]+)?$/', $aId, $aMatches);
+        $bMatch = preg_match('/^claude-([a-z]+)-(\d(-\d)?)(-[0-9]+)?$/', $bId, $bMatches);
         if ($aMatch && !$bMatch) {
             return -1;
         }
@@ -200,6 +203,14 @@ class AnthropicModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetad
                 return 1;
             }
 
+            // Prefer models without a suffix (i.e. base models) over those with a suffix.
+            if (!isset($aMatches[4]) && isset($bMatches[4])) {
+                return -1;
+            }
+            if (!isset($bMatches[4]) && isset($aMatches[4])) {
+                return 1;
+            }
+
             // Prefer 'sonnet' models over other types.
             if ($aMatches[1] === 'sonnet' && $bMatches[1] !== 'sonnet') {
                 return -1;
@@ -209,13 +220,15 @@ class AnthropicModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetad
             }
 
             // Prefer later release dates.
-            $aDate = (int) $aMatches[4];
-            $bDate = (int) $bMatches[4];
-            if ($aDate > $bDate) {
-                return -1;
-            }
-            if ($bDate > $aDate) {
-                return 1;
+            if (isset($aMatches[4]) && isset($bMatches[4])) {
+                $aDate = (int) substr($aMatches[4], 1);
+                $bDate = (int) substr($bMatches[4], 1);
+                if ($aDate > $bDate) {
+                    return -1;
+                }
+                if ($bDate > $aDate) {
+                    return 1;
+                }
             }
         }
 

--- a/src/ProviderImplementations/Google/GoogleModelMetadataDirectory.php
+++ b/src/ProviderImplementations/Google/GoogleModelMetadataDirectory.php
@@ -167,7 +167,7 @@ class GoogleModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
 
         $modelsData = (array) $responseData['models'];
 
-        return array_values(
+        $models = array_values(
             array_map(
                 static function (array $modelData) use (
                     $geminiCapabilities,
@@ -234,5 +234,92 @@ class GoogleModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
                 $modelsData
             )
         );
+
+        usort($models, [$this, 'modelSortCallback']);
+
+        return $models;
+    }
+
+    /**
+     * Callback function for sorting models by ID, to be used with `usort()`.
+     *
+     * This method expresses preferences for certain models or model families within the provider by putting them
+     * earlier in the sorted list. The objective is not to be opinionated about which models are better, but to ensure
+     * that more commonly used, more recent, or flagship models are presented first to users.
+     *
+     * @since n.e.x.t
+     *
+     * @param ModelMetadata $a First model.
+     * @param ModelMetadata $b Second model.
+     * @return int Comparison result.
+     */
+    protected function modelSortCallback(ModelMetadata $a, ModelMetadata $b): int
+    {
+        $aId = $a->getId();
+        $bId = $b->getId();
+
+        // Prefer non-experimental models over experimental models.
+        if (str_contains($aId, '-exp') && !str_contains($bId, '-exp')) {
+            return 1;
+        }
+        if (str_contains($bId, '-exp') && !str_contains($aId, '-exp')) {
+            return -1;
+        }
+
+        // Prefer non-preview models over preview models.
+        if (str_contains($aId, '-preview') && !str_contains($bId, '-preview')) {
+            return 1;
+        }
+        if (str_contains($bId, '-preview') && !str_contains($aId, '-preview')) {
+            return -1;
+        }
+
+        // Prefer Gemini models over non-Gemini models.
+        if (str_starts_with($aId, 'gemini-') && !str_starts_with($bId, 'gemini-')) {
+            return -1;
+        }
+        if (str_starts_with($bId, 'gemini-') && !str_starts_with($aId, 'gemini-')) {
+            return 1;
+        }
+
+        // Prefer Gemini models with version numbers (e.g. 'gemini-2.5', 'gemini-2.0') over those without.
+        $aMatch = preg_match('/^gemini-([0-9.]+)(-[a-z0-9-]+)$/', $aId, $aMatches);
+        $bMatch = preg_match('/^gemini-([0-9.]+)(-[a-z0-9-]+)$/', $bId, $bMatches);
+        if ($aMatch && !$bMatch) {
+            return -1;
+        }
+        if ($bMatch && !$aMatch) {
+            return 1;
+        }
+        if ($aMatch && $bMatch) {
+            // Prefer later model versions.
+            $aVersion = $aMatches[1];
+            $bVersion = $bMatches[1];
+            if (version_compare($aVersion, $bVersion, '>')) {
+                return -1;
+            }
+            if (version_compare($bVersion, $aVersion, '>')) {
+                return 1;
+            }
+
+            // Prefer '-pro' models over other suffixes.
+            if ($aMatches[2] === '-pro' && $bMatches[2] !== '-pro') {
+                return -1;
+            }
+            if ($bMatches[2] === '-pro' && $aMatches[2] !== '-pro') {
+                return 1;
+            }
+
+            // Prefer '-flash' models over other suffixes.
+            if ($aMatches[2] === '-flash' && $bMatches[2] !== '-flash') {
+                return -1;
+            }
+            if ($bMatches[2] === '-flash' && $aMatches[2] !== '-flash') {
+                return 1;
+            }
+        }
+
+        // Fallback: Sort alphabetically.
+        return strcmp($a->getId(), $b->getId());
     }
 }

--- a/src/ProviderImplementations/OpenAi/OpenAiModelMetadataDirectory.php
+++ b/src/ProviderImplementations/OpenAi/OpenAiModelMetadataDirectory.php
@@ -159,7 +159,7 @@ class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
 
         $modelsData = (array) $responseData['data'];
 
-        return array_values(
+        $models = array_values(
             array_map(
                 static function (array $modelData) use (
                     $gptCapabilities,
@@ -223,5 +223,86 @@ class OpenAiModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
                 $modelsData
             )
         );
+
+        usort($models, [$this, 'modelSortCallback']);
+
+        return $models;
+    }
+
+    /**
+     * Callback function for sorting models by ID, to be used with `usort()`.
+     *
+     * This method expresses preferences for certain models or model families within the provider by putting them
+     * earlier in the sorted list. The objective is not to be opinionated about which models are better, but to ensure
+     * that more commonly used, more recent, or flagship models are presented first to users.
+     *
+     * @since n.e.x.t
+     *
+     * @param ModelMetadata $a First model.
+     * @param ModelMetadata $b Second model.
+     * @return int Comparison result.
+     */
+    protected function modelSortCallback(ModelMetadata $a, ModelMetadata $b): int
+    {
+        $aId = $a->getId();
+        $bId = $b->getId();
+
+        // Prefer non-preview models over preview models.
+        if (str_contains($aId, '-preview') && !str_contains($bId, '-preview')) {
+            return 1;
+        }
+        if (str_contains($bId, '-preview') && !str_contains($aId, '-preview')) {
+            return -1;
+        }
+
+        // Prefer GPT models over non-GPT models.
+        if (str_starts_with($aId, 'gpt-') && !str_starts_with($bId, 'gpt-')) {
+            return -1;
+        }
+        if (str_starts_with($bId, 'gpt-') && !str_starts_with($aId, 'gpt-')) {
+            return 1;
+        }
+
+        // Prefer GPT models with version numbers (e.g. 'gpt-5.1', 'gpt-5') over those without.
+        $aMatch = preg_match('/^gpt-([0-9.]+)(-[a-z0-9-]+)?$/', $aId, $aMatches);
+        $bMatch = preg_match('/^gpt-([0-9.]+)(-[a-z0-9-]+)?$/', $bId, $bMatches);
+        if ($aMatch && !$bMatch) {
+            return -1;
+        }
+        if ($bMatch && !$aMatch) {
+            return 1;
+        }
+        if ($aMatch && $bMatch) {
+            // Prefer later model versions.
+            $aVersion = $aMatches[1];
+            $bVersion = $bMatches[1];
+            if (version_compare($aVersion, $bVersion, '>')) {
+                return -1;
+            }
+            if (version_compare($bVersion, $aVersion, '>')) {
+                return 1;
+            }
+
+            // Prefer models without a suffix (i.e. base models) over those with a suffix.
+            if (!isset($aMatches[2]) && isset($bMatches[2])) {
+                return -1;
+            }
+            if (!isset($bMatches[2]) && isset($aMatches[2])) {
+                return 1;
+            }
+
+            // Prefer '-mini' models over others with a suffix.
+            if (isset($aMatches[2]) && isset($bMatches[2])) {
+                if ($aMatches[2] === '-mini' && $bMatches[2] !== '-mini') {
+                    return -1;
+                }
+                if ($bMatches[2] === '-mini' && $aMatches[2] !== '-mini') {
+                    return 1;
+                }
+            }
+        }
+
+        // Fallback: Sort alphabetically.
+        return strcmp($a->getId(), $b->getId());
     }
 }


### PR DESCRIPTION
Fixes #117

This finally resolves a long-standing issue where the default model chosen for a provider would be sort of "random", or rather the first model returned by the provider's API listings.

The solution is to implement model sorting _per provider_ via reasonable heuristics, without getting too opinionated:

* prefer flagship models (and then the common "lower/cheaper tier" variant, if applicable)
* prefer later versions
* prefer non-preview/non-experimental

Keep in mind that the sorting is _per provider_. There is no issue with this in terms of favoring any specific provider, the sorting is just for their models internally.

For easy testing of the sorted model IDs per provider, do this:

* Temporarily add a `var_dump($modelId);` for each `$modelId` iterated over in `PromptBuilder::generateMapFromCandidates` (e.g. line 1216).
* Use the built-in CLI tool, without specifying a model or model preference, but specifying `--providerId` (with each "anthropic", "google", "openai").