### PR TITLE
Feature/token limit reached exception

### DIFF
--- a/src/Common/Exception/TokenLimitReachedException.php
+++ b/src/Common/Exception/TokenLimitReachedException.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Common\Exception;
+
+use Throwable;
+
+/**
+ * Exception thrown when generation stops due to reaching token limits.
+ *
+ * @since n.e.x.t
+ */
+class TokenLimitReachedException extends RuntimeException
+{
+    /**
+     * @var int|null The configured max token limit for the request, if known.
+     */
+    private ?int $maxTokens;
+
+    /**
+     * @var string The provider stop reason that indicated token limit exhaustion.
+     */
+    private string $providerStopReason;
+
+    /**
+     * @var string|null The function name, if token limit was reached during tool-call generation.
+     */
+    private ?string $functionName;
+
+    /**
+     * @var list<string> Required function parameters that were missing, if any.
+     */
+    private array $missingRequiredParameters;
+
+    /**
+     * Constructor.
+     *
+     * @since n.e.x.t
+     *
+     * @param string $message Exception message.
+     * @param int|null $maxTokens The configured max token limit for the request, if known.
+     * @param string $providerStopReason The provider stop reason.
+     * @param string|null $functionName The function name, if relevant.
+     * @param list<string> $missingRequiredParameters Missing required parameters, if relevant.
+     * @param int $code Exception code.
+     * @param Throwable|null $previous Previous throwable.
+     */
+    public function __construct(
+        string $message,
+        ?int $maxTokens,
+        string $providerStopReason,
+        ?string $functionName = null,
+        array $missingRequiredParameters = [],
+        int $code = 0,
+        ?Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+        $this->maxTokens = $maxTokens;
+        $this->providerStopReason = $providerStopReason;
+        $this->functionName = $functionName;
+        $this->missingRequiredParameters = $missingRequiredParameters;
+    }
+
+    /**
+     * Gets the max token limit configured for the request.
+     *
+     * @since n.e.x.t
+     *
+     * @return int|null The max token limit, or null if unknown.
+     */
+    public function getMaxTokens(): ?int
+    {
+        return $this->maxTokens;
+    }
+
+    /**
+     * Gets the provider stop reason that triggered this exception.
+     *
+     * @since n.e.x.t
+     *
+     * @return string The provider stop reason.
+     */
+    public function getProviderStopReason(): string
+    {
+        return $this->providerStopReason;
+    }
+
+    /**
+     * Gets the related function name, if applicable.
+     *
+     * @since n.e.x.t
+     *
+     * @return string|null The function name.
+     */
+    public function getFunctionName(): ?string
+    {
+        return $this->functionName;
+    }
+
+    /**
+     * Gets missing required function parameters, if applicable.
+     *
+     * @since n.e.x.t
+     *
+     * @return list<string> Missing required parameter names.
+     */
+    public function getMissingRequiredParameters(): array
+    {
+        return $this->missingRequiredParameters;
+    }
+}

--- a/src/ProviderImplementations/Anthropic/AnthropicTextGenerationModel.php
+++ b/src/ProviderImplementations/Anthropic/AnthropicTextGenerationModel.php
@@ -568,7 +568,9 @@ class AnthropicTextGenerationModel extends AbstractApiBasedModel implements Text
                 }
             }
 
-            $requiredParametersByFunctionName[$functionDeclaration->getName()] = $requiredParameters;
+            $requiredParametersByFunctionName[$functionDeclaration->getName()] = array_values(
+                array_unique($requiredParameters)
+            );
         }
 
         return $requiredParametersByFunctionName;

--- a/src/ProviderImplementations/Anthropic/AnthropicTextGenerationModel.php
+++ b/src/ProviderImplementations/Anthropic/AnthropicTextGenerationModel.php
@@ -6,6 +6,7 @@ namespace WordPress\AiClient\ProviderImplementations\Anthropic;
 
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Common\Exception\RuntimeException;
+use WordPress\AiClient\Common\Exception\TokenLimitReachedException;
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\Enums\MessagePartChannelEnum;
@@ -480,6 +481,8 @@ class AnthropicTextGenerationModel extends AbstractApiBasedModel implements Text
                 );
         }
 
+        $this->maybeThrowTokenLimitReachedException($responseData, $parts);
+
         $candidates = [new Candidate(
             new Message($role, $parts),
             $finishReason
@@ -519,6 +522,157 @@ class AnthropicTextGenerationModel extends AbstractApiBasedModel implements Text
             $this->providerMetadata(),
             $this->metadata(),
             $additionalData
+        );
+    }
+
+    /**
+     * Checks whether the given stop reason indicates token limit exhaustion.
+     *
+     * @since n.e.x.t
+     *
+     * @param string $stopReason The provider stop reason.
+     * @return bool True if the stop reason indicates token limit exhaustion, false otherwise.
+     */
+    protected function isTokenLimitStopReason(string $stopReason): bool
+    {
+        return in_array($stopReason, ['max_tokens', 'model_context_window_exceeded'], true);
+    }
+
+    /**
+     * Gets required parameters from configured function declarations indexed by function name.
+     *
+     * @since n.e.x.t
+     *
+     * @return array<string, list<string>> Required parameter names indexed by function name.
+     */
+    protected function getRequiredParametersByFunctionName(): array
+    {
+        $functionDeclarations = $this->getConfig()->getFunctionDeclarations();
+        if (!is_array($functionDeclarations)) {
+            return [];
+        }
+
+        $requiredParametersByFunctionName = [];
+        foreach ($functionDeclarations as $functionDeclaration) {
+            if (!$functionDeclaration instanceof FunctionDeclaration) {
+                continue;
+            }
+
+            $requiredParameters = [];
+            $parameters = $functionDeclaration->getParameters();
+            if (is_array($parameters) && isset($parameters['required']) && is_array($parameters['required'])) {
+                foreach ($parameters['required'] as $requiredParameter) {
+                    if (is_string($requiredParameter)) {
+                        $requiredParameters[] = $requiredParameter;
+                    }
+                }
+            }
+
+            $requiredParametersByFunctionName[$functionDeclaration->getName()] = $requiredParameters;
+        }
+
+        return $requiredParametersByFunctionName;
+    }
+
+    /**
+     * Gets required parameter names that are missing from a function call.
+     *
+     * @since n.e.x.t
+     *
+     * @param FunctionCall|null $functionCall The function call.
+     * @param list<string> $requiredParameters Required parameter names.
+     * @return list<string> Missing required parameter names.
+     */
+    protected function getMissingRequiredParameters(?FunctionCall $functionCall, array $requiredParameters): array
+    {
+        if (!$functionCall || count($requiredParameters) === 0) {
+            return [];
+        }
+
+        $args = $functionCall->getArgs();
+        if (is_object($args)) {
+            $args = (array) $args;
+        }
+        if (!is_array($args)) {
+            return $requiredParameters;
+        }
+
+        $missingRequiredParameters = [];
+        foreach ($requiredParameters as $requiredParameter) {
+            if (!array_key_exists($requiredParameter, $args)) {
+                $missingRequiredParameters[] = $requiredParameter;
+            }
+        }
+
+        return $missingRequiredParameters;
+    }
+
+    /**
+     * Throws a token limit exception when the provider response indicates token exhaustion.
+     *
+     * @since n.e.x.t
+     *
+     * @param ResponseData $responseData The response data.
+     * @param list<MessagePart> $parts The parsed message parts from the response content.
+     * @throws TokenLimitReachedException If token limit was reached.
+     */
+    protected function maybeThrowTokenLimitReachedException(array $responseData, array $parts): void
+    {
+        if (!isset($responseData['stop_reason']) || !is_string($responseData['stop_reason'])) {
+            return;
+        }
+        if (!$this->isTokenLimitStopReason($responseData['stop_reason'])) {
+            return;
+        }
+
+        $maxTokens = $this->getConfig()->getMaxTokens() ?? 4096;
+        $functionName = null;
+        $missingRequiredParameters = [];
+        $requiredParametersByFunctionName = $this->getRequiredParametersByFunctionName();
+
+        foreach ($parts as $part) {
+            if (!$part->getType()->isFunctionCall()) {
+                continue;
+            }
+
+            $functionCall = $part->getFunctionCall();
+            if (!$functionCall) {
+                continue;
+            }
+
+            $candidateFunctionName = $functionCall->getName();
+            if ($candidateFunctionName === null) {
+                continue;
+            }
+
+            $requiredParameters = $requiredParametersByFunctionName[$candidateFunctionName] ?? [];
+            $missingParameters = $this->getMissingRequiredParameters($functionCall, $requiredParameters);
+            if (count($missingParameters) > 0) {
+                $functionName = $candidateFunctionName;
+                $missingRequiredParameters = $missingParameters;
+                break;
+            }
+        }
+
+        $message = sprintf(
+            'Generation stopped due to token limit (%d) with stop reason "%s".',
+            $maxTokens,
+            $responseData['stop_reason']
+        );
+        if ($functionName !== null) {
+            $message .= sprintf(
+                ' Tool call "%s" is missing required parameters: %s.',
+                $functionName,
+                implode(', ', $missingRequiredParameters)
+            );
+        }
+
+        throw new TokenLimitReachedException(
+            $message,
+            $maxTokens,
+            $responseData['stop_reason'],
+            $functionName,
+            $missingRequiredParameters
         );
     }
 

--- a/tests/integration/Anthropic/FunctionCallingIntegrationTest.php
+++ b/tests/integration/Anthropic/FunctionCallingIntegrationTest.php
@@ -6,6 +6,7 @@ namespace WordPress\AiClient\Tests\integration\Anthropic;
 
 use PHPUnit\Framework\TestCase;
 use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Common\Exception\TokenLimitReachedException;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\UserMessage;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
@@ -326,6 +327,58 @@ class FunctionCallingIntegrationTest extends TestCase
             $this->assertArrayHasKey('name', $item);
             $this->assertArrayHasKey('quantity', $item);
             $this->assertIsInt($item['quantity']);
+        }
+    }
+
+    /**
+     * Tests tool-calling generation throws token-limit exception when max tokens are very low.
+     */
+    public function testFunctionCallingThrowsTokenLimitReachedExceptionWithVeryLowMaxTokens(): void
+    {
+        $maxTokens = 10;
+        $createPost = new FunctionDeclaration(
+            'create_post',
+            'Create a WordPress post with title, post type and full HTML content',
+            [
+                'type' => 'object',
+                'properties' => [
+                    'title' => ['type' => 'string'],
+                    'post_type' => ['type' => 'string'],
+                    'content' => ['type' => 'string'],
+                ],
+                'required' => ['title', 'post_type', 'content'],
+            ]
+        );
+
+        try {
+            AiClient::prompt(
+                'Call create_post and set content to a very long multi-section HTML document with at least '
+                . '50 list items and 20 headings.'
+            )
+                ->usingProvider('anthropic')
+                ->usingFunctionDeclarations($createPost)
+                ->usingMaxTokens($maxTokens)
+                ->generateTextResult();
+
+            $this->fail('Expected TokenLimitReachedException to be thrown.');
+        } catch (TokenLimitReachedException $exception) {
+            $this->assertSame($maxTokens, $exception->getMaxTokens());
+            $this->assertContains(
+                $exception->getProviderStopReason(),
+                ['max_tokens', 'model_context_window_exceeded']
+            );
+
+            if ($exception->getFunctionName() !== null) {
+                $this->assertSame('create_post', $exception->getFunctionName());
+            }
+
+            if ($exception->getMissingRequiredParameters() !== []) {
+                $missingParameters = $exception->getMissingRequiredParameters();
+                $expectedParameters = ['title', 'post_type', 'content'];
+                foreach ($missingParameters as $missingParameter) {
+                    $this->assertContains($missingParameter, $expectedParameters);
+                }
+            }
         }
     }
 

--- a/tests/integration/Anthropic/TextGenerationIntegrationTest.php
+++ b/tests/integration/Anthropic/TextGenerationIntegrationTest.php
@@ -6,6 +6,7 @@ namespace WordPress\AiClient\Tests\integration\Anthropic;
 
 use PHPUnit\Framework\TestCase;
 use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Common\Exception\TokenLimitReachedException;
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
 use WordPress\AiClient\Tests\integration\traits\IntegrationTestTrait;
@@ -97,5 +98,32 @@ class TextGenerationIntegrationTest extends TestCase
         $this->assertGreaterThan(0, $tokenUsage->getPromptTokens());
         $this->assertGreaterThan(0, $tokenUsage->getCompletionTokens());
         $this->assertGreaterThan(0, $tokenUsage->getTotalTokens());
+    }
+
+    /**
+     * Tests text generation throws token-limit exception when max tokens are very low.
+     */
+    public function testTextGenerationThrowsTokenLimitReachedExceptionWithVeryLowMaxTokens(): void
+    {
+        $maxTokens = 1;
+
+        try {
+            AiClient::prompt(
+                'Write three detailed paragraphs about the history of WordPress and include dates and key milestones.'
+            )
+                ->usingProvider('anthropic')
+                ->usingMaxTokens($maxTokens)
+                ->generateTextResult();
+
+            $this->fail('Expected TokenLimitReachedException to be thrown.');
+        } catch (TokenLimitReachedException $exception) {
+            $this->assertSame($maxTokens, $exception->getMaxTokens());
+            $this->assertContains(
+                $exception->getProviderStopReason(),
+                ['max_tokens', 'model_context_window_exceeded']
+            );
+            $this->assertNull($exception->getFunctionName());
+            $this->assertSame([], $exception->getMissingRequiredParameters());
+        }
     }
 }

--- a/tests/unit/ProviderImplementations/Anthropic/AnthropicTextGenerationModelTest.php
+++ b/tests/unit/ProviderImplementations/Anthropic/AnthropicTextGenerationModelTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Tests\unit\ProviderImplementations\Anthropic;
+
+use PHPUnit\Framework\TestCase;
+use WordPress\AiClient\Common\Exception\TokenLimitReachedException;
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
+use WordPress\AiClient\Providers\DTO\ProviderMetadata;
+use WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface;
+use WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface;
+use WordPress\AiClient\Providers\Http\DTO\Response;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\AiClient\Results\Enums\FinishReasonEnum;
+
+/**
+ * @covers \WordPress\AiClient\ProviderImplementations\Anthropic\AnthropicTextGenerationModel
+ */
+class AnthropicTextGenerationModelTest extends TestCase
+{
+    /**
+     * @var ModelMetadata&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $modelMetadata;
+
+    /**
+     * @var ProviderMetadata&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $providerMetadata;
+
+    /**
+     * @var HttpTransporterInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $mockHttpTransporter;
+
+    /**
+     * @var RequestAuthenticationInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $mockRequestAuthentication;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->modelMetadata = $this->createStub(ModelMetadata::class);
+        $this->modelMetadata->method('getId')->willReturn('claude-3-5-sonnet');
+
+        $this->providerMetadata = $this->createStub(ProviderMetadata::class);
+        $this->providerMetadata->method('getName')->willReturn('Anthropic');
+
+        $this->mockHttpTransporter = $this->createMock(HttpTransporterInterface::class);
+        $this->mockRequestAuthentication = $this->createMock(RequestAuthenticationInterface::class);
+    }
+
+    /**
+     * Creates a mock Anthropic model instance.
+     *
+     * @return MockAnthropicTextGenerationModel
+     */
+    private function createModel(): MockAnthropicTextGenerationModel
+    {
+        return new MockAnthropicTextGenerationModel(
+            $this->modelMetadata,
+            $this->providerMetadata,
+            $this->mockHttpTransporter,
+            $this->mockRequestAuthentication
+        );
+    }
+
+    /**
+     * Tests generateTextResult() on a normal successful response.
+     *
+     * @return void
+     */
+    public function testGenerateTextResultSuccess(): void
+    {
+        $prompt = [new Message(MessageRoleEnum::user(), [new MessagePart('Hello')])];
+        $response = new Response(
+            200,
+            [],
+            json_encode([
+                'id' => 'msg_123',
+                'role' => 'assistant',
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'Hi there!',
+                    ],
+                ],
+                'stop_reason' => 'end_turn',
+                'usage' => [
+                    'input_tokens' => 10,
+                    'output_tokens' => 5,
+                ],
+            ])
+        );
+
+        $this->mockRequestAuthentication
+            ->expects($this->once())
+            ->method('authenticateRequest')
+            ->willReturnArgument(0);
+
+        $this->mockHttpTransporter
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn($response);
+
+        $model = $this->createModel();
+        $result = $model->generateTextResult($prompt);
+
+        $this->assertInstanceOf(GenerativeAiResult::class, $result);
+        $this->assertEquals('msg_123', $result->getId());
+        $this->assertCount(1, $result->getCandidates());
+        $this->assertEquals(
+            FinishReasonEnum::stop(),
+            $result->getCandidates()[0]->getFinishReason()
+        );
+        $this->assertEquals('Hi there!', $result->getCandidates()[0]->getMessage()->getParts()[0]->getText());
+    }
+
+    /**
+     * Tests generateTextResult() throws when token limit is reached without tools.
+     *
+     * @return void
+     */
+    public function testGenerateTextResultThrowsTokenLimitReachedException(): void
+    {
+        $prompt = [new Message(MessageRoleEnum::user(), [new MessagePart('Tell me a very long story')])];
+        $response = new Response(
+            200,
+            [],
+            json_encode([
+                'id' => 'msg_456',
+                'role' => 'assistant',
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'Once upon a time...',
+                    ],
+                ],
+                'stop_reason' => 'max_tokens',
+                'usage' => [
+                    'input_tokens' => 25,
+                    'output_tokens' => 4096,
+                ],
+            ])
+        );
+
+        $this->mockRequestAuthentication
+            ->expects($this->once())
+            ->method('authenticateRequest')
+            ->willReturnArgument(0);
+
+        $this->mockHttpTransporter
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn($response);
+
+        $model = $this->createModel();
+
+        $this->expectException(TokenLimitReachedException::class);
+        $model->generateTextResult($prompt);
+    }
+}

--- a/tests/unit/ProviderImplementations/Anthropic/MockAnthropicTextGenerationModel.php
+++ b/tests/unit/ProviderImplementations/Anthropic/MockAnthropicTextGenerationModel.php
@@ -33,10 +33,12 @@ class MockAnthropicTextGenerationModel extends AnthropicTextGenerationModel
     /**
      * Constructor.
      *
-     * @param ModelMetadata $metadata Model metadata.
-     * @param ProviderMetadata $providerMetadata Provider metadata.
-     * @param HttpTransporterInterface&\PHPUnit\Framework\MockObject\MockObject $mockHttpTransporter Mock HTTP transporter.
-     * @param RequestAuthenticationInterface&\PHPUnit\Framework\MockObject\MockObject $mockRequestAuthentication Mock request authentication.
+     * @param ModelMetadata          $metadata              Model metadata.
+     * @param ProviderMetadata       $providerMetadata      Provider metadata.
+     * @param HttpTransporterInterface&\PHPUnit\Framework\MockObject\MockObject
+     *                               $mockHttpTransporter   Mock HTTP transporter.
+     * @param RequestAuthenticationInterface&\PHPUnit\Framework\MockObject\MockObject
+     *                               $mockRequestAuthentication Mock request authentication.
      */
     public function __construct(
         ModelMetadata $metadata,

--- a/tests/unit/ProviderImplementations/Anthropic/MockAnthropicTextGenerationModel.php
+++ b/tests/unit/ProviderImplementations/Anthropic/MockAnthropicTextGenerationModel.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Tests\unit\ProviderImplementations\Anthropic;
+
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\ProviderImplementations\Anthropic\AnthropicTextGenerationModel;
+use WordPress\AiClient\Providers\DTO\ProviderMetadata;
+use WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface;
+use WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface;
+use WordPress\AiClient\Providers\Http\DTO\Response;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\AiClient\Tools\DTO\FunctionCall;
+
+/**
+ * Mock class for testing AnthropicTextGenerationModel.
+ */
+class MockAnthropicTextGenerationModel extends AnthropicTextGenerationModel
+{
+    /**
+     * @var HttpTransporterInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $mockHttpTransporter;
+
+    /**
+     * @var RequestAuthenticationInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $mockRequestAuthentication;
+
+    /**
+     * Constructor.
+     *
+     * @param ModelMetadata $metadata Model metadata.
+     * @param ProviderMetadata $providerMetadata Provider metadata.
+     * @param HttpTransporterInterface&\PHPUnit\Framework\MockObject\MockObject $mockHttpTransporter Mock HTTP transporter.
+     * @param RequestAuthenticationInterface&\PHPUnit\Framework\MockObject\MockObject $mockRequestAuthentication Mock request authentication.
+     */
+    public function __construct(
+        ModelMetadata $metadata,
+        ProviderMetadata $providerMetadata,
+        $mockHttpTransporter,
+        $mockRequestAuthentication
+    ) {
+        parent::__construct($metadata, $providerMetadata);
+        $this->mockHttpTransporter = $mockHttpTransporter;
+        $this->mockRequestAuthentication = $mockRequestAuthentication;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getHttpTransporter(): HttpTransporterInterface
+    {
+        return $this->mockHttpTransporter;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getRequestAuthentication(): RequestAuthenticationInterface
+    {
+        return $this->mockRequestAuthentication;
+    }
+
+    /**
+     * Exposes prepareGenerateTextParams() for testing.
+     *
+     * @param list<Message> $prompt The prompt.
+     * @return array<string, mixed> The parameters.
+     */
+    public function exposePrepareGenerateTextParams(array $prompt): array
+    {
+        return $this->prepareGenerateTextParams($prompt);
+    }
+
+    /**
+     * Exposes parseResponseToGenerativeAiResult() for testing.
+     *
+     * @param Response $response The response.
+     * @return GenerativeAiResult The parsed result.
+     */
+    public function exposeParseResponseToGenerativeAiResult(Response $response): GenerativeAiResult
+    {
+        return $this->parseResponseToGenerativeAiResult($response);
+    }
+
+    /**
+     * Exposes isTokenLimitStopReason() for testing.
+     *
+     * @param string $stopReason The stop reason.
+     * @return bool Whether the stop reason indicates token limit.
+     */
+    public function exposeIsTokenLimitStopReason(string $stopReason): bool
+    {
+        return $this->isTokenLimitStopReason($stopReason);
+    }
+
+    /**
+     * Exposes getRequiredParametersByFunctionName() for testing.
+     *
+     * @return array<string, list<string>> Required parameters indexed by function name.
+     */
+    public function exposeGetRequiredParametersByFunctionName(): array
+    {
+        return $this->getRequiredParametersByFunctionName();
+    }
+
+    /**
+     * Exposes getMissingRequiredParameters() for testing.
+     *
+     * @param FunctionCall|null $functionCall The function call.
+     * @param list<string> $requiredParameters Required parameter names.
+     * @return list<string> Missing required parameters.
+     */
+    public function exposeGetMissingRequiredParameters(?FunctionCall $functionCall, array $requiredParameters): array
+    {
+        return $this->getMissingRequiredParameters($functionCall, $requiredParameters);
+    }
+
+    /**
+     * Exposes maybeThrowTokenLimitReachedException() for testing.
+     *
+     * @param array<string, mixed> $responseData The response data.
+     * @param list<MessagePart> $parts Parsed message parts.
+     * @return void
+     */
+    public function exposeMaybeThrowTokenLimitReachedException(array $responseData, array $parts): void
+    {
+        $this->maybeThrowTokenLimitReachedException($responseData, $parts);
+    }
+}


### PR DESCRIPTION
This PR adds explicit token-limit handling for Anthropic so truncated outputs are surfaced as exceptions instead of normal results.

### What changed
- Added `TokenLimitReachedException` (`src/Common/Exception/TokenLimitReachedException.php`) with structured metadata:
  - `maxTokens`
  - `providerStopReason`
  - optional `functionName`
  - optional `missingRequiredParameters`
- Updated Anthropic response parsing (`src/ProviderImplementations/Anthropic/AnthropicTextGenerationModel.php`) to throw `TokenLimitReachedException` when `stop_reason` is:
  - `max_tokens`
  - `model_context_window_exceeded`
- Added tool-call diagnostics for partial argument payloads by comparing returned args with required schema fields.
- Added Anthropic unit test scaffolding and initial coverage:
  - `tests/unit/ProviderImplementations/Anthropic/MockAnthropicTextGenerationModel.php`
  - `tests/unit/ProviderImplementations/Anthropic/AnthropicTextGenerationModelTest.php`
- Added Anthropic integration tests for max-token scenarios (plain text + tool-calling):
  - `tests/integration/Anthropic/TextGenerationIntegrationTest.php`
  - `tests/integration/Anthropic/FunctionCallingIntegrationTest.php`

  This relates to https://github.com/WordPress/php-ai-client/issues/193
  
I know that the providers will be moved to their own repositories. But as this change is still in very early stage. I decided to do this PR to the client repository, so that discussion on how this should be implemented can start.

The PR is co-authored with OpenAIs Codex 5.3 model.