### PR TITLE
Adds integration test scaffolding

### DIFF
--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -58,4 +58,4 @@ jobs:
       run: composer install --prefer-dist --no-progress
 
     - name: Run unit tests
-      run: composer phpunit
+      run: composer test:unit

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,11 @@ GEMINI.md
 
 .idea/
 .vscode/
+
+############
+## Environment
+############
+
+.env
+.env.local
+.env.*.local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,32 @@ Note that `list<string>` and `string[]` _are not_ the same. The latter is an ali
 
 All code must be backward compatible with PHP 7.4, which is the minimum required PHP version for this project.
 
+## Running Tests
+
+### Unit Tests
+
+```bash
+composer test:unit
+```
+
+### Integration Tests
+
+Integration tests make real API calls and require provider API keys. Create a `.env` file in the project root:
+
+```
+OPENAI_API_KEY=sk-...
+GOOGLE_API_KEY=...
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Then run:
+
+```bash
+composer test:integration
+```
+
+Tests for providers without keys will be skipped automatically.
+
 ## Branch naming conventions
 
 There are a few protected branch naming conventions:

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "phpstan/phpstan": "~2.1",
         "phpunit/phpunit": "^9.5 || ^10.0",
         "slevomat/coding-standard": "^8.20",
-        "squizlabs/php_codesniffer": "^3.7"
+        "squizlabs/php_codesniffer": "^3.7",
+        "symfony/dotenv": "^5.4"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -76,6 +77,9 @@
         "phpcbf": "phpcbf",
         "phpcs": "phpcs",
         "phpstan": "phpstan analyze --memory-limit=256M",
-        "phpunit": "phpunit"
+        "phpunit": "phpunit",
+        "test": "@test:unit",
+        "test:unit": "phpunit --testsuite unit",
+        "test:integration": "phpunit --configuration phpunit-integration.xml.dist"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce3bd24175778c6b366b7c38ef11dd07",
+    "content-hash": "61d50540cdf6ab250eb7fed927280793",
     "packages": [
         {
             "name": "php-http/discovery",
@@ -3341,6 +3341,77 @@
                 }
             ],
             "time": "2024-09-25T14:11:13+00:00"
+        },
+        {
+            "name": "symfony/dotenv",
+            "version": "v5.4.48",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dotenv.git",
+                "reference": "08013403089c8a126c968179179b817a552841ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/08013403089c8a126c968179179b817a552841ab",
+                "reference": "08013403089c8a126c968179179b817a552841ab",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3"
+            },
+            "require-dev": {
+                "symfony/console": "^4.4|^5.0|^6.0",
+                "symfony/process": "^4.4|^5.0|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Dotenv\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Registers environment variables from a .env file",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/dotenv/tree/v5.4.48"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-27T09:33:00+00:00"
         },
         {
             "name": "symfony/options-resolver",

--- a/docs/PREPUBLISH-CHECKLIST.md
+++ b/docs/PREPUBLISH-CHECKLIST.md
@@ -2,6 +2,7 @@
 
 Before publishing a new release, you MUST check all of the following:
 
+- Run integration tests to verify provider functionality: `composer test:integration`
 - Ensure there is no `n.e.x.t` usage in any PHP file.
   - If there is, replace these `n.e.x.t` strings with the new release's version number.
 - Ensure the [`WordPress\AiClient\AiClient`](https://github.com/WordPress/php-ai-client/blob/trunk/src/AiClient.php) `VERSION` constant is set to the new release's version number.

--- a/phpunit-integration.xml.dist
+++ b/phpunit-integration.xml.dist
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/integration/bootstrap.php"
          cacheResultFile=".phpunit.cache/test-results"
          executionOrder="depends,defects"
-         forceCoversAnnotation="true"
-         beStrictAboutCoversAnnotation="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
          failOnRisky="true"
@@ -13,18 +11,8 @@
          verbose="true"
          colors="true">
     <testsuites>
-        <testsuite name="unit">
-            <directory suffix="Test.php">tests/unit</directory>
-        </testsuite>
         <testsuite name="integration">
             <directory suffix="Test.php">tests/integration</directory>
         </testsuite>
     </testsuites>
-
-    <coverage cacheDirectory=".phpunit.cache/code-coverage"
-              processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
 </phpunit>

--- a/tests/integration/Anthropic/FunctionCallingIntegrationTest.php
+++ b/tests/integration/Anthropic/FunctionCallingIntegrationTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Tests\integration\Anthropic;
+
+use PHPUnit\Framework\TestCase;
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\AiClient\Tests\integration\traits\IntegrationTestTrait;
+use WordPress\AiClient\Tools\DTO\FunctionCall;
+use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
+
+/**
+ * Integration tests for Anthropic function calling.
+ *
+ * These tests make real API calls to Anthropic and require the ANTHROPIC_API_KEY
+ * environment variable to be set.
+ *
+ * @group integration
+ * @group anthropic
+ * @group function-calling
+ *
+ * @coversNothing
+ */
+class FunctionCallingIntegrationTest extends TestCase
+{
+    use IntegrationTestTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->requireApiKey('ANTHROPIC_API_KEY');
+    }
+
+    /**
+     * Tests function calling with multiple arguments.
+     */
+    public function testFunctionCallingWithMultipleArguments(): void
+    {
+        $getWeather = new FunctionDeclaration(
+            'get_weather',
+            'Get the current weather for a location',
+            [
+                'type' => 'object',
+                'properties' => [
+                    'location' => [
+                        'type' => 'string',
+                        'description' => 'The city and state, e.g. San Francisco, CA',
+                    ],
+                    'unit' => [
+                        'type' => 'string',
+                        'enum' => ['celsius', 'fahrenheit'],
+                        'description' => 'The temperature unit',
+                    ],
+                ],
+                'required' => ['location', 'unit'],
+            ]
+        );
+
+        $result = AiClient::prompt('What is the weather in Paris, France? Use celsius.')
+            ->usingProvider('anthropic')
+            ->usingFunctionDeclarations($getWeather)
+            ->generateTextResult();
+
+        $this->assertInstanceOf(GenerativeAiResult::class, $result);
+
+        $functionCall = $this->extractFunctionCall($result);
+        $this->assertNotNull($functionCall, 'Expected a function call in the response');
+        $this->assertEquals('get_weather', $functionCall->getName());
+
+        $args = $functionCall->getArgs();
+        $this->assertIsArray($args);
+        $this->assertArrayHasKey('location', $args);
+        $this->assertArrayHasKey('unit', $args);
+        $this->assertStringContainsStringIgnoringCase('paris', $args['location']);
+        $this->assertEquals('celsius', $args['unit']);
+    }
+
+    /**
+     * Tests function calling with no arguments.
+     */
+    public function testFunctionCallingWithNoArguments(): void
+    {
+        $sayHi = new FunctionDeclaration(
+            'say_hi',
+            'Says hi to the user. Call this function when the user asks for a greeting.',
+            null
+        );
+
+        $result = AiClient::prompt('Please greet me.')
+            ->usingProvider('anthropic')
+            ->usingFunctionDeclarations($sayHi)
+            ->generateTextResult();
+
+        $this->assertInstanceOf(GenerativeAiResult::class, $result);
+
+        $functionCall = $this->extractFunctionCall($result);
+        $this->assertNotNull($functionCall, 'Expected a function call in the response');
+        $this->assertEquals('say_hi', $functionCall->getName());
+
+        // Args should be null or empty for a no-argument function
+        $args = $functionCall->getArgs();
+        $this->assertTrue(
+            $args === null || $args === [] || $args === (object) [],
+            'Expected no arguments for say_hi function'
+        );
+    }
+
+    /**
+     * Tests function calling with a non-object parameter (string).
+     *
+     * Note: This tests a function where the parameter schema is a simple string,
+     * not an object with properties. This is a less common but valid use case.
+     */
+    public function testFunctionCallingWithStringParameter(): void
+    {
+        $sayHiTo = new FunctionDeclaration(
+            'say_hi_to',
+            'Says hi to a specific person by name',
+            [
+                'type' => 'string',
+                'description' => 'The name of the person to greet',
+            ]
+        );
+
+        $result = AiClient::prompt('Say hi to Bob.')
+            ->usingProvider('anthropic')
+            ->usingFunctionDeclarations($sayHiTo)
+            ->generateTextResult();
+
+        $this->assertInstanceOf(GenerativeAiResult::class, $result);
+
+        $functionCall = $this->extractFunctionCall($result);
+        $this->assertNotNull($functionCall, 'Expected a function call in the response');
+        $this->assertEquals('say_hi_to', $functionCall->getName());
+
+        $args = $functionCall->getArgs();
+        // The args should be the string "Bob" or contain "Bob" somewhere
+        $this->assertNotNull($args, 'Expected arguments for say_hi_to function');
+        if (is_string($args)) {
+            $this->assertStringContainsStringIgnoringCase('bob', $args);
+        } elseif (is_array($args)) {
+            // Some providers may wrap the string in an object/array
+            $argsJson = json_encode($args);
+            $this->assertStringContainsStringIgnoringCase('bob', $argsJson);
+        }
+    }
+
+    /**
+     * Extracts the first function call from a result.
+     *
+     * @param GenerativeAiResult $result The result to extract from.
+     * @return FunctionCall|null The function call or null if not found.
+     */
+    private function extractFunctionCall(GenerativeAiResult $result): ?FunctionCall
+    {
+        $candidates = $result->getCandidates();
+        if (empty($candidates)) {
+            return null;
+        }
+
+        $message = $candidates[0]->getMessage();
+        foreach ($message->getParts() as $part) {
+            if ($part->getType()->isFunctionCall()) {
+                return $part->getFunctionCall();
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/integration/Anthropic/TextGenerationIntegrationTest.php
+++ b/tests/integration/Anthropic/TextGenerationIntegrationTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Tests\integration\Anthropic;
+
+use PHPUnit\Framework\TestCase;
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\AiClient\Tests\integration\traits\IntegrationTestTrait;
+
+/**
+ * Integration tests for Anthropic text generation.
+ *
+ * These tests make real API calls to Anthropic and require the ANTHROPIC_API_KEY
+ * environment variable to be set.
+ *
+ * @group integration
+ * @group anthropic
+ *
+ * @coversNothing
+ */
+class TextGenerationIntegrationTest extends TestCase
+{
+    use IntegrationTestTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->requireApiKey('ANTHROPIC_API_KEY');
+    }
+
+    /**
+     * Tests basic text generation with a simple prompt.
+     */
+    public function testSimpleTextGeneration(): void
+    {
+        $result = AiClient::prompt('Say "hello" and nothing else.')
+            ->usingProvider('anthropic')
+            ->generateTextResult();
+
+        $this->assertInstanceOf(GenerativeAiResult::class, $result);
+        $this->assertStringContainsStringIgnoringCase('hello', $result->toText());
+    }
+
+    /**
+     * Tests text generation with a system message.
+     */
+    public function testTextGenerationWithSystemMessage(): void
+    {
+        $result = AiClient::prompt('What is your name?')
+            ->usingProvider('anthropic')
+            ->usingSystemInstruction('You are an assistant named "TestBot". Always introduce yourself by name.')
+            ->generateTextResult();
+
+        $this->assertInstanceOf(GenerativeAiResult::class, $result);
+        $this->assertStringContainsStringIgnoringCase('TestBot', $result->toText());
+    }
+
+    /**
+     * Tests that text generation returns token usage information.
+     */
+    public function testTextGenerationReturnsTokenUsage(): void
+    {
+        $result = AiClient::prompt('Say "hello" and nothing else.')
+            ->usingProvider('anthropic')
+            ->generateTextResult();
+
+        $tokenUsage = $result->getTokenUsage();
+        $this->assertGreaterThan(0, $tokenUsage->getPromptTokens());
+        $this->assertGreaterThan(0, $tokenUsage->getCompletionTokens());
+        $this->assertGreaterThan(0, $tokenUsage->getTotalTokens());
+    }
+}

--- a/tests/integration/Google/FunctionCallingIntegrationTest.php
+++ b/tests/integration/Google/FunctionCallingIntegrationTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Tests\integration\Google;
+
+use PHPUnit\Framework\TestCase;
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\AiClient\Tests\integration\traits\IntegrationTestTrait;
+use WordPress\AiClient\Tools\DTO\FunctionCall;
+use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
+
+/**
+ * Integration tests for Google function calling.
+ *
+ * These tests make real API calls to Google and require the GOOGLE_API_KEY
+ * environment variable to be set.
+ *
+ * @group integration
+ * @group google
+ * @group function-calling
+ *
+ * @coversNothing
+ */
+class FunctionCallingIntegrationTest extends TestCase
+{
+    use IntegrationTestTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->requireApiKey('GOOGLE_API_KEY');
+    }
+
+    /**
+     * Tests function calling with multiple arguments.
+     */
+    public function testFunctionCallingWithMultipleArguments(): void
+    {
+        $getWeather = new FunctionDeclaration(
+            'get_weather',
+            'Get the current weather for a location',
+            [
+                'type' => 'object',
+                'properties' => [
+                    'location' => [
+                        'type' => 'string',
+                        'description' => 'The city and state, e.g. San Francisco, CA',
+                    ],
+                    'unit' => [
+                        'type' => 'string',
+                        'enum' => ['celsius', 'fahrenheit'],
+                        'description' => 'The temperature unit',
+                    ],
+                ],
+                'required' => ['location', 'unit'],
+            ]
+        );
+
+        $result = AiClient::prompt('What is the weather in Paris, France? Use celsius.')
+            ->usingProvider('google')
+            ->usingFunctionDeclarations($getWeather)
+            ->generateTextResult();
+
+        $this->assertInstanceOf(GenerativeAiResult::class, $result);
+
+        $functionCall = $this->extractFunctionCall($result);
+        $this->assertNotNull($functionCall, 'Expected a function call in the response');
+        $this->assertEquals('get_weather', $functionCall->getName());
+
+        $args = $functionCall->getArgs();
+        $this->assertIsArray($args);
+        $this->assertArrayHasKey('location', $args);
+        $this->assertArrayHasKey('unit', $args);
+        $this->assertStringContainsStringIgnoringCase('paris', $args['location']);
+        $this->assertEquals('celsius', $args['unit']);
+    }
+
+    /**
+     * Tests function calling with no arguments.
+     */
+    public function testFunctionCallingWithNoArguments(): void
+    {
+        $sayHi = new FunctionDeclaration(
+            'say_hi',
+            'Says hi to the user. Call this function when the user asks for a greeting.',
+            null
+        );
+
+        $result = AiClient::prompt('Please greet me.')
+            ->usingProvider('google')
+            ->usingFunctionDeclarations($sayHi)
+            ->generateTextResult();
+
+        $this->assertInstanceOf(GenerativeAiResult::class, $result);
+
+        $functionCall = $this->extractFunctionCall($result);
+        $this->assertNotNull($functionCall, 'Expected a function call in the response');
+        $this->assertEquals('say_hi', $functionCall->getName());
+
+        // Args should be null or empty for a no-argument function
+        $args = $functionCall->getArgs();
+        $this->assertTrue(
+            $args === null || $args === [] || $args === (object) [],
+            'Expected no arguments for say_hi function'
+        );
+    }
+
+    /**
+     * Tests function calling with a non-object parameter (string).
+     *
+     * Note: This tests a function where the parameter schema is a simple string,
+     * not an object with properties. This is a less common but valid use case.
+     */
+    public function testFunctionCallingWithStringParameter(): void
+    {
+        $sayHiTo = new FunctionDeclaration(
+            'say_hi_to',
+            'Says hi to a specific person by name',
+            [
+                'type' => 'string',
+                'description' => 'The name of the person to greet',
+            ]
+        );
+
+        $result = AiClient::prompt('Say hi to Bob.')
+            ->usingProvider('google')
+            ->usingFunctionDeclarations($sayHiTo)
+            ->generateTextResult();
+
+        $this->assertInstanceOf(GenerativeAiResult::class, $result);
+
+        $functionCall = $this->extractFunctionCall($result);
+        $this->assertNotNull($functionCall, 'Expected a function call in the response');
+        $this->assertEquals('say_hi_to', $functionCall->getName());
+
+        $args = $functionCall->getArgs();
+        // The args should be the string "Bob" or contain "Bob" somewhere
+        $this->assertNotNull($args, 'Expected arguments for say_hi_to function');
+        if (is_string($args)) {
+            $this->assertStringContainsStringIgnoringCase('bob', $args);
+        } elseif (is_array($args)) {
+            // Some providers may wrap the string in an object/array
+            $argsJson = json_encode($args);
+            $this->assertStringContainsStringIgnoringCase('bob', $argsJson);
+        }
+    }
+
+    /**
+     * Extracts the first function call from a result.
+     *
+     * @param GenerativeAiResult $result The result to extract from.
+     * @return FunctionCall|null The function call or null if not found.
+     */
+    private function extractFunctionCall(GenerativeAiResult $result): ?FunctionCall
+    {
+        $candidates = $result->getCandidates();
+        if (empty($candidates)) {
+            return null;
+        }
+
+        $message = $candidates[0]->getMessage();
+        foreach ($message->getParts() as $part) {
+            if ($part->getType()->isFunctionCall()) {
+                return $part->getFunctionCall();
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/integration/Google/TextGenerationIntegrationTest.php
+++ b/tests/integration/Google/TextGenerationIntegrationTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Tests\integration\Google;
+
+use PHPUnit\Framework\TestCase;
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\AiClient\Tests\integration\traits\IntegrationTestTrait;
+
+/**
+ * Integration tests for Google text generation.
+ *
+ * These tests make real API calls to Google and require the GOOGLE_API_KEY
+ * environment variable to be set.
+ *
+ * @group integration
+ * @group google
+ *
+ * @coversNothing
+ */
+class TextGenerationIntegrationTest extends TestCase
+{
+    use IntegrationTestTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->requireApiKey('GOOGLE_API_KEY');
+    }
+
+    /**
+     * Tests basic text generation with a simple prompt.
+     */
+    public function testSimpleTextGeneration(): void
+    {
+        $result = AiClient::prompt('Say "hello" and nothing else.')
+            ->usingProvider('google')
+            ->generateTextResult();
+
+        $this->assertInstanceOf(GenerativeAiResult::class, $result);
+        $this->assertStringContainsStringIgnoringCase('hello', $result->toText());
+    }
+
+    /**
+     * Tests text generation with a system message.
+     */
+    public function testTextGenerationWithSystemMessage(): void
+    {
+        $result = AiClient::prompt('What is your name?')
+            ->usingProvider('google')
+            ->usingSystemInstruction('You are an assistant named "TestBot". Always introduce yourself by name.')
+            ->generateTextResult();
+
+        $this->assertInstanceOf(GenerativeAiResult::class, $result);
+        $this->assertStringContainsStringIgnoringCase('TestBot', $result->toText());
+    }
+
+    /**
+     * Tests that text generation returns token usage information.
+     */
+    public function testTextGenerationReturnsTokenUsage(): void
+    {
+        $result = AiClient::prompt('Say "hello" and nothing else.')
+            ->usingProvider('google')
+            ->generateTextResult();
+
+        $tokenUsage = $result->getTokenUsage();
+        $this->assertGreaterThan(0, $tokenUsage->getPromptTokens());
+        $this->assertGreaterThan(0, $tokenUsage->getCompletionTokens());
+        $this->assertGreaterThan(0, $tokenUsage->getTotalTokens());
+    }
+}

--- a/tests/integration/OpenAi/FunctionCallingIntegrationTest.php
+++ b/tests/integration/OpenAi/FunctionCallingIntegrationTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Tests\integration\OpenAi;
+
+use PHPUnit\Framework\TestCase;
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\AiClient\Tests\integration\traits\IntegrationTestTrait;
+use WordPress\AiClient\Tools\DTO\FunctionCall;
+use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
+
+/**
+ * Integration tests for OpenAI function calling.
+ *
+ * These tests make real API calls to OpenAI and require the OPENAI_API_KEY
+ * environment variable to be set.
+ *
+ * @group integration
+ * @group openai
+ * @group function-calling
+ *
+ * @coversNothing
+ */
+class FunctionCallingIntegrationTest extends TestCase
+{
+    use IntegrationTestTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->requireApiKey('OPENAI_API_KEY');
+    }
+
+    /**
+     * Tests function calling with multiple arguments.
+     */
+    public function testFunctionCallingWithMultipleArguments(): void
+    {
+        $getWeather = new FunctionDeclaration(
+            'get_weather',
+            'Get the current weather for a location',
+            [
+                'type' => 'object',
+                'properties' => [
+                    'location' => [
+                        'type' => 'string',
+                        'description' => 'The city and state, e.g. San Francisco, CA',
+                    ],
+                    'unit' => [
+                        'type' => 'string',
+                        'enum' => ['celsius', 'fahrenheit'],
+                        'description' => 'The temperature unit',
+                    ],
+                ],
+                'required' => ['location', 'unit'],
+            ]
+        );
+
+        $result = AiClient::prompt('What is the weather in Paris, France? Use celsius.')
+            ->usingProvider('openai')
+            ->usingFunctionDeclarations($getWeather)
+            ->generateTextResult();
+
+        $this->assertInstanceOf(GenerativeAiResult::class, $result);
+
+        $functionCall = $this->extractFunctionCall($result);
+        $this->assertNotNull($functionCall, 'Expected a function call in the response');
+        $this->assertEquals('get_weather', $functionCall->getName());
+
+        $args = $functionCall->getArgs();
+        $this->assertIsArray($args);
+        $this->assertArrayHasKey('location', $args);
+        $this->assertArrayHasKey('unit', $args);
+        $this->assertStringContainsStringIgnoringCase('paris', $args['location']);
+        $this->assertEquals('celsius', $args['unit']);
+    }
+
+    /**
+     * Tests function calling with no arguments.
+     */
+    public function testFunctionCallingWithNoArguments(): void
+    {
+        $sayHi = new FunctionDeclaration(
+            'say_hi',
+            'Says hi to the user. Call this function when the user asks for a greeting.',
+            null
+        );
+
+        $result = AiClient::prompt('Please greet me.')
+            ->usingProvider('openai')
+            ->usingFunctionDeclarations($sayHi)
+            ->generateTextResult();
+
+        $this->assertInstanceOf(GenerativeAiResult::class, $result);
+
+        $functionCall = $this->extractFunctionCall($result);
+        $this->assertNotNull($functionCall, 'Expected a function call in the response');
+        $this->assertEquals('say_hi', $functionCall->getName());
+
+        // Args should be null or empty for a no-argument function
+        $args = $functionCall->getArgs();
+        $this->assertTrue(
+            $args === null || $args === [] || $args === (object) [],
+            'Expected no arguments for say_hi function'
+        );
+    }
+
+    /**
+     * Tests function calling with a non-object parameter (string).
+     *
+     * Note: This tests a function where the parameter schema is a simple string,
+     * not an object with properties. This is a less common but valid use case.
+     */
+    public function testFunctionCallingWithStringParameter(): void
+    {
+        $sayHiTo = new FunctionDeclaration(
+            'say_hi_to',
+            'Says hi to a specific person by name',
+            [
+                'type' => 'string',
+                'description' => 'The name of the person to greet',
+            ]
+        );
+
+        $result = AiClient::prompt('Say hi to Bob.')
+            ->usingProvider('openai')
+            ->usingFunctionDeclarations($sayHiTo)
+            ->generateTextResult();
+
+        $this->assertInstanceOf(GenerativeAiResult::class, $result);
+
+        $functionCall = $this->extractFunctionCall($result);
+        $this->assertNotNull($functionCall, 'Expected a function call in the response');
+        $this->assertEquals('say_hi_to', $functionCall->getName());
+
+        $args = $functionCall->getArgs();
+        // The args should be the string "Bob" or contain "Bob" somewhere
+        $this->assertNotNull($args, 'Expected arguments for say_hi_to function');
+        if (is_string($args)) {
+            $this->assertStringContainsStringIgnoringCase('bob', $args);
+        } elseif (is_array($args)) {
+            // Some providers may wrap the string in an object/array
+            $argsJson = json_encode($args);
+            $this->assertStringContainsStringIgnoringCase('bob', $argsJson);
+        }
+    }
+
+    /**
+     * Extracts the first function call from a result.
+     *
+     * @param GenerativeAiResult $result The result to extract from.
+     * @return FunctionCall|null The function call or null if not found.
+     */
+    private function extractFunctionCall(GenerativeAiResult $result): ?FunctionCall
+    {
+        $candidates = $result->getCandidates();
+        if (empty($candidates)) {
+            return null;
+        }
+
+        $message = $candidates[0]->getMessage();
+        foreach ($message->getParts() as $part) {
+            if ($part->getType()->isFunctionCall()) {
+                return $part->getFunctionCall();
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/integration/OpenAi/TextGenerationIntegrationTest.php
+++ b/tests/integration/OpenAi/TextGenerationIntegrationTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Tests\integration\OpenAi;
+
+use PHPUnit\Framework\TestCase;
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\AiClient\Tests\integration\traits\IntegrationTestTrait;
+
+/**
+ * Integration tests for OpenAI text generation.
+ *
+ * These tests make real API calls to OpenAI and require the OPENAI_API_KEY
+ * environment variable to be set.
+ *
+ * @group integration
+ * @group openai
+ *
+ * @coversNothing
+ */
+class TextGenerationIntegrationTest extends TestCase
+{
+    use IntegrationTestTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->requireApiKey('OPENAI_API_KEY');
+    }
+
+    /**
+     * Tests basic text generation with a simple prompt.
+     */
+    public function testSimpleTextGeneration(): void
+    {
+        $result = AiClient::prompt('Say "hello" and nothing else.')
+            ->usingProvider('openai')
+            ->generateTextResult();
+
+        $this->assertInstanceOf(GenerativeAiResult::class, $result);
+        $this->assertStringContainsStringIgnoringCase('hello', $result->toText());
+    }
+
+    /**
+     * Tests text generation with a system message.
+     */
+    public function testTextGenerationWithSystemMessage(): void
+    {
+        $result = AiClient::prompt('What is your name?')
+            ->usingProvider('openai')
+            ->usingSystemInstruction('You are an assistant named "TestBot". Always introduce yourself by name.')
+            ->generateTextResult();
+
+        $this->assertInstanceOf(GenerativeAiResult::class, $result);
+        $this->assertStringContainsStringIgnoringCase('TestBot', $result->toText());
+    }
+
+    /**
+     * Tests that text generation returns token usage information.
+     */
+    public function testTextGenerationReturnsTokenUsage(): void
+    {
+        $result = AiClient::prompt('Say "hello" and nothing else.')
+            ->usingProvider('openai')
+            ->generateTextResult();
+
+        $tokenUsage = $result->getTokenUsage();
+        $this->assertGreaterThan(0, $tokenUsage->getPromptTokens());
+        $this->assertGreaterThan(0, $tokenUsage->getCompletionTokens());
+        $this->assertGreaterThan(0, $tokenUsage->getTotalTokens());
+    }
+}

--- a/tests/integration/bootstrap.php
+++ b/tests/integration/bootstrap.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Bootstrap file for integration tests.
+ *
+ * Loads environment variables from .env file before running tests.
+ */
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use Symfony\Component\Dotenv\Dotenv;
+
+$envFile = dirname(__DIR__, 2) . '/.env';
+if (file_exists($envFile)) {
+    $dotenv = new Dotenv();
+    // Enable putenv() so getenv() works (used by ProviderRegistry for API keys)
+    $dotenv->usePutenv(true);
+    $dotenv->load($envFile);
+}

--- a/tests/integration/traits/IntegrationTestTrait.php
+++ b/tests/integration/traits/IntegrationTestTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Tests\integration\traits;
+
+/**
+ * Trait providing shared functionality for integration tests.
+ *
+ * This trait provides utility methods for integration tests that make
+ * real API calls to AI providers.
+ */
+trait IntegrationTestTrait
+{
+    /**
+     * Skips the test if the specified environment variable is not set.
+     *
+     * @param string $envVar The name of the environment variable to check.
+     */
+    protected function requireApiKey(string $envVar): void
+    {
+        // Check both $_ENV (populated by symfony/dotenv) and getenv() (shell environment)
+        $value = $_ENV[$envVar] ?? getenv($envVar);
+        if ($value === false || $value === '' || $value === null) {
+            $this->markTestSkipped("Skipping: {$envVar} environment variable is not set.");
+        }
+    }
+}


### PR DESCRIPTION
This introduces integration tests for running actual prompts against the models. As this has grown it's become more obvious that the only way to really catch Provider issues is by running prompts. While we would do some basic testing locally, having a proper suite of tests is really useful for catching things and avoiding regressions.

These tests can't be run automatically as they require credentials. As such, we'll want to run this manually periodically when developing, and every time before publishing a new release.

API keys can be loaded as part of the environment or put in a `.env` file.

NOTE:
There is a purposely failing test for OpenAI function calling. This will be resolved in #175 as a broader effort to correct issues with function calling across the provider APIs.