### PR TITLE
Add anthropic-beta header for structured outputs.

### DIFF
--- a/src/ProviderImplementations/Anthropic/AnthropicTextGenerationModel.php
+++ b/src/ProviderImplementations/Anthropic/AnthropicTextGenerationModel.php
@@ -79,10 +79,18 @@ class AnthropicTextGenerationModel extends AbstractApiBasedModel implements Text
 
         $params = $this->prepareGenerateTextParams($prompt);
 
+        $headers = ['Content-Type' => 'application/json'];
+
+        // Add beta header for structured outputs if JSON schema output is requested.
+        $config = $this->getConfig();
+        if ('application/json' === $config->getOutputMimeType() && $config->getOutputSchema()) {
+            $headers['anthropic-beta'] = 'structured-outputs-2025-11-13';
+        }
+
         $request = new Request(
             HttpMethodEnum::POST(),
             AnthropicProvider::url('messages'),
-            ['Content-Type' => 'application/json'],
+            $headers,
             $params,
             $this->getRequestOptions()
         );


### PR DESCRIPTION
When requesting structured JSON output from the Anthropic API using the `output_format` parameter with a JSON schema, the API requires the `anthropic-beta: structured-outputs-2025-11-13` header to be present in the request. Without this header, Anthropic rejects the request because structured outputs is currently a beta feature that must be explicitly opted into. This fix detects when JSON schema output is configured via `getOutputMimeType()` and `getOutputSchema()` and automatically adds the required beta header, allowing structured output requests to succeed.

See [Claude Docs: Structured outputs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs)

Fixes #151.