### PR TITLE
Fix broken Google API URLs

### DIFF
--- a/src/ProviderImplementations/Google/GoogleImageGenerationModel.php
+++ b/src/ProviderImplementations/Google/GoogleImageGenerationModel.php
@@ -22,7 +22,7 @@ class GoogleImageGenerationModel extends AbstractOpenAiCompatibleImageGeneration
     {
         return new Request(
             $method,
-            GoogleProvider::url('openai' . ltrim($path, '/')),
+            GoogleProvider::url('openai/' . ltrim($path, '/')),
             $headers,
             $data
         );

--- a/src/ProviderImplementations/Google/GoogleTextGenerationModel.php
+++ b/src/ProviderImplementations/Google/GoogleTextGenerationModel.php
@@ -24,7 +24,7 @@ class GoogleTextGenerationModel extends AbstractOpenAiCompatibleTextGenerationMo
     {
         return new Request(
             $method,
-            GoogleProvider::url('openai' . ltrim($path, '/')),
+            GoogleProvider::url('openai/' . ltrim($path, '/')),
             $headers,
             $data
         );


### PR DESCRIPTION
Yikes! Requests to the Google API are currently not working at all.

Looks like this broke in #115 - more specifically, see https://github.com/WordPress/php-ai-client/pull/115/files#diff-34150b8509051ad1c9d1e475df24d5454c3a994273831cb477bd01fa172b186aR25 🤦 

We need more comprehensive testing of the concrete provider implementations to prevent such errors to go unnoticed in the future. I think ideally we can actually fire a cheap request to each provider, to really ensure things work end to end, as this would further help to recognize breakage in case a provider makes a breaking change.