### PR TITLE
Fix proper Google API implementation

### DIFF
--- a/src/ProviderImplementations/Google/GoogleImageGenerationModel.php
+++ b/src/ProviderImplementations/Google/GoogleImageGenerationModel.php
@@ -12,6 +12,8 @@ use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiBasedModel;
+use WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface;
+use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
 use WordPress\AiClient\Providers\Http\DTO\Request;
 use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
@@ -55,6 +57,24 @@ class GoogleImageGenerationModel extends AbstractApiBasedModel implements ImageG
      *
      * @since n.e.x.t
      */
+    public function getRequestAuthentication(): RequestAuthenticationInterface
+    {
+        /*
+         * Since we're calling the Google API here, we need to use the Google specific
+         * API key authentication class.
+         */
+        $requestAuthentication = parent::getRequestAuthentication();
+        if (!$requestAuthentication instanceof ApiKeyRequestAuthentication) {
+            return $requestAuthentication;
+        }
+        return new GoogleApiKeyRequestAuthentication($requestAuthentication->getApiKey());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
     public function generateImageResult(array $prompt): GenerativeAiResult
     {
         /*
@@ -65,6 +85,8 @@ class GoogleImageGenerationModel extends AbstractApiBasedModel implements ImageG
         if (str_starts_with($this->metadata()->getId(), 'gemini-')) {
             $multimodalOutputModel = new GoogleTextGenerationModel($this->metadata(), $this->providerMetadata());
             $multimodalOutputModel->setConfig($this->getConfig());
+            $multimodalOutputModel->setHttpTransporter($this->getHttpTransporter());
+            $multimodalOutputModel->setRequestAuthentication($this->getRequestAuthentication());
             $requestOptions = $this->getRequestOptions();
             if ($requestOptions) {
                 $multimodalOutputModel->setRequestOptions($requestOptions);

--- a/src/ProviderImplementations/Google/GoogleModelMetadataDirectory.php
+++ b/src/ProviderImplementations/Google/GoogleModelMetadataDirectory.php
@@ -43,8 +43,8 @@ class GoogleModelMetadataDirectory extends AbstractOpenAiCompatibleModelMetadata
     public function getRequestAuthentication(): RequestAuthenticationInterface
     {
         /*
-         * Since we're calling the primary Google API models endpoint here, we need to use the Google specific API key
-         * authentication class.
+         * Since we're calling the Google API here, we need to use the Google specific
+         * API key authentication class.
          */
         $requestAuthentication = parent::getRequestAuthentication();
         if (!$requestAuthentication instanceof ApiKeyRequestAuthentication) {

--- a/src/ProviderImplementations/Google/GoogleProvider.php
+++ b/src/ProviderImplementations/Google/GoogleProvider.php
@@ -41,6 +41,18 @@ class GoogleProvider extends AbstractApiProvider
         ModelMetadata $modelMetadata,
         ProviderMetadata $providerMetadata
     ): ModelInterface {
+        /*
+         * Temporary workaround: We don't have a clean way of returning multimodal output model classes yet,
+         * currently the implementations are separated by capability. There are a few Google models that support both
+         * text and image generation, so if we detect that the model supports image generation, we'll return the image
+         * generation model class in that case, because it's far more likely that users want to use those models for
+         * image generation. We will have to revisit that in the near future for a proper solution.
+         */
+        $capabilitiesStringList = $modelMetadata->toArray()[ModelMetadata::KEY_SUPPORTED_CAPABILITIES];
+        if (in_array('image_generation', $capabilitiesStringList, true)) {
+            return new GoogleImageGenerationModel($modelMetadata, $providerMetadata);
+        }
+
         $capabilities = $modelMetadata->getSupportedCapabilities();
         foreach ($capabilities as $capability) {
             if ($capability->isTextGeneration()) {

--- a/src/ProviderImplementations/Google/GoogleTextGenerationModel.php
+++ b/src/ProviderImplementations/Google/GoogleTextGenerationModel.php
@@ -14,6 +14,8 @@ use WordPress\AiClient\Messages\Enums\MessagePartChannelEnum;
 use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 use WordPress\AiClient\Messages\Enums\ModalityEnum;
 use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiBasedModel;
+use WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface;
+use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
 use WordPress\AiClient\Providers\Http\DTO\Request;
 use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
@@ -54,6 +56,24 @@ use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
  */
 class GoogleTextGenerationModel extends AbstractApiBasedModel implements TextGenerationModelInterface
 {
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public function getRequestAuthentication(): RequestAuthenticationInterface
+    {
+        /*
+         * Since we're calling the Google API here, we need to use the Google specific
+         * API key authentication class.
+         */
+        $requestAuthentication = parent::getRequestAuthentication();
+        if (!$requestAuthentication instanceof ApiKeyRequestAuthentication) {
+            return $requestAuthentication;
+        }
+        return new GoogleApiKeyRequestAuthentication($requestAuthentication->getApiKey());
+    }
+
     /**
      * {@inheritDoc}
      *


### PR DESCRIPTION
Follow up to #155.

I hadn't yet tested things when it was merged, so this PR has the fixes needed to actually make things work.

**Note:** A workaround is included to return the image generation specific class when using Gemini multimodal output models that _primarily_ are used for image generation. This is only since we don't have model class implementations yet that are actually multimodal. Let's discuss in a separate issue what's the best way to go about that, for a proper solution. Doesn't have to block this work.