### PR TITLE
json_last_error() usage for json_decode validation for compliance

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -92,7 +92,7 @@ if (empty($positional_args[0])) {
 $promptInput = $positional_args[0];
 if (str_starts_with($promptInput, '{') || str_starts_with($promptInput, '[')) {
     $decodedInput = json_decode($promptInput, true);
-    if ($decodedInput) {
+    if (json_last_error() === JSON_ERROR_NONE) {
         $promptInput = $decodedInput;
     }
 }


### PR DESCRIPTION
json_last_error() is used across cli.php, but this one was missing a proper check/validation. Pushing a small update for consistency and avoiding warnings.