### PR TITLE
Prepare 0.4.2 release

### DIFF
--- a/src/AiClient.php
+++ b/src/AiClient.php
@@ -89,7 +89,7 @@ class AiClient
     /**
      * @var string The version of the AI Client.
      */
-    public const VERSION = '0.4.1';
+    public const VERSION = '0.4.2';
 
     /**
      * @var ProviderRegistry|null The default provider registry instance.

--- a/src/Events/AfterGenerateResultEvent.php
+++ b/src/Events/AfterGenerateResultEvent.php
@@ -116,7 +116,7 @@ class AfterGenerateResultEvent
      * modifications to the cloned event from affecting the original.
      * The model object is not cloned as it is a service object.
      *
-     * @since 0.4.1
+     * @since 0.4.2
      */
     public function __clone()
     {

--- a/src/Events/BeforeGenerateResultEvent.php
+++ b/src/Events/BeforeGenerateResultEvent.php
@@ -93,7 +93,7 @@ class BeforeGenerateResultEvent
      * modifications to the cloned event from affecting the original.
      * The model object is not cloned as it is a service object.
      *
-     * @since 0.4.1
+     * @since 0.4.2
      */
     public function __clone()
     {

--- a/src/Files/DTO/File.php
+++ b/src/Files/DTO/File.php
@@ -498,7 +498,7 @@ class File extends AbstractDataTransferObject
      * This method ensures that the MimeType value object is cloned to prevent
      * any shared references between the original and cloned file.
      *
-     * @since 0.4.1
+     * @since 0.4.2
      */
     public function __clone()
     {

--- a/src/Messages/DTO/Message.php
+++ b/src/Messages/DTO/Message.php
@@ -200,7 +200,7 @@ class Message extends AbstractDataTransferObject
      * This method ensures that message part objects are cloned to prevent
      * modifications to the cloned message from affecting the original.
      *
-     * @since 0.4.1
+     * @since 0.4.2
      */
     public function __clone()
     {

--- a/src/Messages/DTO/MessagePart.php
+++ b/src/Messages/DTO/MessagePart.php
@@ -325,7 +325,7 @@ class MessagePart extends AbstractDataTransferObject
      * This method ensures that nested objects (file, function call, function response)
      * are cloned to prevent modifications to the cloned part from affecting the original.
      *
-     * @since 0.4.1
+     * @since 0.4.2
      */
     public function __clone()
     {

--- a/src/Providers/Models/DTO/ModelMetadata.php
+++ b/src/Providers/Models/DTO/ModelMetadata.php
@@ -224,7 +224,7 @@ class ModelMetadata extends AbstractDataTransferObject
      * This method ensures that supported option objects are cloned to prevent
      * modifications to the cloned metadata from affecting the original.
      *
-     * @since 0.4.1
+     * @since 0.4.2
      */
     public function __clone()
     {

--- a/src/Results/DTO/Candidate.php
+++ b/src/Results/DTO/Candidate.php
@@ -140,7 +140,7 @@ class Candidate extends AbstractDataTransferObject
      * This method ensures that the message object is cloned to prevent
      * modifications to the cloned candidate from affecting the original.
      *
-     * @since 0.4.1
+     * @since 0.4.2
      */
     public function __clone()
     {

--- a/src/Results/DTO/GenerativeAiResult.php
+++ b/src/Results/DTO/GenerativeAiResult.php
@@ -520,7 +520,7 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
      * This method ensures that all nested objects (candidates, token usage, metadata)
      * are cloned to prevent modifications to the cloned result from affecting the original.
      *
-     * @since 0.4.1
+     * @since 0.4.2
      */
     public function __clone()
     {


### PR DESCRIPTION
#187 had accidentally added hard-coded strings for the latest version instead of `n.e.x.t` - fixed as part of this :)