### PR TITLE
Pin github actions to specific versions

### DIFF
--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -38,9 +38,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
         with:
           php-version: 'latest'
 
@@ -48,7 +48,7 @@ jobs:
         run: composer validate
 
       - name: Install PHP dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
         with:
           composer-options: '--prefer-dist'
 

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -32,12 +32,12 @@ jobs:
     strategy:
       matrix:
         php-version: ['7.4', '8.0', '8.4']
+        coverage: [true, false]
 
     steps:
-    - uses: actions/checkout@v4
-
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
       with:
         php-version: ${{ matrix.php-version }}
         coverage: xdebug
@@ -47,7 +47,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v3
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -32,7 +32,6 @@ jobs:
     strategy:
       matrix:
         php-version: ['7.4', '8.0', '8.4']
-        coverage: [true, false]
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
This pins each of the 3rd party actions to a specific hash to ensure it is immutable.

Also updates a few actions to the most recent version.

Fixes #196.