### PR TITLE
Fix: correctly sets the transporter on subsequent try

### DIFF
--- a/src/Providers/ProviderRegistry.php
+++ b/src/Providers/ProviderRegistry.php
@@ -96,6 +96,7 @@ class ProviderRegistry implements WithHttpTransporterInterface
              */
             try {
                 $this->setHttpTransporter(HttpTransporterFactory::createTransporter());
+                $httpTransporter = $this->getHttpTransporter();
             } catch (DiscoveryNotFoundException $e) {
                 /*
                  * If no HTTP client implementation can be discovered yet, we can ignore this for now.


### PR DESCRIPTION
Turns out when we caught and retried setting the transporter we weren't setting the variable. This would cause the first alphabetical Provider (Anthropic) to not have access to the transporter. Oops!

This was caught by #176 — proof that it's valuable already! 😆 