### PR TITLE
Skip passing thoughts to OpenAI compatible APIs because they don't support marking them as such

### DIFF
--- a/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
+++ b/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
@@ -313,6 +313,13 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
     {
         $type = $part->getType();
         if ($type->isText()) {
+            /*
+             * The OpenAI Chat Completions API spec does not support annotating thought parts as input,
+             * so we instead skip them.
+             */
+            if ($part->getChannel()->isThought()) {
+                return null;
+            }
             return [
                 'type' => 'text',
                 'text' => $part->getText(),

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
@@ -1304,4 +1304,19 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
 
         $this->assertNull($part);
     }
+
+    /**
+     * Tests getMessagePartContentData() with text part in thought channel.
+     *
+     * @return void
+     */
+    public function testGetMessagePartContentDataThoughtPart(): void
+    {
+        $part = new MessagePart('Thinking...', MessagePartChannelEnum::thought());
+        $model = $this->createModel();
+        $data = $model->exposeGetMessagePartContentData($part);
+
+        // Should be skipped because OpenAI API doesn't support receiving thoughts.
+        $this->assertNull($data);
+    }
 }


### PR DESCRIPTION
There is no way in the OpenAI `chat/completions` specification to mark _input_ message content as thoughts/reasoning. So far we're just passing all text through as regular content, which can lead to model confusion because it can't differentiate between actual model responses and thoughts from previous turns.

Therefore, it's safer to skip them entirely. Thoughts should not matter too much for subsequent turns. Ideally this would be supported by the API, but the tradeoff of skipping is safer.