### PR TITLE
Fix object cloning to also clone nested objects (deep cloning)

### DIFF
--- a/src/Events/AfterGenerateResultEvent.php
+++ b/src/Events/AfterGenerateResultEvent.php
@@ -117,10 +117,8 @@ class AfterGenerateResultEvent
      * The model object is not cloned as it is a service object.
      *
      * @since 0.4.1
-     *
-     * @return void
      */
-    public function __clone(): void
+    public function __clone()
     {
         $clonedMessages = [];
         foreach ($this->messages as $message) {

--- a/src/Events/AfterGenerateResultEvent.php
+++ b/src/Events/AfterGenerateResultEvent.php
@@ -108,4 +108,25 @@ class AfterGenerateResultEvent
     {
         return $this->result;
     }
+
+    /**
+     * Performs a deep clone of the event.
+     *
+     * This method ensures that message and result objects are cloned to prevent
+     * modifications to the cloned event from affecting the original.
+     * The model object is not cloned as it is a service object.
+     *
+     * @since 0.4.1
+     *
+     * @return void
+     */
+    public function __clone(): void
+    {
+        $clonedMessages = [];
+        foreach ($this->messages as $message) {
+            $clonedMessages[] = clone $message;
+        }
+        $this->messages = $clonedMessages;
+        $this->result = clone $this->result;
+    }
 }

--- a/src/Events/BeforeGenerateResultEvent.php
+++ b/src/Events/BeforeGenerateResultEvent.php
@@ -85,4 +85,24 @@ class BeforeGenerateResultEvent
     {
         return $this->capability;
     }
+
+    /**
+     * Performs a deep clone of the event.
+     *
+     * This method ensures that message objects are cloned to prevent
+     * modifications to the cloned event from affecting the original.
+     * The model object is not cloned as it is a service object.
+     *
+     * @since 0.4.1
+     *
+     * @return void
+     */
+    public function __clone(): void
+    {
+        $clonedMessages = [];
+        foreach ($this->messages as $message) {
+            $clonedMessages[] = clone $message;
+        }
+        $this->messages = $clonedMessages;
+    }
 }

--- a/src/Events/BeforeGenerateResultEvent.php
+++ b/src/Events/BeforeGenerateResultEvent.php
@@ -94,10 +94,8 @@ class BeforeGenerateResultEvent
      * The model object is not cloned as it is a service object.
      *
      * @since 0.4.1
-     *
-     * @return void
      */
-    public function __clone(): void
+    public function __clone()
     {
         $clonedMessages = [];
         foreach ($this->messages as $message) {

--- a/src/Files/DTO/File.php
+++ b/src/Files/DTO/File.php
@@ -499,10 +499,8 @@ class File extends AbstractDataTransferObject
      * any shared references between the original and cloned file.
      *
      * @since 0.4.1
-     *
-     * @return void
      */
-    public function __clone(): void
+    public function __clone()
     {
         $this->mimeType = clone $this->mimeType;
     }

--- a/src/Files/DTO/File.php
+++ b/src/Files/DTO/File.php
@@ -491,4 +491,19 @@ class File extends AbstractDataTransferObject
             throw new InvalidArgumentException('File requires either url or base64Data.');
         }
     }
+
+    /**
+     * Performs a deep clone of the file.
+     *
+     * This method ensures that the MimeType value object is cloned to prevent
+     * any shared references between the original and cloned file.
+     *
+     * @since 0.4.1
+     *
+     * @return void
+     */
+    public function __clone(): void
+    {
+        $this->mimeType = clone $this->mimeType;
+    }
 }

--- a/src/Messages/DTO/Message.php
+++ b/src/Messages/DTO/Message.php
@@ -201,10 +201,8 @@ class Message extends AbstractDataTransferObject
      * modifications to the cloned message from affecting the original.
      *
      * @since 0.4.1
-     *
-     * @return void
      */
-    public function __clone(): void
+    public function __clone()
     {
         $clonedParts = [];
         foreach ($this->parts as $part) {

--- a/src/Messages/DTO/Message.php
+++ b/src/Messages/DTO/Message.php
@@ -193,4 +193,23 @@ class Message extends AbstractDataTransferObject
             throw new InvalidArgumentException('Invalid message role: ' . $role->value);
         }
     }
+
+    /**
+     * Performs a deep clone of the message.
+     *
+     * This method ensures that message part objects are cloned to prevent
+     * modifications to the cloned message from affecting the original.
+     *
+     * @since 0.4.1
+     *
+     * @return void
+     */
+    public function __clone(): void
+    {
+        $clonedParts = [];
+        foreach ($this->parts as $part) {
+            $clonedParts[] = clone $part;
+        }
+        $this->parts = $clonedParts;
+    }
 }

--- a/src/Messages/DTO/MessagePart.php
+++ b/src/Messages/DTO/MessagePart.php
@@ -318,4 +318,27 @@ class MessagePart extends AbstractDataTransferObject
             );
         }
     }
+
+    /**
+     * Performs a deep clone of the message part.
+     *
+     * This method ensures that nested objects (file, function call, function response)
+     * are cloned to prevent modifications to the cloned part from affecting the original.
+     *
+     * @since 0.4.1
+     *
+     * @return void
+     */
+    public function __clone(): void
+    {
+        if ($this->file !== null) {
+            $this->file = clone $this->file;
+        }
+        if ($this->functionCall !== null) {
+            $this->functionCall = clone $this->functionCall;
+        }
+        if ($this->functionResponse !== null) {
+            $this->functionResponse = clone $this->functionResponse;
+        }
+    }
 }

--- a/src/Messages/DTO/MessagePart.php
+++ b/src/Messages/DTO/MessagePart.php
@@ -326,10 +326,8 @@ class MessagePart extends AbstractDataTransferObject
      * are cloned to prevent modifications to the cloned part from affecting the original.
      *
      * @since 0.4.1
-     *
-     * @return void
      */
-    public function __clone(): void
+    public function __clone()
     {
         if ($this->file !== null) {
             $this->file = clone $this->file;

--- a/src/Providers/Models/DTO/ModelMetadata.php
+++ b/src/Providers/Models/DTO/ModelMetadata.php
@@ -217,4 +217,23 @@ class ModelMetadata extends AbstractDataTransferObject
             )
         );
     }
+
+    /**
+     * Performs a deep clone of the model metadata.
+     *
+     * This method ensures that supported option objects are cloned to prevent
+     * modifications to the cloned metadata from affecting the original.
+     *
+     * @since 0.4.1
+     *
+     * @return void
+     */
+    public function __clone(): void
+    {
+        $clonedOptions = [];
+        foreach ($this->supportedOptions as $option) {
+            $clonedOptions[] = clone $option;
+        }
+        $this->supportedOptions = $clonedOptions;
+    }
 }

--- a/src/Providers/Models/DTO/ModelMetadata.php
+++ b/src/Providers/Models/DTO/ModelMetadata.php
@@ -225,10 +225,8 @@ class ModelMetadata extends AbstractDataTransferObject
      * modifications to the cloned metadata from affecting the original.
      *
      * @since 0.4.1
-     *
-     * @return void
      */
-    public function __clone(): void
+    public function __clone()
     {
         $clonedOptions = [];
         foreach ($this->supportedOptions as $option) {

--- a/src/Results/DTO/Candidate.php
+++ b/src/Results/DTO/Candidate.php
@@ -141,10 +141,8 @@ class Candidate extends AbstractDataTransferObject
      * modifications to the cloned candidate from affecting the original.
      *
      * @since 0.4.1
-     *
-     * @return void
      */
-    public function __clone(): void
+    public function __clone()
     {
         $this->message = clone $this->message;
     }

--- a/src/Results/DTO/Candidate.php
+++ b/src/Results/DTO/Candidate.php
@@ -133,4 +133,19 @@ class Candidate extends AbstractDataTransferObject
             FinishReasonEnum::from($array[self::KEY_FINISH_REASON])
         );
     }
+
+    /**
+     * Performs a deep clone of the candidate.
+     *
+     * This method ensures that the message object is cloned to prevent
+     * modifications to the cloned candidate from affecting the original.
+     *
+     * @since 0.4.1
+     *
+     * @return void
+     */
+    public function __clone(): void
+    {
+        $this->message = clone $this->message;
+    }
 }

--- a/src/Results/DTO/GenerativeAiResult.php
+++ b/src/Results/DTO/GenerativeAiResult.php
@@ -521,10 +521,8 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
      * are cloned to prevent modifications to the cloned result from affecting the original.
      *
      * @since 0.4.1
-     *
-     * @return void
      */
-    public function __clone(): void
+    public function __clone()
     {
         $clonedCandidates = [];
         foreach ($this->candidates as $candidate) {

--- a/src/Results/DTO/GenerativeAiResult.php
+++ b/src/Results/DTO/GenerativeAiResult.php
@@ -513,4 +513,26 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
             $array[self::KEY_ADDITIONAL_DATA] ?? []
         );
     }
+
+    /**
+     * Performs a deep clone of the result.
+     *
+     * This method ensures that all nested objects (candidates, token usage, metadata)
+     * are cloned to prevent modifications to the cloned result from affecting the original.
+     *
+     * @since 0.4.1
+     *
+     * @return void
+     */
+    public function __clone(): void
+    {
+        $clonedCandidates = [];
+        foreach ($this->candidates as $candidate) {
+            $clonedCandidates[] = clone $candidate;
+        }
+        $this->candidates = $clonedCandidates;
+        $this->tokenUsage = clone $this->tokenUsage;
+        $this->providerMetadata = clone $this->providerMetadata;
+        $this->modelMetadata = clone $this->modelMetadata;
+    }
 }

--- a/tests/unit/Events/AfterPromptSentEventTest.php
+++ b/tests/unit/Events/AfterPromptSentEventTest.php
@@ -81,4 +81,34 @@ class AfterPromptSentEventTest extends TestCase
         $this->assertSame($result, $event->getResult());
         $this->assertCount(1, $event->getResult()->getCandidates());
     }
+
+    /**
+     * Tests that cloning the event creates independent message and result copies.
+     *
+     * @return void
+     */
+    public function testCloneClonesMessagesAndResult(): void
+    {
+        $messages = [
+            new UserMessage([new MessagePart('Hello, world!')]),
+        ];
+        $result = $this->createTestResult('Test response');
+        $model = $this->createMockTextGenerationModel($result);
+        $capability = CapabilityEnum::textGeneration();
+
+        $original = new AfterGenerateResultEvent($messages, $model, $capability, $result);
+        $cloned = clone $original;
+
+        // Messages should be different instances
+        $this->assertNotSame($original->getMessages()[0], $cloned->getMessages()[0]);
+
+        // Result should be a different instance
+        $this->assertNotSame($original->getResult(), $cloned->getResult());
+
+        // Model should be the same instance (service objects are not cloned)
+        $this->assertSame($original->getModel(), $cloned->getModel());
+
+        // Capability enum should be the same instance (enums are singletons)
+        $this->assertSame($original->getCapability(), $cloned->getCapability());
+    }
 }

--- a/tests/unit/Events/BeforePromptSentEventTest.php
+++ b/tests/unit/Events/BeforePromptSentEventTest.php
@@ -76,4 +76,36 @@ class BeforePromptSentEventTest extends TestCase
 
         $this->assertCount(3, $event->getMessages());
     }
+
+    /**
+     * Tests that cloning the event creates independent message copies.
+     *
+     * @return void
+     */
+    public function testCloneClonesMessages(): void
+    {
+        $messages = [
+            new UserMessage([new MessagePart('First message')]),
+            new UserMessage([new MessagePart('Second message')]),
+        ];
+        $result = $this->createTestResult();
+        $model = $this->createMockTextGenerationModel($result);
+        $capability = CapabilityEnum::textGeneration();
+
+        $original = new BeforeGenerateResultEvent($messages, $model, $capability);
+        $cloned = clone $original;
+
+        // Messages should be different instances
+        $originalMessages = $original->getMessages();
+        $clonedMessages = $cloned->getMessages();
+        foreach ($originalMessages as $index => $originalMessage) {
+            $this->assertNotSame($originalMessage, $clonedMessages[$index]);
+        }
+
+        // Model should be the same instance (service objects are not cloned)
+        $this->assertSame($original->getModel(), $cloned->getModel());
+
+        // Capability enum should be the same instance (enums are singletons)
+        $this->assertSame($original->getCapability(), $cloned->getCapability());
+    }
 }

--- a/tests/unit/Files/DTO/FileTest.php
+++ b/tests/unit/Files/DTO/FileTest.php
@@ -571,4 +571,24 @@ class FileTest extends TestCase
         $this->assertTrue($urlFileNoMime->isRemote());
         $this->assertFalse($urlFileNoMime->isInline());
     }
+
+    /**
+     * Tests that cloning File creates an independent MimeType copy.
+     *
+     * @return void
+     */
+    public function testCloneClonesMimeType(): void
+    {
+        $original = new File('https://example.com/document.pdf', 'application/pdf');
+        $cloned = clone $original;
+
+        // MimeType object should be a different instance
+        $this->assertNotSame($original->getMimeTypeObject(), $cloned->getMimeTypeObject());
+
+        // But the string value should be equivalent
+        $this->assertEquals($original->getMimeType(), $cloned->getMimeType());
+
+        // FileType enum should be the same instance (enums are singletons)
+        $this->assertSame($original->getFileType(), $cloned->getFileType());
+    }
 }

--- a/tests/unit/Messages/DTO/MessagePartTest.php
+++ b/tests/unit/Messages/DTO/MessagePartTest.php
@@ -440,4 +440,50 @@ class MessagePartTest extends TestCase
 
         MessagePart::fromArray($json);
     }
+
+    /**
+     * Tests that cloning MessagePart with File creates an independent File copy.
+     *
+     * @return void
+     */
+    public function testCloneClonesFile(): void
+    {
+        $file = new File('https://example.com/image.png', 'image/png');
+        $original = new MessagePart($file);
+        $cloned = clone $original;
+
+        $this->assertNotSame($original->getFile(), $cloned->getFile());
+
+        // Type and channel enums should be the same instance
+        $this->assertSame($original->getType(), $cloned->getType());
+        $this->assertSame($original->getChannel(), $cloned->getChannel());
+    }
+
+    /**
+     * Tests that cloning MessagePart with FunctionCall creates an independent copy.
+     *
+     * @return void
+     */
+    public function testCloneClonesFunctionCall(): void
+    {
+        $functionCall = new FunctionCall('call_123', 'testFunction', ['param' => 'value']);
+        $original = new MessagePart($functionCall);
+        $cloned = clone $original;
+
+        $this->assertNotSame($original->getFunctionCall(), $cloned->getFunctionCall());
+    }
+
+    /**
+     * Tests that cloning MessagePart with FunctionResponse creates an independent copy.
+     *
+     * @return void
+     */
+    public function testCloneClonesFunctionResponse(): void
+    {
+        $functionResponse = new FunctionResponse('resp_123', 'testFunction', ['result' => 42]);
+        $original = new MessagePart($functionResponse);
+        $cloned = clone $original;
+
+        $this->assertNotSame($original->getFunctionResponse(), $cloned->getFunctionResponse());
+    }
 }

--- a/tests/unit/Messages/DTO/MessageTest.php
+++ b/tests/unit/Messages/DTO/MessageTest.php
@@ -500,4 +500,29 @@ class MessageTest extends TestCase
 
         new Message(MessageRoleEnum::user(), $parts);
     }
+
+    /**
+     * Tests that cloning the message creates independent part copies.
+     *
+     * @return void
+     */
+    public function testCloneClonesParts(): void
+    {
+        $parts = [
+            new MessagePart('First part'),
+            new MessagePart('Second part'),
+        ];
+        $original = new Message(MessageRoleEnum::user(), $parts);
+        $cloned = clone $original;
+
+        // Parts should be different instances
+        $originalParts = $original->getParts();
+        $clonedParts = $cloned->getParts();
+        foreach ($originalParts as $index => $originalPart) {
+            $this->assertNotSame($originalPart, $clonedParts[$index]);
+        }
+
+        // Role enum should be the same instance (enums are singletons)
+        $this->assertSame($original->getRole(), $cloned->getRole());
+    }
 }

--- a/tests/unit/Providers/Models/DTO/ModelMetadataTest.php
+++ b/tests/unit/Providers/Models/DTO/ModelMetadataTest.php
@@ -450,4 +450,38 @@ class ModelMetadataTest extends TestCase
             $metadata
         );
     }
+
+    /**
+     * Tests that cloning creates independent SupportedOption copies.
+     *
+     * @return void
+     */
+    public function testCloneClonesSupportedOptions(): void
+    {
+        $options = [
+            new SupportedOption(OptionEnum::temperature(), [0.0, 0.5, 1.0]),
+            new SupportedOption(OptionEnum::maxTokens(), null),
+        ];
+        $original = new ModelMetadata(
+            'test-model',
+            'Test Model',
+            [CapabilityEnum::textGeneration()],
+            $options
+        );
+        $cloned = clone $original;
+
+        // SupportedOptions should be different instances
+        $originalOptions = $original->getSupportedOptions();
+        $clonedOptions = $cloned->getSupportedOptions();
+        foreach ($originalOptions as $index => $originalOption) {
+            $this->assertNotSame($originalOption, $clonedOptions[$index]);
+        }
+
+        // Capabilities (enums) should be the same instances
+        $originalCaps = $original->getSupportedCapabilities();
+        $clonedCaps = $cloned->getSupportedCapabilities();
+        foreach ($originalCaps as $index => $cap) {
+            $this->assertSame($cap, $clonedCaps[$index]);
+        }
+    }
 }

--- a/tests/unit/Results/DTO/CandidateTest.php
+++ b/tests/unit/Results/DTO/CandidateTest.php
@@ -388,4 +388,28 @@ class CandidateTest extends TestCase
         );
         $this->assertImplementsArrayTransformation($candidate);
     }
+
+    /**
+     * Tests that cloning the candidate creates an independent message copy.
+     *
+     * @return void
+     */
+    public function testCloneClonesMessage(): void
+    {
+        $message = new ModelMessage([new MessagePart('Test response')]);
+        $original = new Candidate($message, FinishReasonEnum::stop());
+        $cloned = clone $original;
+
+        // Message should be a different instance
+        $this->assertNotSame($original->getMessage(), $cloned->getMessage());
+
+        // FinishReason enum should be the same instance (enums are singletons)
+        $this->assertSame($original->getFinishReason(), $cloned->getFinishReason());
+
+        // But the content should be equivalent
+        $this->assertEquals(
+            $original->getMessage()->getParts()[0]->getText(),
+            $cloned->getMessage()->getParts()[0]->getText()
+        );
+    }
 }

--- a/tests/unit/Results/DTO/GenerativeAiResultTest.php
+++ b/tests/unit/Results/DTO/GenerativeAiResultTest.php
@@ -959,4 +959,41 @@ class GenerativeAiResultTest extends TestCase
         );
         $this->assertImplementsArrayTransformation($result);
     }
+
+    /**
+     * Tests that cloning the result creates independent nested object copies.
+     *
+     * @return void
+     */
+    public function testCloneClonesNestedObjects(): void
+    {
+        $message = new ModelMessage([new MessagePart('Test response')]);
+        $candidate = new Candidate($message, FinishReasonEnum::stop(), 10);
+        $tokenUsage = new TokenUsage(10, 20, 30);
+
+        $original = new GenerativeAiResult(
+            'test-id',
+            [$candidate],
+            $tokenUsage,
+            $this->createTestProviderMetadata(),
+            $this->createTestModelMetadata()
+        );
+        $cloned = clone $original;
+
+        // Candidates should be different instances
+        $this->assertNotSame($original->getCandidates()[0], $cloned->getCandidates()[0]);
+
+        // TokenUsage should be a different instance
+        $this->assertNotSame($original->getTokenUsage(), $cloned->getTokenUsage());
+
+        // ProviderMetadata should be a different instance
+        $this->assertNotSame($original->getProviderMetadata(), $cloned->getProviderMetadata());
+
+        // ModelMetadata should be a different instance
+        $this->assertNotSame($original->getModelMetadata(), $cloned->getModelMetadata());
+
+        // But the data should be equivalent
+        $this->assertEquals($original->getId(), $cloned->getId());
+        $this->assertEquals($original->toText(), $cloned->toText());
+    }
 }


### PR DESCRIPTION
In https://github.com/WordPress/wp-ai-client/pull/49 we realized that DTOs in this don't clone deeply. It's certainly useful to be able to clone DTOs as they're meant to represent a single, serializable group of data. One could be cloned via `toArray()` and `fromArray()` but that's awkward and doesn't work when cloning via PHP.

This adds support for deep cloning as well as tests to check that cloned DTOs don't reference old objects.