### PR TITLE
Adds caching support via PSR-16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/event-dispatcher": "^1.0",
-        "psr/http-message": "^1.0 || ^2.0"
+        "psr/http-message": "^1.0 || ^2.0",
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c290e23e54f97989b8d04bb33bf137fc",
+    "content-hash": "ce3bd24175778c6b366b7c38ef11dd07",
     "packages": [
         {
             "name": "php-http/discovery",
@@ -458,6 +458,57 @@
                 "source": "https://github.com/php-fig/http-message/tree/2.0"
             },
             "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/master"
+            },
+            "time": "2017-10-23T01:57:42+00:00"
         }
     ],
     "packages-dev": [

--- a/src/AiClient.php
+++ b/src/AiClient.php
@@ -88,6 +88,11 @@ use WordPress\AiClient\Results\DTO\GenerativeAiResult;
 class AiClient
 {
     /**
+     * @var string The version of the AI Client.
+     */
+    public const VERSION = '0.3.0';
+
+    /**
      * @var ProviderRegistry|null The default provider registry instance.
      */
     private static ?ProviderRegistry $defaultRegistry = null;

--- a/src/AiClient.php
+++ b/src/AiClient.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace WordPress\AiClient;
 
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\SimpleCache\CacheInterface;
 use WordPress\AiClient\Builders\PromptBuilder;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Common\Exception\RuntimeException;
@@ -97,6 +98,11 @@ class AiClient
     private static ?EventDispatcherInterface $eventDispatcher = null;
 
     /**
+     * @var CacheInterface|null The PSR-16 cache for storing and retrieving cached data.
+     */
+    private static ?CacheInterface $cache = null;
+
+    /**
      * Gets the default provider registry instance.
      *
      * @since 0.1.0
@@ -146,6 +152,34 @@ class AiClient
     public static function getEventDispatcher(): ?EventDispatcherInterface
     {
         return self::$eventDispatcher;
+    }
+
+    /**
+     * Sets the PSR-16 cache for storing and retrieving cached data.
+     *
+     * The cache can be used to store AI responses and other data to avoid
+     * redundant API calls and improve performance.
+     *
+     * @since n.e.x.t
+     *
+     * @param CacheInterface|null $cache The PSR-16 cache instance, or null to disable caching.
+     * @return void
+     */
+    public static function setCache(?CacheInterface $cache): void
+    {
+        self::$cache = $cache;
+    }
+
+    /**
+     * Gets the PSR-16 cache instance.
+     *
+     * @since n.e.x.t
+     *
+     * @return CacheInterface|null The cache instance, or null if not set.
+     */
+    public static function getCache(): ?CacheInterface
+    {
+        return self::$cache;
     }
 
     /**

--- a/src/Common/Contracts/CachesDataInterface.php
+++ b/src/Common/Contracts/CachesDataInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Common\Contracts;
+
+/**
+ * Interface for objects that cache data.
+ *
+ * @since n.e.x.t
+ */
+interface CachesDataInterface
+{
+    /**
+     * Invalidates all caches managed by this object.
+     *
+     * @since n.e.x.t
+     *
+     * @return void
+     */
+    public function invalidateCaches(): void;
+}

--- a/src/Common/Traits/WithDataCachingTrait.php
+++ b/src/Common/Traits/WithDataCachingTrait.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Common\Traits;
+
+use WordPress\AiClient\AiClient;
+
+/**
+ * Trait for objects that cache data using PSR-16 cache.
+ *
+ * @since n.e.x.t
+ */
+trait WithDataCachingTrait
+{
+    /**
+     * Gets the base cache key for this object.
+     *
+     * The base cache key is used as a prefix for all cache keys managed by this object.
+     * It should be unique to the implementing class to avoid cache key collisions.
+     *
+     * @since n.e.x.t
+     *
+     * @return string The base cache key.
+     */
+    abstract protected function getBaseCacheKey(): string;
+
+    /**
+     * Gets a value from the cache.
+     *
+     * @since n.e.x.t
+     *
+     * @param string $key     The cache key suffix (will be appended to the base key).
+     * @param mixed  $default The default value to return if the key does not exist.
+     * @return mixed The cached value or the default value if not found.
+     */
+    protected function getCache(string $key, $default = null)
+    {
+        $cache = AiClient::getCache();
+        if ($cache === null) {
+            return $default;
+        }
+
+        return $cache->get($this->buildCacheKey($key), $default);
+    }
+
+    /**
+     * Sets a value in the cache.
+     *
+     * @since n.e.x.t
+     *
+     * @param string                $key   The cache key suffix (will be appended to the base key).
+     * @param mixed                 $value The value to cache.
+     * @param int|\DateInterval|null $ttl   The TTL for the cache entry, or null for default.
+     * @return bool True on success, false on failure or if no cache is configured.
+     */
+    protected function setCache(string $key, $value, $ttl = null): bool
+    {
+        $cache = AiClient::getCache();
+        if ($cache === null) {
+            return false;
+        }
+
+        return $cache->set($this->buildCacheKey($key), $value, $ttl);
+    }
+
+    /**
+     * Clears a value from the cache.
+     *
+     * @since n.e.x.t
+     *
+     * @param string $key The cache key suffix (will be appended to the base key).
+     * @return bool True on success, false on failure or if no cache is configured.
+     */
+    protected function clearCache(string $key): bool
+    {
+        $cache = AiClient::getCache();
+        if ($cache === null) {
+            return false;
+        }
+
+        return $cache->delete($this->buildCacheKey($key));
+    }
+
+    /**
+     * Builds the full cache key by combining the base key with the suffix.
+     *
+     * @since n.e.x.t
+     *
+     * @param string $key The cache key suffix.
+     * @return string The full cache key.
+     */
+    private function buildCacheKey(string $key): string
+    {
+        return $this->getBaseCacheKey() . '_' . $key;
+    }
+}

--- a/src/Common/Traits/WithDataCachingTrait.php
+++ b/src/Common/Traits/WithDataCachingTrait.php
@@ -7,12 +7,24 @@ namespace WordPress\AiClient\Common\Traits;
 use WordPress\AiClient\AiClient;
 
 /**
- * Trait for objects that cache data using PSR-16 cache.
+ * Trait for objects that cache data using PSR-16 cache with in-memory fallback.
+ *
+ * When a PSR-16 cache is configured via AiClient::setCache(), data is stored persistently.
+ * Otherwise, data is cached in-memory for the duration of the request.
  *
  * @since n.e.x.t
  */
 trait WithDataCachingTrait
 {
+    /**
+     * In-memory cache used when no PSR-16 cache is configured.
+     *
+     * @since n.e.x.t
+     *
+     * @var array<string, mixed>
+     */
+    private array $localCache = [];
+
     /**
      * Gets the cache key suffixes managed by this object.
      *
@@ -35,6 +47,49 @@ trait WithDataCachingTrait
     abstract protected function getBaseCacheKey(): string;
 
     /**
+     * Checks if a value exists in the cache.
+     *
+     * @since n.e.x.t
+     *
+     * @param string $key The cache key suffix (will be appended to the base key).
+     * @return bool True if the value exists in cache, false otherwise.
+     */
+    protected function hasCache(string $key): bool
+    {
+        $fullKey = $this->buildCacheKey($key);
+
+        $cache = AiClient::getCache();
+        if ($cache !== null) {
+            return $cache->has($fullKey);
+        }
+
+        return array_key_exists($fullKey, $this->localCache);
+    }
+
+    /**
+     * Gets a value from the cache, or computes and caches it if not present.
+     *
+     * @since n.e.x.t
+     *
+     * @param string                 $key      The cache key suffix (will be appended to the base key).
+     * @param callable               $callback The callback to compute the value if not cached.
+     * @param int|\DateInterval|null $ttl      The TTL for the cache entry, or null for default.
+     *                                         Ignored for local cache.
+     * @return mixed The cached or computed value.
+     */
+    protected function cached(string $key, callable $callback, $ttl = null)
+    {
+        if ($this->hasCache($key)) {
+            return $this->getCache($key);
+        }
+
+        $value = $callback();
+        $this->setCache($key, $value, $ttl);
+
+        return $value;
+    }
+
+    /**
      * Gets a value from the cache.
      *
      * @since n.e.x.t
@@ -45,12 +100,14 @@ trait WithDataCachingTrait
      */
     protected function getCache(string $key, $default = null)
     {
+        $fullKey = $this->buildCacheKey($key);
+
         $cache = AiClient::getCache();
-        if ($cache === null) {
-            return $default;
+        if ($cache !== null) {
+            return $cache->get($fullKey, $default);
         }
 
-        return $cache->get($this->buildCacheKey($key), $default);
+        return $this->localCache[$fullKey] ?? $default;
     }
 
     /**
@@ -60,17 +117,20 @@ trait WithDataCachingTrait
      *
      * @param string                $key   The cache key suffix (will be appended to the base key).
      * @param mixed                 $value The value to cache.
-     * @param int|\DateInterval|null $ttl   The TTL for the cache entry, or null for default.
-     * @return bool True on success, false on failure or if no cache is configured.
+     * @param int|\DateInterval|null $ttl   The TTL for the cache entry, or null for default. Ignored for local cache.
+     * @return bool True on success, false on failure.
      */
     protected function setCache(string $key, $value, $ttl = null): bool
     {
+        $fullKey = $this->buildCacheKey($key);
+
         $cache = AiClient::getCache();
-        if ($cache === null) {
-            return false;
+        if ($cache !== null) {
+            return $cache->set($fullKey, $value, $ttl);
         }
 
-        return $cache->set($this->buildCacheKey($key), $value, $ttl);
+        $this->localCache[$fullKey] = $value;
+        return true;
     }
 
     /**
@@ -93,16 +153,19 @@ trait WithDataCachingTrait
      * @since n.e.x.t
      *
      * @param string $key The cache key suffix (will be appended to the base key).
-     * @return bool True on success, false on failure or if no cache is configured.
+     * @return bool True on success, false on failure.
      */
     protected function clearCache(string $key): bool
     {
+        $fullKey = $this->buildCacheKey($key);
+
         $cache = AiClient::getCache();
-        if ($cache === null) {
-            return false;
+        if ($cache !== null) {
+            return $cache->delete($fullKey);
         }
 
-        return $cache->delete($this->buildCacheKey($key));
+        unset($this->localCache[$fullKey]);
+        return true;
     }
 
     /**

--- a/src/Common/Traits/WithDataCachingTrait.php
+++ b/src/Common/Traits/WithDataCachingTrait.php
@@ -14,6 +14,15 @@ use WordPress\AiClient\AiClient;
 trait WithDataCachingTrait
 {
     /**
+     * Gets the cache key suffixes managed by this object.
+     *
+     * @since n.e.x.t
+     *
+     * @return list<string> The cache key suffixes.
+     */
+    abstract protected function getCachedKeys(): array;
+
+    /**
      * Gets the base cache key for this object.
      *
      * The base cache key is used as a prefix for all cache keys managed by this object.
@@ -62,6 +71,20 @@ trait WithDataCachingTrait
         }
 
         return $cache->set($this->buildCacheKey($key), $value, $ttl);
+    }
+
+    /**
+     * Invalidates all caches managed by this object.
+     *
+     * @since n.e.x.t
+     *
+     * @return void
+     */
+    public function invalidateCaches(): void
+    {
+        foreach ($this->getCachedKeys() as $key) {
+            $this->clearCache($key);
+        }
     }
 
     /**

--- a/src/Providers/ApiBasedImplementation/AbstractApiBasedModelMetadataDirectory.php
+++ b/src/Providers/ApiBasedImplementation/AbstractApiBasedModelMetadataDirectory.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace WordPress\AiClient\Providers\ApiBasedImplementation;
 
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Common\Contracts\CachesDataInterface;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+use WordPress\AiClient\Common\Traits\WithDataCachingTrait;
 use WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface;
 use WordPress\AiClient\Providers\Http\Contracts\WithHttpTransporterInterface;
 use WordPress\AiClient\Providers\Http\Contracts\WithRequestAuthenticationInterface;
@@ -20,15 +23,21 @@ use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 abstract class AbstractApiBasedModelMetadataDirectory implements
     ModelMetadataDirectoryInterface,
     WithHttpTransporterInterface,
-    WithRequestAuthenticationInterface
+    WithRequestAuthenticationInterface,
+    CachesDataInterface
 {
     use WithHttpTransporterTrait;
     use WithRequestAuthenticationTrait;
+    use WithDataCachingTrait;
 
     /**
-     * @var ?array<string, ModelMetadata> Map of model ID to model metadata, effectively for caching.
+     * The cache key suffix for the models list.
+     *
+     * @since n.e.x.t
+     *
+     * @var string
      */
-    private ?array $modelMetadataMap = null;
+    private const MODELS_CACHE_KEY = 'models';
 
     /**
      * {@inheritDoc}
@@ -77,10 +86,32 @@ abstract class AbstractApiBasedModelMetadataDirectory implements
      */
     private function getModelMetadataMap(): array
     {
-        if ($this->modelMetadataMap === null) {
-            $this->modelMetadataMap = $this->sendListModelsRequest();
-        }
-        return $this->modelMetadataMap;
+        /** @var array<string, ModelMetadata> */
+        return $this->cached(
+            self::MODELS_CACHE_KEY,
+            fn () => $this->sendListModelsRequest(),
+            86400
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    protected function getCachedKeys(): array
+    {
+        return [self::MODELS_CACHE_KEY];
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    protected function getBaseCacheKey(): string
+    {
+        return 'ai_client_' . AiClient::VERSION . '_' . md5(static::class);
     }
 
     /**

--- a/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleModelMetadataDirectory.php
+++ b/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleModelMetadataDirectory.php
@@ -81,7 +81,7 @@ abstract class AbstractOpenAiCompatibleModelMetadataDirectory extends AbstractAp
      */
     protected function getCacheKey(): string
     {
-        return 'ai_client_models_' . md5(static::class);
+        return 'ai_client_models_' . AiClient::VERSION . '_' . md5(static::class);
     }
 
     /**

--- a/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleModelMetadataDirectory.php
+++ b/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleModelMetadataDirectory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WordPress\AiClient\Providers\OpenAiCompatibleImplementation;
 
+use WordPress\AiClient\AiClient;
 use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiBasedModelMetadataDirectory;
 use WordPress\AiClient\Providers\Http\DTO\Request;
 use WordPress\AiClient\Providers\Http\DTO\Response;
@@ -20,6 +21,8 @@ use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
  * providers that have adopted OpenAI's models API specification as a standard interface.
  *
  * @since 0.1.0
+ *
+ * @phpstan-import-type ModelMetadataArrayShape from ModelMetadata
  */
 abstract class AbstractOpenAiCompatibleModelMetadataDirectory extends AbstractApiBasedModelMetadataDirectory
 {
@@ -30,6 +33,19 @@ abstract class AbstractOpenAiCompatibleModelMetadataDirectory extends AbstractAp
      */
     protected function sendListModelsRequest(): array
     {
+        $cache = AiClient::getCache();
+        $cacheKey = $this->getCacheKey();
+
+        // Try to get cached data.
+        if ($cache !== null) {
+            $cachedData = $cache->get($cacheKey);
+            if (is_array($cachedData)) {
+                /** @var array<string, ModelMetadataArrayShape> $cachedData */
+                return $this->hydrateModelMetadataMap($cachedData);
+            }
+        }
+
+        // Fetch from API.
         $httpTransporter = $this->getHttpTransporter();
 
         $request = $this->createRequest(HttpMethodEnum::GET(), 'models');
@@ -43,6 +59,61 @@ abstract class AbstractOpenAiCompatibleModelMetadataDirectory extends AbstractAp
         $modelMetadataMap = [];
         foreach ($modelsMetadataList as $modelMetadata) {
             $modelMetadataMap[$modelMetadata->getId()] = $modelMetadata;
+        }
+
+        // Store in cache.
+        if ($cache !== null) {
+            $cache->set($cacheKey, $this->dehydrateModelMetadataMap($modelMetadataMap));
+        }
+
+        return $modelMetadataMap;
+    }
+
+    /**
+     * Gets the cache key for this directory.
+     *
+     * The cache key is unique per child class to ensure different providers
+     * don't share cached model data.
+     *
+     * @since n.e.x.t
+     *
+     * @return string The cache key.
+     */
+    protected function getCacheKey(): string
+    {
+        return 'ai_client_models_' . md5(static::class);
+    }
+
+    /**
+     * Converts a model metadata map to an array format suitable for caching.
+     *
+     * @since n.e.x.t
+     *
+     * @param array<string, ModelMetadata> $modelMetadataMap The model metadata map.
+     * @return array<string, array<string, mixed>> The dehydrated data.
+     */
+    private function dehydrateModelMetadataMap(array $modelMetadataMap): array
+    {
+        $data = [];
+        foreach ($modelMetadataMap as $modelId => $modelMetadata) {
+            $data[$modelId] = $modelMetadata->toArray();
+        }
+        return $data;
+    }
+
+    /**
+     * Converts cached array data back to a model metadata map.
+     *
+     * @since n.e.x.t
+     *
+     * @param array<string, ModelMetadataArrayShape> $cachedData The cached data.
+     * @return array<string, ModelMetadata> The hydrated model metadata map.
+     */
+    private function hydrateModelMetadataMap(array $cachedData): array
+    {
+        $modelMetadataMap = [];
+        foreach ($cachedData as $modelId => $modelData) {
+            $modelMetadataMap[$modelId] = ModelMetadata::fromArray($modelData);
         }
         return $modelMetadataMap;
     }

--- a/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleModelMetadataDirectory.php
+++ b/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleModelMetadataDirectory.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace WordPress\AiClient\Providers\OpenAiCompatibleImplementation;
 
-use WordPress\AiClient\AiClient;
-use WordPress\AiClient\Common\Contracts\CachesDataInterface;
-use WordPress\AiClient\Common\Traits\WithDataCachingTrait;
 use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiBasedModelMetadataDirectory;
 use WordPress\AiClient\Providers\Http\DTO\Request;
 use WordPress\AiClient\Providers\Http\DTO\Response;
@@ -23,21 +20,9 @@ use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
  * providers that have adopted OpenAI's models API specification as a standard interface.
  *
  * @since 0.1.0
- *
- * @phpstan-import-type ModelMetadataArrayShape from ModelMetadata
  */
-abstract class AbstractOpenAiCompatibleModelMetadataDirectory extends AbstractApiBasedModelMetadataDirectory implements
-    CachesDataInterface
+abstract class AbstractOpenAiCompatibleModelMetadataDirectory extends AbstractApiBasedModelMetadataDirectory
 {
-    use WithDataCachingTrait;
-
-    /**
-     * The cache key suffix for the models list.
-     *
-     * @var string
-     */
-    private const MODELS_CACHE_KEY = 'models';
-
     /**
      * {@inheritDoc}
      *
@@ -45,14 +30,6 @@ abstract class AbstractOpenAiCompatibleModelMetadataDirectory extends AbstractAp
      */
     protected function sendListModelsRequest(): array
     {
-        // Try to get cached data.
-        $cachedData = $this->getCache(self::MODELS_CACHE_KEY);
-        if (is_array($cachedData)) {
-            /** @var array<string, ModelMetadataArrayShape> $cachedData */
-            return $this->hydrateModelMetadataMap($cachedData);
-        }
-
-        // Fetch from API.
         $httpTransporter = $this->getHttpTransporter();
 
         $request = $this->createRequest(HttpMethodEnum::GET(), 'models');
@@ -60,71 +37,14 @@ abstract class AbstractOpenAiCompatibleModelMetadataDirectory extends AbstractAp
         $response = $httpTransporter->send($request);
 
         $this->throwIfNotSuccessful($response);
+
         $modelsMetadataList = $this->parseResponseToModelMetadataList($response);
 
-        // Parse list to map.
         $modelMetadataMap = [];
         foreach ($modelsMetadataList as $modelMetadata) {
             $modelMetadataMap[$modelMetadata->getId()] = $modelMetadata;
         }
 
-        // Store in cache for 1 day.
-        $this->setCache(self::MODELS_CACHE_KEY, $this->dehydrateModelMetadataMap($modelMetadataMap), 86400);
-
-        return $modelMetadataMap;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @since n.e.x.t
-     */
-    protected function getCachedKeys(): array
-    {
-        return [self::MODELS_CACHE_KEY];
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @since n.e.x.t
-     */
-    protected function getBaseCacheKey(): string
-    {
-        return 'ai_client_' . AiClient::VERSION . '_' . md5(static::class);
-    }
-
-    /**
-     * Converts a model metadata map to an array format suitable for caching.
-     *
-     * @since n.e.x.t
-     *
-     * @param array<string, ModelMetadata> $modelMetadataMap The model metadata map.
-     * @return array<string, array<string, mixed>> The dehydrated data.
-     */
-    private function dehydrateModelMetadataMap(array $modelMetadataMap): array
-    {
-        $data = [];
-        foreach ($modelMetadataMap as $modelId => $modelMetadata) {
-            $data[$modelId] = $modelMetadata->toArray();
-        }
-        return $data;
-    }
-
-    /**
-     * Converts cached array data back to a model metadata map.
-     *
-     * @since n.e.x.t
-     *
-     * @param array<string, ModelMetadataArrayShape> $cachedData The cached data.
-     * @return array<string, ModelMetadata> The hydrated model metadata map.
-     */
-    private function hydrateModelMetadataMap(array $cachedData): array
-    {
-        $modelMetadataMap = [];
-        foreach ($cachedData as $modelId => $modelData) {
-            $modelMetadataMap[$modelId] = ModelMetadata::fromArray($modelData);
-        }
         return $modelMetadataMap;
     }
 

--- a/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleModelMetadataDirectory.php
+++ b/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleModelMetadataDirectory.php
@@ -79,9 +79,9 @@ abstract class AbstractOpenAiCompatibleModelMetadataDirectory extends AbstractAp
      *
      * @since n.e.x.t
      */
-    public function invalidateCaches(): void
+    protected function getCachedKeys(): array
     {
-        $this->clearCache(self::MODELS_CACHE_KEY);
+        return [self::MODELS_CACHE_KEY];
     }
 
     /**

--- a/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleModelMetadataDirectory.php
+++ b/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleModelMetadataDirectory.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace WordPress\AiClient\Providers\OpenAiCompatibleImplementation;
 
 use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Common\Contracts\CachesDataInterface;
+use WordPress\AiClient\Common\Traits\WithDataCachingTrait;
 use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiBasedModelMetadataDirectory;
 use WordPress\AiClient\Providers\Http\DTO\Request;
 use WordPress\AiClient\Providers\Http\DTO\Response;
@@ -24,8 +26,18 @@ use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
  *
  * @phpstan-import-type ModelMetadataArrayShape from ModelMetadata
  */
-abstract class AbstractOpenAiCompatibleModelMetadataDirectory extends AbstractApiBasedModelMetadataDirectory
+abstract class AbstractOpenAiCompatibleModelMetadataDirectory extends AbstractApiBasedModelMetadataDirectory implements
+    CachesDataInterface
 {
+    use WithDataCachingTrait;
+
+    /**
+     * The cache key suffix for the models list.
+     *
+     * @var string
+     */
+    private const MODELS_CACHE_KEY = 'models';
+
     /**
      * {@inheritDoc}
      *
@@ -33,16 +45,11 @@ abstract class AbstractOpenAiCompatibleModelMetadataDirectory extends AbstractAp
      */
     protected function sendListModelsRequest(): array
     {
-        $cache = AiClient::getCache();
-        $cacheKey = $this->getCacheKey();
-
         // Try to get cached data.
-        if ($cache !== null) {
-            $cachedData = $cache->get($cacheKey);
-            if (is_array($cachedData)) {
-                /** @var array<string, ModelMetadataArrayShape> $cachedData */
-                return $this->hydrateModelMetadataMap($cachedData);
-            }
+        $cachedData = $this->getCache(self::MODELS_CACHE_KEY);
+        if (is_array($cachedData)) {
+            /** @var array<string, ModelMetadataArrayShape> $cachedData */
+            return $this->hydrateModelMetadataMap($cachedData);
         }
 
         // Fetch from API.
@@ -61,27 +68,30 @@ abstract class AbstractOpenAiCompatibleModelMetadataDirectory extends AbstractAp
             $modelMetadataMap[$modelMetadata->getId()] = $modelMetadata;
         }
 
-        // Store in cache.
-        if ($cache !== null) {
-            $cache->set($cacheKey, $this->dehydrateModelMetadataMap($modelMetadataMap));
-        }
+        // Store in cache for 1 day.
+        $this->setCache(self::MODELS_CACHE_KEY, $this->dehydrateModelMetadataMap($modelMetadataMap), 86400);
 
         return $modelMetadataMap;
     }
 
     /**
-     * Gets the cache key for this directory.
-     *
-     * The cache key is unique per child class to ensure different providers
-     * don't share cached model data.
+     * {@inheritDoc}
      *
      * @since n.e.x.t
-     *
-     * @return string The cache key.
      */
-    protected function getCacheKey(): string
+    public function invalidateCaches(): void
     {
-        return 'ai_client_models_' . AiClient::VERSION . '_' . md5(static::class);
+        $this->clearCache(self::MODELS_CACHE_KEY);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    protected function getBaseCacheKey(): string
+    {
+        return 'ai_client_' . AiClient::VERSION . '_' . md5(static::class);
     }
 
     /**

--- a/tests/mocks/MockCache.php
+++ b/tests/mocks/MockCache.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Tests\mocks;
+
+use DateInterval;
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * Mock cache for testing.
+ *
+ * This simple implementation stores values in memory and tracks
+ * cache operations for testing purposes.
+ */
+class MockCache implements CacheInterface
+{
+    /**
+     * @var array<string, mixed> The cached values.
+     */
+    private array $cache = [];
+
+    /**
+     * @var list<array{operation: string, key: string, value?: mixed}> The recorded operations.
+     */
+    private array $operations = [];
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param string $key The cache key.
+     * @param mixed $default Default value to return if key doesn't exist.
+     * @return mixed The cached value or default.
+     */
+    public function get($key, $default = null)
+    {
+        $this->operations[] = ['operation' => 'get', 'key' => $key];
+        return $this->cache[$key] ?? $default;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param string $key The cache key.
+     * @param mixed $value The value to cache.
+     * @param int|DateInterval|null $ttl The TTL (ignored in mock).
+     * @return bool True on success.
+     */
+    public function set($key, $value, $ttl = null): bool
+    {
+        $this->operations[] = ['operation' => 'set', 'key' => $key, 'value' => $value];
+        $this->cache[$key] = $value;
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param string $key The cache key.
+     * @return bool True on success.
+     */
+    public function delete($key): bool
+    {
+        $this->operations[] = ['operation' => 'delete', 'key' => $key];
+        unset($this->cache[$key]);
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return bool True on success.
+     */
+    public function clear(): bool
+    {
+        $this->operations[] = ['operation' => 'clear', 'key' => ''];
+        $this->cache = [];
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param iterable<string> $keys The cache keys.
+     * @param mixed $default Default value for missing keys.
+     * @return iterable<string, mixed> The cached values.
+     */
+    public function getMultiple($keys, $default = null): iterable
+    {
+        $result = [];
+        foreach ($keys as $key) {
+            $result[$key] = $this->get($key, $default);
+        }
+        return $result;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param iterable<string, mixed> $values The values to cache.
+     * @param int|DateInterval|null $ttl The TTL (ignored in mock).
+     * @return bool True on success.
+     */
+    public function setMultiple($values, $ttl = null): bool
+    {
+        foreach ($values as $key => $value) {
+            $this->set($key, $value, $ttl);
+        }
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param iterable<string> $keys The cache keys.
+     * @return bool True on success.
+     */
+    public function deleteMultiple($keys): bool
+    {
+        foreach ($keys as $key) {
+            $this->delete($key);
+        }
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param string $key The cache key.
+     * @return bool True if key exists.
+     */
+    public function has($key): bool
+    {
+        $this->operations[] = ['operation' => 'has', 'key' => $key];
+        return array_key_exists($key, $this->cache);
+    }
+
+    /**
+     * Gets all recorded operations.
+     *
+     * @return list<array{operation: string, key: string, value?: mixed}> The recorded operations.
+     */
+    public function getOperations(): array
+    {
+        return $this->operations;
+    }
+
+    /**
+     * Gets operations filtered by type.
+     *
+     * @param string $operation The operation type (get, set, delete, clear, has).
+     * @return list<array{operation: string, key: string, value?: mixed}> The filtered operations.
+     */
+    public function getOperationsOfType(string $operation): array
+    {
+        return array_values(array_filter(
+            $this->operations,
+            static function (array $op) use ($operation): bool {
+                return $op['operation'] === $operation;
+            }
+        ));
+    }
+
+    /**
+     * Clears all recorded operations.
+     *
+     * @return void
+     */
+    public function clearOperations(): void
+    {
+        $this->operations = [];
+    }
+
+    /**
+     * Gets a value directly from the cache without recording an operation.
+     *
+     * @param string $key The cache key.
+     * @return mixed The cached value or null.
+     */
+    public function peek(string $key)
+    {
+        return $this->cache[$key] ?? null;
+    }
+
+    /**
+     * Sets a value directly in the cache without recording an operation.
+     *
+     * @param string $key The cache key.
+     * @param mixed $value The value to cache.
+     * @return void
+     */
+    public function seed(string $key, $value): void
+    {
+        $this->cache[$key] = $value;
+    }
+}

--- a/tests/unit/Providers/ApiBasedImplementation/AbstractApiBasedModelMetadataDirectoryTest.php
+++ b/tests/unit/Providers/ApiBasedImplementation/AbstractApiBasedModelMetadataDirectoryTest.php
@@ -14,7 +14,7 @@ use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 class AbstractApiBasedModelMetadataDirectoryTest extends TestCase
 {
     /**
-     * @var ModelMetadata[]
+     * @var array<string, ModelMetadata>
      */
     private array $mockModels;
 

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleModelMetadataDirectoryTest.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleModelMetadataDirectoryTest.php
@@ -5,14 +5,16 @@ declare(strict_types=1);
 namespace WordPress\AiClient\Tests\unit\Providers\OpenAiCompatibleImplementation;
 
 use PHPUnit\Framework\TestCase;
+use WordPress\AiClient\AiClient;
 use WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface;
 use WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface;
 use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Http\Exception\ClientException;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Tests\mocks\MockCache;
 
 /**
- * @covers \WordPress\AiClient\Providers\ApiBasedImplementation\AbstractOpenAiCompatibleModelMetadataDirectory
+ * @covers \WordPress\AiClient\Providers\OpenAiCompatibleImplementation\AbstractOpenAiCompatibleModelMetadataDirectory
  */
 class AbstractOpenAiCompatibleModelMetadataDirectoryTest extends TestCase
 {
@@ -32,6 +34,14 @@ class AbstractOpenAiCompatibleModelMetadataDirectoryTest extends TestCase
 
         $this->mockHttpTransporter = $this->createMock(HttpTransporterInterface::class);
         $this->mockRequestAuthentication = $this->createMock(RequestAuthenticationInterface::class);
+    }
+
+    protected function tearDown(): void
+    {
+        // Reset static cache state after each test.
+        AiClient::setCache(null);
+
+        parent::tearDown();
     }
 
     /**
@@ -112,5 +122,253 @@ class AbstractOpenAiCompatibleModelMetadataDirectoryTest extends TestCase
         $this->expectExceptionMessage('Bad Request (400) - Invalid parameter provided.');
 
         $directory->listModelMetadata();
+    }
+
+    /**
+     * Tests that cache is used when available and populated.
+     *
+     * @return void
+     */
+    public function testSendListModelsRequestUsesCachedData(): void
+    {
+        $cache = new MockCache();
+
+        // Seed the cache with model data.
+        $cacheKey = 'ai_client_models_' . md5(MockOpenAiCompatibleModelMetadataDirectory::class);
+        $cachedData = [
+            'cached-model-a' => [
+                'id' => 'cached-model-a',
+                'name' => 'Cached Model A',
+                'supportedCapabilities' => ['text_generation'],
+                'supportedOptions' => [],
+            ],
+            'cached-model-b' => [
+                'id' => 'cached-model-b',
+                'name' => 'Cached Model B',
+                'supportedCapabilities' => ['text_generation'],
+                'supportedOptions' => [],
+            ],
+        ];
+        $cache->seed($cacheKey, $cachedData);
+
+        AiClient::setCache($cache);
+
+        // HTTP transporter should NOT be called when cache is available.
+        $this->mockHttpTransporter
+            ->expects($this->never())
+            ->method('send');
+
+        $directory = new MockOpenAiCompatibleModelMetadataDirectory(
+            $this->mockHttpTransporter,
+            $this->mockRequestAuthentication,
+            null,
+            [],
+            true
+        );
+
+        $modelsMetadata = $directory->listModelMetadata();
+
+        $this->assertCount(2, $modelsMetadata);
+        $this->assertEquals('cached-model-a', $modelsMetadata[0]->getId());
+        $this->assertEquals('Cached Model A', $modelsMetadata[0]->getName());
+        $this->assertEquals('cached-model-b', $modelsMetadata[1]->getId());
+        $this->assertEquals('Cached Model B', $modelsMetadata[1]->getName());
+    }
+
+    /**
+     * Tests that API response is cached when cache is available but empty.
+     *
+     * @return void
+     */
+    public function testSendListModelsRequestCachesApiResponse(): void
+    {
+        $cache = new MockCache();
+        AiClient::setCache($cache);
+
+        $response = new Response(200, [], '{"data": [{"id": "api-model-a"}, {"id": "api-model-b"}]}');
+
+        $this->mockRequestAuthentication
+            ->expects($this->once())
+            ->method('authenticateRequest')
+            ->willReturnArgument(0);
+
+        $this->mockHttpTransporter
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn($response);
+
+        $directory = new MockOpenAiCompatibleModelMetadataDirectory(
+            $this->mockHttpTransporter,
+            $this->mockRequestAuthentication,
+            null,
+            [],
+            true
+        );
+
+        $modelsMetadata = $directory->listModelMetadata();
+
+        $this->assertCount(2, $modelsMetadata);
+        $this->assertEquals('api-model-a', $modelsMetadata[0]->getId());
+        $this->assertEquals('api-model-b', $modelsMetadata[1]->getId());
+
+        // Verify cache was written.
+        $setOperations = $cache->getOperationsOfType('set');
+        $this->assertCount(1, $setOperations);
+
+        $cacheKey = 'ai_client_models_' . md5(MockOpenAiCompatibleModelMetadataDirectory::class);
+        $this->assertEquals($cacheKey, $setOperations[0]['key']);
+
+        // Verify cached data structure.
+        $cachedData = $cache->peek($cacheKey);
+        $this->assertIsArray($cachedData);
+        $this->assertArrayHasKey('api-model-a', $cachedData);
+        $this->assertArrayHasKey('api-model-b', $cachedData);
+        $this->assertEquals('api-model-a', $cachedData['api-model-a']['id']);
+    }
+
+    /**
+     * Tests that API is called when no cache is configured.
+     *
+     * @return void
+     */
+    public function testSendListModelsRequestWorksWithoutCache(): void
+    {
+        // Ensure no cache is set.
+        AiClient::setCache(null);
+
+        $response = new Response(200, [], '{"data": [{"id": "model-x"}]}');
+
+        $this->mockRequestAuthentication
+            ->expects($this->once())
+            ->method('authenticateRequest')
+            ->willReturnArgument(0);
+
+        $this->mockHttpTransporter
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn($response);
+
+        $directory = new MockOpenAiCompatibleModelMetadataDirectory(
+            $this->mockHttpTransporter,
+            $this->mockRequestAuthentication,
+            null,
+            [],
+            true
+        );
+
+        $modelsMetadata = $directory->listModelMetadata();
+
+        $this->assertCount(1, $modelsMetadata);
+        $this->assertEquals('model-x', $modelsMetadata[0]->getId());
+    }
+
+    /**
+     * Tests that cache keys are unique per child class.
+     *
+     * @return void
+     */
+    public function testCacheKeysAreUniquePerChildClass(): void
+    {
+        $cache = new MockCache();
+        AiClient::setCache($cache);
+
+        // Seed cache for the first directory class.
+        $cacheKey1 = 'ai_client_models_' . md5(MockOpenAiCompatibleModelMetadataDirectory::class);
+        $cachedData1 = [
+            'first-provider-model' => [
+                'id' => 'first-provider-model',
+                'name' => 'First Provider Model',
+                'supportedCapabilities' => ['text_generation'],
+                'supportedOptions' => [],
+            ],
+        ];
+        $cache->seed($cacheKey1, $cachedData1);
+
+        // Seed cache for the second directory class with different data.
+        $cacheKey2 = 'ai_client_models_' . md5(AnotherMockOpenAiCompatibleModelMetadataDirectory::class);
+        $cachedData2 = [
+            'second-provider-model' => [
+                'id' => 'second-provider-model',
+                'name' => 'Second Provider Model',
+                'supportedCapabilities' => ['text_generation'],
+                'supportedOptions' => [],
+            ],
+        ];
+        $cache->seed($cacheKey2, $cachedData2);
+
+        // Verify keys are different.
+        $this->assertNotEquals($cacheKey1, $cacheKey2);
+
+        // HTTP transporter should NOT be called for either directory.
+        $this->mockHttpTransporter
+            ->expects($this->never())
+            ->method('send');
+
+        $directory1 = new MockOpenAiCompatibleModelMetadataDirectory(
+            $this->mockHttpTransporter,
+            $this->mockRequestAuthentication,
+            null,
+            [],
+            true
+        );
+
+        $directory2 = new AnotherMockOpenAiCompatibleModelMetadataDirectory(
+            $this->mockHttpTransporter,
+            $this->mockRequestAuthentication,
+            null,
+            [],
+            true
+        );
+
+        $models1 = $directory1->listModelMetadata();
+        $models2 = $directory2->listModelMetadata();
+
+        // Each directory should get its own cached data.
+        $this->assertCount(1, $models1);
+        $this->assertEquals('first-provider-model', $models1[0]->getId());
+
+        $this->assertCount(1, $models2);
+        $this->assertEquals('second-provider-model', $models2[0]->getId());
+    }
+
+    /**
+     * Tests that cache is bypassed when cached data is not an array.
+     *
+     * @return void
+     */
+    public function testCacheBypassedWhenCachedDataIsInvalid(): void
+    {
+        $cache = new MockCache();
+        AiClient::setCache($cache);
+
+        // Seed cache with invalid data (not an array).
+        $cacheKey = 'ai_client_models_' . md5(MockOpenAiCompatibleModelMetadataDirectory::class);
+        $cache->seed($cacheKey, 'invalid-string-data');
+
+        $response = new Response(200, [], '{"data": [{"id": "fresh-model"}]}');
+
+        $this->mockRequestAuthentication
+            ->expects($this->once())
+            ->method('authenticateRequest')
+            ->willReturnArgument(0);
+
+        // API should be called because cached data is invalid.
+        $this->mockHttpTransporter
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn($response);
+
+        $directory = new MockOpenAiCompatibleModelMetadataDirectory(
+            $this->mockHttpTransporter,
+            $this->mockRequestAuthentication,
+            null,
+            [],
+            true
+        );
+
+        $modelsMetadata = $directory->listModelMetadata();
+
+        $this->assertCount(1, $modelsMetadata);
+        $this->assertEquals('fresh-model', $modelsMetadata[0]->getId());
     }
 }

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleModelMetadataDirectoryTest.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleModelMetadataDirectoryTest.php
@@ -134,7 +134,7 @@ class AbstractOpenAiCompatibleModelMetadataDirectoryTest extends TestCase
         $cache = new MockCache();
 
         // Seed the cache with model data.
-        $cacheKey = 'ai_client_models_' . md5(MockOpenAiCompatibleModelMetadataDirectory::class);
+        $cacheKey = 'ai_client_models_' . AiClient::VERSION . '_' . md5(MockOpenAiCompatibleModelMetadataDirectory::class);
         $cachedData = [
             'cached-model-a' => [
                 'id' => 'cached-model-a',
@@ -215,7 +215,7 @@ class AbstractOpenAiCompatibleModelMetadataDirectoryTest extends TestCase
         $setOperations = $cache->getOperationsOfType('set');
         $this->assertCount(1, $setOperations);
 
-        $cacheKey = 'ai_client_models_' . md5(MockOpenAiCompatibleModelMetadataDirectory::class);
+        $cacheKey = 'ai_client_models_' . AiClient::VERSION . '_' . md5(MockOpenAiCompatibleModelMetadataDirectory::class);
         $this->assertEquals($cacheKey, $setOperations[0]['key']);
 
         // Verify cached data structure.
@@ -273,7 +273,7 @@ class AbstractOpenAiCompatibleModelMetadataDirectoryTest extends TestCase
         AiClient::setCache($cache);
 
         // Seed cache for the first directory class.
-        $cacheKey1 = 'ai_client_models_' . md5(MockOpenAiCompatibleModelMetadataDirectory::class);
+        $cacheKey1 = 'ai_client_models_' . AiClient::VERSION . '_' . md5(MockOpenAiCompatibleModelMetadataDirectory::class);
         $cachedData1 = [
             'first-provider-model' => [
                 'id' => 'first-provider-model',
@@ -285,7 +285,7 @@ class AbstractOpenAiCompatibleModelMetadataDirectoryTest extends TestCase
         $cache->seed($cacheKey1, $cachedData1);
 
         // Seed cache for the second directory class with different data.
-        $cacheKey2 = 'ai_client_models_' . md5(AnotherMockOpenAiCompatibleModelMetadataDirectory::class);
+        $cacheKey2 = 'ai_client_models_' . AiClient::VERSION . '_' . md5(AnotherMockOpenAiCompatibleModelMetadataDirectory::class);
         $cachedData2 = [
             'second-provider-model' => [
                 'id' => 'second-provider-model',
@@ -342,7 +342,7 @@ class AbstractOpenAiCompatibleModelMetadataDirectoryTest extends TestCase
         AiClient::setCache($cache);
 
         // Seed cache with invalid data (not an array).
-        $cacheKey = 'ai_client_models_' . md5(MockOpenAiCompatibleModelMetadataDirectory::class);
+        $cacheKey = 'ai_client_models_' . AiClient::VERSION . '_' . md5(MockOpenAiCompatibleModelMetadataDirectory::class);
         $cache->seed($cacheKey, 'invalid-string-data');
 
         $response = new Response(200, [], '{"data": [{"id": "fresh-model"}]}');

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleModelMetadataDirectoryTest.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleModelMetadataDirectoryTest.php
@@ -133,22 +133,22 @@ class AbstractOpenAiCompatibleModelMetadataDirectoryTest extends TestCase
     {
         $cache = new MockCache();
 
-        // Seed the cache with model data.
+        // Seed the cache with ModelMetadata objects.
         $cacheKey = 'ai_client_' . AiClient::VERSION . '_'
             . md5(MockOpenAiCompatibleModelMetadataDirectory::class) . '_models';
         $cachedData = [
-            'cached-model-a' => [
+            'cached-model-a' => ModelMetadata::fromArray([
                 'id' => 'cached-model-a',
                 'name' => 'Cached Model A',
                 'supportedCapabilities' => ['text_generation'],
                 'supportedOptions' => [],
-            ],
-            'cached-model-b' => [
+            ]),
+            'cached-model-b' => ModelMetadata::fromArray([
                 'id' => 'cached-model-b',
                 'name' => 'Cached Model B',
                 'supportedCapabilities' => ['text_generation'],
                 'supportedOptions' => [],
-            ],
+            ]),
         ];
         $cache->seed($cacheKey, $cachedData);
 
@@ -220,12 +220,13 @@ class AbstractOpenAiCompatibleModelMetadataDirectoryTest extends TestCase
             . md5(MockOpenAiCompatibleModelMetadataDirectory::class) . '_models';
         $this->assertEquals($cacheKey, $setOperations[0]['key']);
 
-        // Verify cached data structure.
+        // Verify cached data structure (ModelMetadata objects).
         $cachedData = $cache->peek($cacheKey);
         $this->assertIsArray($cachedData);
         $this->assertArrayHasKey('api-model-a', $cachedData);
         $this->assertArrayHasKey('api-model-b', $cachedData);
-        $this->assertEquals('api-model-a', $cachedData['api-model-a']['id']);
+        $this->assertInstanceOf(ModelMetadata::class, $cachedData['api-model-a']);
+        $this->assertEquals('api-model-a', $cachedData['api-model-a']->getId());
     }
 
     /**
@@ -274,16 +275,16 @@ class AbstractOpenAiCompatibleModelMetadataDirectoryTest extends TestCase
         $cache = new MockCache();
         AiClient::setCache($cache);
 
-        // Seed cache for the first directory class.
+        // Seed cache for the first directory class with ModelMetadata objects.
         $cacheKey1 = 'ai_client_' . AiClient::VERSION . '_'
             . md5(MockOpenAiCompatibleModelMetadataDirectory::class) . '_models';
         $cachedData1 = [
-            'first-provider-model' => [
+            'first-provider-model' => ModelMetadata::fromArray([
                 'id' => 'first-provider-model',
                 'name' => 'First Provider Model',
                 'supportedCapabilities' => ['text_generation'],
                 'supportedOptions' => [],
-            ],
+            ]),
         ];
         $cache->seed($cacheKey1, $cachedData1);
 
@@ -291,12 +292,12 @@ class AbstractOpenAiCompatibleModelMetadataDirectoryTest extends TestCase
         $cacheKey2 = 'ai_client_' . AiClient::VERSION . '_'
             . md5(AnotherMockOpenAiCompatibleModelMetadataDirectory::class) . '_models';
         $cachedData2 = [
-            'second-provider-model' => [
+            'second-provider-model' => ModelMetadata::fromArray([
                 'id' => 'second-provider-model',
                 'name' => 'Second Provider Model',
                 'supportedCapabilities' => ['text_generation'],
                 'supportedOptions' => [],
-            ],
+            ]),
         ];
         $cache->seed($cacheKey2, $cachedData2);
 
@@ -333,47 +334,5 @@ class AbstractOpenAiCompatibleModelMetadataDirectoryTest extends TestCase
 
         $this->assertCount(1, $models2);
         $this->assertEquals('second-provider-model', $models2[0]->getId());
-    }
-
-    /**
-     * Tests that cache is bypassed when cached data is not an array.
-     *
-     * @return void
-     */
-    public function testCacheBypassedWhenCachedDataIsInvalid(): void
-    {
-        $cache = new MockCache();
-        AiClient::setCache($cache);
-
-        // Seed cache with invalid data (not an array).
-        $cacheKey = 'ai_client_' . AiClient::VERSION . '_'
-            . md5(MockOpenAiCompatibleModelMetadataDirectory::class) . '_models';
-        $cache->seed($cacheKey, 'invalid-string-data');
-
-        $response = new Response(200, [], '{"data": [{"id": "fresh-model"}]}');
-
-        $this->mockRequestAuthentication
-            ->expects($this->once())
-            ->method('authenticateRequest')
-            ->willReturnArgument(0);
-
-        // API should be called because cached data is invalid.
-        $this->mockHttpTransporter
-            ->expects($this->once())
-            ->method('send')
-            ->willReturn($response);
-
-        $directory = new MockOpenAiCompatibleModelMetadataDirectory(
-            $this->mockHttpTransporter,
-            $this->mockRequestAuthentication,
-            null,
-            [],
-            true
-        );
-
-        $modelsMetadata = $directory->listModelMetadata();
-
-        $this->assertCount(1, $modelsMetadata);
-        $this->assertEquals('fresh-model', $modelsMetadata[0]->getId());
     }
 }

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleModelMetadataDirectoryTest.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleModelMetadataDirectoryTest.php
@@ -134,7 +134,8 @@ class AbstractOpenAiCompatibleModelMetadataDirectoryTest extends TestCase
         $cache = new MockCache();
 
         // Seed the cache with model data.
-        $cacheKey = 'ai_client_models_' . AiClient::VERSION . '_' . md5(MockOpenAiCompatibleModelMetadataDirectory::class);
+        $cacheKey = 'ai_client_' . AiClient::VERSION . '_'
+            . md5(MockOpenAiCompatibleModelMetadataDirectory::class) . '_models';
         $cachedData = [
             'cached-model-a' => [
                 'id' => 'cached-model-a',
@@ -215,7 +216,8 @@ class AbstractOpenAiCompatibleModelMetadataDirectoryTest extends TestCase
         $setOperations = $cache->getOperationsOfType('set');
         $this->assertCount(1, $setOperations);
 
-        $cacheKey = 'ai_client_models_' . AiClient::VERSION . '_' . md5(MockOpenAiCompatibleModelMetadataDirectory::class);
+        $cacheKey = 'ai_client_' . AiClient::VERSION . '_'
+            . md5(MockOpenAiCompatibleModelMetadataDirectory::class) . '_models';
         $this->assertEquals($cacheKey, $setOperations[0]['key']);
 
         // Verify cached data structure.
@@ -273,7 +275,8 @@ class AbstractOpenAiCompatibleModelMetadataDirectoryTest extends TestCase
         AiClient::setCache($cache);
 
         // Seed cache for the first directory class.
-        $cacheKey1 = 'ai_client_models_' . AiClient::VERSION . '_' . md5(MockOpenAiCompatibleModelMetadataDirectory::class);
+        $cacheKey1 = 'ai_client_' . AiClient::VERSION . '_'
+            . md5(MockOpenAiCompatibleModelMetadataDirectory::class) . '_models';
         $cachedData1 = [
             'first-provider-model' => [
                 'id' => 'first-provider-model',
@@ -285,7 +288,8 @@ class AbstractOpenAiCompatibleModelMetadataDirectoryTest extends TestCase
         $cache->seed($cacheKey1, $cachedData1);
 
         // Seed cache for the second directory class with different data.
-        $cacheKey2 = 'ai_client_models_' . AiClient::VERSION . '_' . md5(AnotherMockOpenAiCompatibleModelMetadataDirectory::class);
+        $cacheKey2 = 'ai_client_' . AiClient::VERSION . '_'
+            . md5(AnotherMockOpenAiCompatibleModelMetadataDirectory::class) . '_models';
         $cachedData2 = [
             'second-provider-model' => [
                 'id' => 'second-provider-model',
@@ -342,7 +346,8 @@ class AbstractOpenAiCompatibleModelMetadataDirectoryTest extends TestCase
         AiClient::setCache($cache);
 
         // Seed cache with invalid data (not an array).
-        $cacheKey = 'ai_client_models_' . AiClient::VERSION . '_' . md5(MockOpenAiCompatibleModelMetadataDirectory::class);
+        $cacheKey = 'ai_client_' . AiClient::VERSION . '_'
+            . md5(MockOpenAiCompatibleModelMetadataDirectory::class) . '_models';
         $cache->seed($cacheKey, 'invalid-string-data');
 
         $response = new Response(200, [], '{"data": [{"id": "fresh-model"}]}');

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/AnotherMockOpenAiCompatibleModelMetadataDirectory.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/AnotherMockOpenAiCompatibleModelMetadataDirectory.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Tests\unit\Providers\OpenAiCompatibleImplementation;
+
+/**
+ * Second mock class for testing that cache keys are unique per child class.
+ *
+ * This class extends the main mock but represents a different "provider" to verify
+ * that the cache key generation properly differentiates between child classes.
+ */
+class AnotherMockOpenAiCompatibleModelMetadataDirectory extends MockOpenAiCompatibleModelMetadataDirectory
+{
+    // Inherits all functionality from parent.
+    // The class name difference ensures a different cache key.
+}

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/MockOpenAiCompatibleModelMetadataDirectory.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/MockOpenAiCompatibleModelMetadataDirectory.php
@@ -10,6 +10,7 @@ use WordPress\AiClient\Providers\Http\DTO\Request;
 use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 use WordPress\AiClient\Providers\OpenAiCompatibleImplementation\AbstractOpenAiCompatibleModelMetadataDirectory;
 
 /**
@@ -33,28 +34,36 @@ class MockOpenAiCompatibleModelMetadataDirectory extends AbstractOpenAiCompatibl
     private array $mockModels;
 
     /**
-     * @var callable
+     * @var callable|null
      */
     private $modelMetadataStubFactory;
+
+    /**
+     * @var bool Whether to use real ModelMetadata objects instead of stubs.
+     */
+    private bool $useRealModelMetadata;
 
     /**
      * Constructor.
      *
      * @param HttpTransporterInterface&\PHPUnit\Framework\MockObject\MockObject $mockHttpTransporter
      * @param RequestAuthenticationInterface&\PHPUnit\Framework\MockObject\MockObject $mockRequestAuthentication
-     * @param callable $modelMetadataStubFactory
+     * @param callable|null $modelMetadataStubFactory Factory for creating stubs (null to use real objects).
      * @param array<string, ModelMetadata> $mockModels
+     * @param bool $useRealModelMetadata Whether to use real ModelMetadata objects.
      */
     public function __construct(
         $mockHttpTransporter,
         $mockRequestAuthentication,
-        callable $modelMetadataStubFactory,
-        array $mockModels = []
+        ?callable $modelMetadataStubFactory = null,
+        array $mockModels = [],
+        bool $useRealModelMetadata = false
     ) {
         $this->mockHttpTransporter = $mockHttpTransporter;
         $this->mockRequestAuthentication = $mockRequestAuthentication;
         $this->modelMetadataStubFactory = $modelMetadataStubFactory;
         $this->mockModels = $mockModels;
+        $this->useRealModelMetadata = $useRealModelMetadata;
     }
 
     /**
@@ -95,12 +104,31 @@ class MockOpenAiCompatibleModelMetadataDirectory extends AbstractOpenAiCompatibl
         if (isset($data['data']) && is_array($data['data'])) {
             foreach ($data['data'] as $modelData) {
                 if (isset($modelData['id']) && is_string($modelData['id'])) {
-                    $factory = $this->modelMetadataStubFactory;
-                    $modelMetadata = $factory($modelData['id']);
-                    $modelsMetadata[] = $modelMetadata;
+                    if ($this->useRealModelMetadata) {
+                        $modelsMetadata[] = $this->createRealModelMetadata($modelData['id']);
+                    } elseif ($this->modelMetadataStubFactory !== null) {
+                        $factory = $this->modelMetadataStubFactory;
+                        $modelsMetadata[] = $factory($modelData['id']);
+                    }
                 }
             }
         }
         return $modelsMetadata;
+    }
+
+    /**
+     * Creates a real ModelMetadata instance.
+     *
+     * @param string $modelId The model ID.
+     * @return ModelMetadata The model metadata.
+     */
+    private function createRealModelMetadata(string $modelId): ModelMetadata
+    {
+        return new ModelMetadata(
+            $modelId,
+            ucfirst($modelId),
+            [CapabilityEnum::textGeneration()],
+            []
+        );
     }
 }


### PR DESCRIPTION
Resolves #141 

This PR adds optional PSR-16 caching support to the AI Client. When a cache is configured, model metadata from provider APIs (like the list of available models) is stored and reused instead of making repeated API calls. This improves performance and reduces API usage, especially useful in applications that frequently initialize the client or query model availability.

  What's new:
  - AiClient::setCache() and AiClient::getCache() for configuring a PSR-16 cache
  - psr/simple-cache added as a dependency
  - AbstractOpenAiCompatibleModelMetadataDirectory now caches /models API responses
  - Cache keys are unique per provider to prevent data conflicts
  - MockCache test helper for verifying cache behavior