### PR TITLE
Enhance error message extraction and move class to more appropriate namespace

### DIFF
--- a/src/Providers/Http/Exception/ClientException.php
+++ b/src/Providers/Http/Exception/ClientException.php
@@ -7,7 +7,7 @@ namespace WordPress\AiClient\Providers\Http\Exception;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Providers\Http\DTO\Request;
 use WordPress\AiClient\Providers\Http\DTO\Response;
-use WordPress\AiClient\Providers\Http\Utilities\ErrorMessageExtractor;
+use WordPress\AiClient\Providers\Http\Util\ErrorMessageExtractor;
 
 /**
  * Exception thrown for 4xx HTTP client errors.

--- a/src/Providers/Http/Exception/ServerException.php
+++ b/src/Providers/Http/Exception/ServerException.php
@@ -6,7 +6,7 @@ namespace WordPress\AiClient\Providers\Http\Exception;
 
 use WordPress\AiClient\Common\Exception\RuntimeException;
 use WordPress\AiClient\Providers\Http\DTO\Response;
-use WordPress\AiClient\Providers\Http\Utilities\ErrorMessageExtractor;
+use WordPress\AiClient\Providers\Http\Util\ErrorMessageExtractor;
 
 /**
  * Exception thrown for 5xx HTTP server errors.

--- a/src/Providers/Http/Util/ErrorMessageExtractor.php
+++ b/src/Providers/Http/Util/ErrorMessageExtractor.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WordPress\AiClient\Providers\Http\Utilities;
+namespace WordPress\AiClient\Providers\Http\Util;
 
 /**
  * Utility for extracting error messages from API response data.
@@ -11,6 +11,7 @@ namespace WordPress\AiClient\Providers\Http\Utilities;
  * to avoid code duplication across exception classes.
  *
  * @since 0.2.0
+ * @since n.e.x.t Moved from Utilities namespace to Util namespace.
  */
 class ErrorMessageExtractor
 {
@@ -31,6 +32,18 @@ class ErrorMessageExtractor
     {
         if (!is_array($data)) {
             return null;
+        }
+
+        // Handle [ { "error": { "message": "Error text" } } ]
+        if (
+            isset($data[0]) &&
+            is_array($data[0]) &&
+            isset($data[0]['error']) &&
+            is_array($data[0]['error']) &&
+            isset($data[0]['error']['message']) &&
+            is_string($data[0]['error']['message'])
+        ) {
+            return $data[0]['error']['message'];
         }
 
         // Handle { "error": { "message": "Error text" } }


### PR DESCRIPTION
Some provider API endpoints, such as those from Google may return an array of error objects with message inside. This PR enhances the `ErrorMessageExtractor` to account for that shape, leading to more helpful error messages.

Additionally, I noticed there's both a `Providers\Http\Util` namespace and a `Providers\Http\Utilities` namespace. That doesn't make any sense, so they are being combined into one as part of this PR.