### PR TITLE
Fix invalid `input_text` type when sending model messages back to OpenAI Responses API

### DIFF
--- a/src/ProviderImplementations/OpenAi/OpenAiTextGenerationModel.php
+++ b/src/ProviderImplementations/OpenAi/OpenAiTextGenerationModel.php
@@ -247,9 +247,10 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
             return null;
         }
 
+        $role = $message->getRole();
         $content = [];
         foreach ($parts as $part) {
-            $partData = $this->getMessagePartData($part);
+            $partData = $this->getMessagePartData($part, $role);
 
             // Function calls and responses are top-level items, not wrapped in a message.
             // validateMessages() ensures these are the only part in a message.
@@ -262,7 +263,7 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
         }
 
         return [
-            'role' => $this->getMessageRoleString($message->getRole()),
+            'role' => $this->getMessageRoleString($role),
             'content' => $content,
         ];
     }
@@ -289,15 +290,16 @@ class OpenAiTextGenerationModel extends AbstractApiBasedModel implements TextGen
      * @since 0.4.0
      *
      * @param MessagePart $part The message part to get the data for.
+     * @param MessageRoleEnum $role The role of the message containing the part.
      * @return array<string, mixed> The data for the message part.
      * @throws InvalidArgumentException If the message part type or data is unsupported.
      */
-    protected function getMessagePartData(MessagePart $part): array
+    protected function getMessagePartData(MessagePart $part, MessageRoleEnum $role): array
     {
         $type = $part->getType();
         if ($type->isText()) {
             return [
-                'type' => 'input_text',
+                'type' => $role->isModel() ? 'output_text' : 'input_text',
                 'text' => $part->getText(),
             ];
         }

--- a/tests/integration/Anthropic/TextGenerationIntegrationTest.php
+++ b/tests/integration/Anthropic/TextGenerationIntegrationTest.php
@@ -6,6 +6,7 @@ namespace WordPress\AiClient\Tests\integration\Anthropic;
 
 use PHPUnit\Framework\TestCase;
 use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
 use WordPress\AiClient\Tests\integration\traits\IntegrationTestTrait;
 
@@ -41,6 +42,32 @@ class TextGenerationIntegrationTest extends TestCase
 
         $this->assertInstanceOf(GenerativeAiResult::class, $result);
         $this->assertStringContainsStringIgnoringCase('hello', $result->toText());
+    }
+
+    /**
+     * Tests text generation with a simple multi-turn chat.
+     */
+    public function testMultiTurnTextGeneration(): void
+    {
+        $result = AiClient::prompt([
+            Message::fromArray([
+                'role' => 'user',
+                'parts' => [['text' => 'When was WordPress first released?']],
+            ]),
+            Message::fromArray([
+                'role' => 'model',
+                'parts' => [['text' => 'In 2003.']],
+            ]),
+            Message::fromArray([
+                'role' => 'user',
+                'parts' => [['text' => 'Who created it?']],
+            ]),
+        ])
+            ->usingProvider('anthropic')
+            ->generateTextResult();
+
+        $this->assertInstanceOf(GenerativeAiResult::class, $result);
+        $this->assertStringContainsStringIgnoringCase('Matt Mullenweg', $result->toText());
     }
 
     /**

--- a/tests/integration/Google/TextGenerationIntegrationTest.php
+++ b/tests/integration/Google/TextGenerationIntegrationTest.php
@@ -6,6 +6,7 @@ namespace WordPress\AiClient\Tests\integration\Google;
 
 use PHPUnit\Framework\TestCase;
 use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
 use WordPress\AiClient\Tests\integration\traits\IntegrationTestTrait;
 
@@ -41,6 +42,32 @@ class TextGenerationIntegrationTest extends TestCase
 
         $this->assertInstanceOf(GenerativeAiResult::class, $result);
         $this->assertStringContainsStringIgnoringCase('hello', $result->toText());
+    }
+
+    /**
+     * Tests text generation with a simple multi-turn chat.
+     */
+    public function testMultiTurnTextGeneration(): void
+    {
+        $result = AiClient::prompt([
+            Message::fromArray([
+                'role' => 'user',
+                'parts' => [['text' => 'When was WordPress first released?']],
+            ]),
+            Message::fromArray([
+                'role' => 'model',
+                'parts' => [['text' => 'In 2003.']],
+            ]),
+            Message::fromArray([
+                'role' => 'user',
+                'parts' => [['text' => 'Who created it?']],
+            ]),
+        ])
+            ->usingProvider('google')
+            ->generateTextResult();
+
+        $this->assertInstanceOf(GenerativeAiResult::class, $result);
+        $this->assertStringContainsStringIgnoringCase('Matt Mullenweg', $result->toText());
     }
 
     /**

--- a/tests/integration/OpenAi/TextGenerationIntegrationTest.php
+++ b/tests/integration/OpenAi/TextGenerationIntegrationTest.php
@@ -6,6 +6,7 @@ namespace WordPress\AiClient\Tests\integration\OpenAi;
 
 use PHPUnit\Framework\TestCase;
 use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
 use WordPress\AiClient\Tests\integration\traits\IntegrationTestTrait;
 
@@ -41,6 +42,32 @@ class TextGenerationIntegrationTest extends TestCase
 
         $this->assertInstanceOf(GenerativeAiResult::class, $result);
         $this->assertStringContainsStringIgnoringCase('hello', $result->toText());
+    }
+
+    /**
+     * Tests text generation with a simple multi-turn chat.
+     */
+    public function testMultiTurnTextGeneration(): void
+    {
+        $result = AiClient::prompt([
+            Message::fromArray([
+                'role' => 'user',
+                'parts' => [['text' => 'When was WordPress first released?']],
+            ]),
+            Message::fromArray([
+                'role' => 'model',
+                'parts' => [['text' => 'In 2003.']],
+            ]),
+            Message::fromArray([
+                'role' => 'user',
+                'parts' => [['text' => 'Who created it?']],
+            ]),
+        ])
+            ->usingProvider('openai')
+            ->generateTextResult();
+
+        $this->assertInstanceOf(GenerativeAiResult::class, $result);
+        $this->assertStringContainsStringIgnoringCase('Matt Mullenweg', $result->toText());
     }
 
     /**

--- a/tests/unit/ProviderImplementations/OpenAi/MockOpenAiTextGenerationModel.php
+++ b/tests/unit/ProviderImplementations/OpenAi/MockOpenAiTextGenerationModel.php
@@ -145,11 +145,12 @@ class MockOpenAiTextGenerationModel extends OpenAiTextGenerationModel
      * Exposes getMessagePartData for testing.
      *
      * @param MessagePart $part
+     * @param MessageRoleEnum $role
      * @return array<string, mixed>
      */
-    public function exposeGetMessagePartData(MessagePart $part): array
+    public function exposeGetMessagePartData(MessagePart $part, MessageRoleEnum $role): array
     {
-        return $this->getMessagePartData($part);
+        return $this->getMessagePartData($part, $role);
     }
 
     /**

--- a/tests/unit/ProviderImplementations/OpenAi/OpenAiTextGenerationModelTest.php
+++ b/tests/unit/ProviderImplementations/OpenAi/OpenAiTextGenerationModelTest.php
@@ -357,7 +357,7 @@ class OpenAiTextGenerationModelTest extends TestCase
         $model = $this->createModel();
         $part = new MessagePart('Hello world');
 
-        $data = $model->exposeGetMessagePartData($part);
+        $data = $model->exposeGetMessagePartData($part, MessageRoleEnum::user());
 
         $this->assertEquals('input_text', $data['type']);
         $this->assertEquals('Hello world', $data['text']);
@@ -374,7 +374,7 @@ class OpenAiTextGenerationModelTest extends TestCase
         $file = new File('https://example.com/image.png', 'image/png');
         $part = new MessagePart($file);
 
-        $data = $model->exposeGetMessagePartData($part);
+        $data = $model->exposeGetMessagePartData($part, MessageRoleEnum::user());
 
         $this->assertEquals('input_image', $data['type']);
         $this->assertEquals('https://example.com/image.png', $data['image_url']);
@@ -393,7 +393,7 @@ class OpenAiTextGenerationModelTest extends TestCase
         $file = new File($b64, 'image/png');
         $part = new MessagePart($file);
 
-        $data = $model->exposeGetMessagePartData($part);
+        $data = $model->exposeGetMessagePartData($part, MessageRoleEnum::user());
 
         $this->assertEquals('input_image', $data['type']);
         $this->assertStringStartsWith('data:image/png;base64,', $data['image_url']);

--- a/tests/unit/ProviderImplementations/OpenAi/OpenAiTextGenerationModelTest.php
+++ b/tests/unit/ProviderImplementations/OpenAi/OpenAiTextGenerationModelTest.php
@@ -364,6 +364,22 @@ class OpenAiTextGenerationModelTest extends TestCase
     }
 
     /**
+     * Tests getMessagePartData() with text part.
+     *
+     * @return void
+     */
+    public function testGetMessagePartDataWithModelText(): void
+    {
+        $model = $this->createModel();
+        $part = new MessagePart('Hello world');
+
+        $data = $model->exposeGetMessagePartData($part, MessageRoleEnum::model());
+
+        $this->assertEquals('output_text', $data['type']);
+        $this->assertEquals('Hello world', $data['text']);
+    }
+
+    /**
      * Tests getMessagePartData() with remote image.
      *
      * @return void


### PR DESCRIPTION
Fixes #182 

Supersedes #183 

I've added a basic integration test for multi-turn messages, for the other providers too, just to make sure it works and is covered.

You can verify that this fixes the bug by temporarily changing the `output_text` string in my changed line back to `input_text` - this would lead to the original behavior before this PR, and you'll get the exact exception that #182 mentions.