### PR TITLE
Make HTTP transporter setup in registry more flexible to not throw discovery exception when no HTTP request is even being attempted

### DIFF
--- a/src/AiClient.php
+++ b/src/AiClient.php
@@ -13,7 +13,6 @@ use WordPress\AiClient\ProviderImplementations\Google\GoogleProvider;
 use WordPress\AiClient\ProviderImplementations\OpenAi\OpenAiProvider;
 use WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface;
 use WordPress\AiClient\Providers\Contracts\ProviderInterface;
-use WordPress\AiClient\Providers\Http\HttpTransporterFactory;
 use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WordPress\AiClient\Providers\ProviderRegistry;
@@ -109,7 +108,6 @@ class AiClient
             $registry = new ProviderRegistry();
 
             // Set up default HTTP transporter and register built-in providers.
-            $registry->setHttpTransporter(HttpTransporterFactory::createTransporter());
             $registry->registerProvider(AnthropicProvider::class);
             $registry->registerProvider(GoogleProvider::class);
             $registry->registerProvider(OpenAiProvider::class);

--- a/src/AiClient.php
+++ b/src/AiClient.php
@@ -107,7 +107,7 @@ class AiClient
         if (self::$defaultRegistry === null) {
             $registry = new ProviderRegistry();
 
-            // Set up default HTTP transporter and register built-in providers.
+            // Register built-in providers.
             $registry->registerProvider(AnthropicProvider::class);
             $registry->registerProvider(GoogleProvider::class);
             $registry->registerProvider(OpenAiProvider::class);

--- a/src/Providers/ProviderRegistry.php
+++ b/src/Providers/ProviderRegistry.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WordPress\AiClient\Providers;
 
+use Http\Discovery\Exception\NotFoundException as DiscoveryNotFoundException;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Common\Exception\RuntimeException;
 use WordPress\AiClient\Providers\Contracts\ProviderInterface;
@@ -14,6 +15,7 @@ use WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface;
 use WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface;
 use WordPress\AiClient\Providers\Http\Contracts\WithHttpTransporterInterface;
 use WordPress\AiClient\Providers\Http\Contracts\WithRequestAuthenticationInterface;
+use WordPress\AiClient\Providers\Http\HttpTransporterFactory;
 use WordPress\AiClient\Providers\Http\Traits\WithHttpTransporterTrait;
 use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
@@ -85,14 +87,26 @@ class ProviderRegistry implements WithHttpTransporterInterface
         // If there is already a HTTP transporter instance set, hook it up to the provider as needed.
         try {
             $httpTransporter = $this->getHttpTransporter();
-            $this->setHttpTransporterForProvider($className, $httpTransporter);
         } catch (RuntimeException $e) {
             /*
              * If this fails, it's okay. There is no defined sequence between setting the HTTP transporter in the
              * registry and registering providers in it, so it might be that the transporter is set later. It will be
              * hooked up then.
-             * Therefore we can simply ignore this exception.
+             * But for now we can ignore this exception and attempt to set the default HTTP transporter, if possible.
              */
+            try {
+                $this->setHttpTransporter(HttpTransporterFactory::createTransporter());
+            } catch (DiscoveryNotFoundException $e) {
+                /*
+                 * If no HTTP client implementation can be discovered yet, we can ignore this for now.
+                 * It might be set later, so it's not a hard error at this point.
+                 * We'll try again the next time a provider is registered, or maybe by that time an explicit
+                 * HTTP transporter will have been set.
+                 */
+            }
+        }
+        if (isset($httpTransporter)) {
+            $this->setHttpTransporterForProvider($className, $httpTransporter);
         }
 
         // Hook up the request authentication instance, using a default if not set.

--- a/tests/unit/Providers/ProviderRegistryTest.php
+++ b/tests/unit/Providers/ProviderRegistryTest.php
@@ -571,29 +571,6 @@ class ProviderRegistryTest extends TestCase
     }
 
     /**
-     * Tests bindModelDependencies without HTTP transporter when model needs it.
-     *
-     * @return void
-     */
-    public function testBindModelDependenciesWithoutHttpTransporter(): void
-    {
-        // Register provider but don't set HTTP transporter
-        $this->registry->registerProvider(MockProvider::class);
-
-        // Create a mock model instance that implements WithHttpTransporterInterface
-        $modelInstance = $this->createMock(MockModel::class);
-        $modelInstance->expects($this->once())
-            ->method('providerMetadata')
-            ->willReturn(MockProvider::metadata());
-
-        // Expect runtime exception when trying to get HTTP transporter that isn't set
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('HttpTransporterInterface instance not set');
-
-        $this->registry->bindModelDependencies($modelInstance);
-    }
-
-    /**
      * Tests setProviderRequestAuthentication throws exception when provider expects specific auth type but gets
      * another.
      *


### PR DESCRIPTION
This partially will fix https://github.com/WordPress/wp-ai-client/issues/41 - specifically, when a provider is registered before an HTTP client has been configured in the PSR-17 discovery mechanism.

This is probably not sufficient by itself as a proper fix for that issue, but it's already a partial fix, which means a workaround will no longer be needed. And since this library is not meant to be _only_ used with WordPress, it makes sense to optimize for general flexibility:

* The problem is that currently, whenever someone tries to register a provider, the default registry is initialized.
* And since the HTTP transporter is set as part of that, we run into an exception if no 3P code has provided an HTTP client yet. This is bad DX because there's no point in throwing an exception at this point, given that no HTTP request is even being attempted.

This PR fixes that, by dynamically attempting to set the default HTTP transporter when no (other) HTTP transporter has already been set, and doing that in a way that is forgiving in terms of the discovery exception.

cc @martin-helmich @LukasFritzeDev