### PR TITLE
Fix: Send text-only messages as plain string in Responses API Fixes #182

### DIFF
--- a/src/ProviderImplementations/OpenAi/OpenAiTextGenerationModel.php
+++ b/src/ProviderImplementations/OpenAi/OpenAiTextGenerationModel.php
@@ -247,6 +247,15 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
             return null;
         }
 
+        // Special handling for text-only messages: send text directly as a string
+        if (count($parts) === 1 && $parts[0]->getType()->isText()) {
+            $text = $parts[0]->getText();
+            return [
+                'role' => $this->getMessageRoleString($message->getRole()),
+                'content' => $text, // Send text directly as a string
+            ];
+        }
+
         $content = [];
         foreach ($parts as $part) {
             $partData = $this->getMessagePartData($part);

--- a/tests/unit/ProviderImplementations/OpenAi/OpenAiTextGenerationModelTest.php
+++ b/tests/unit/ProviderImplementations/OpenAi/OpenAiTextGenerationModelTest.php
@@ -181,9 +181,9 @@ class OpenAiTextGenerationModelTest extends TestCase
         $this->assertCount(1, $params['input']);
         $this->assertArrayNotHasKey('type', $params['input'][0]);
         $this->assertEquals('user', $params['input'][0]['role']);
-        $this->assertCount(1, $params['input'][0]['content']);
-        $this->assertEquals('input_text', $params['input'][0]['content'][0]['type']);
-        $this->assertEquals('Test message', $params['input'][0]['content'][0]['text']);
+        // Text-only messages should have content as a plain string, not an array
+        $this->assertIsString($params['input'][0]['content']);
+        $this->assertEquals('Test message', $params['input'][0]['content']);
     }
 
     /**


### PR DESCRIPTION
Fix bug that appears when trying to send a text-only message through the OpenAI Responses API. The API rejects messages with `type: 'input_text'` and expects plain strings for text-only content. This fix sends text-only messages as strings while maintaining object format for messages with files.

Fixes #182