### PR TITLE
Fix: corrects test namespaces

### DIFF
--- a/tests/unit/Builders/MessageBuilderTest.php
+++ b/tests/unit/Builders/MessageBuilderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WordPress\AiClient\Tests\Unit\Builders;
+namespace WordPress\AiClient\Tests\unit\Builders;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/Providers/Http/Collections/HeadersCollectionTest.php
+++ b/tests/unit/Providers/Http/Collections/HeadersCollectionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WordPress\AiClient\Tests\Unit\Providers\Http\Collections;
+namespace WordPress\AiClient\Tests\unit\Providers\Http\Collections;
 
 use PHPUnit\Framework\TestCase;
 use WordPress\AiClient\Providers\Http\Collections\HeadersCollection;

--- a/tests/unit/Providers/Http/Enums/HttpMethodEnumTest.php
+++ b/tests/unit/Providers/Http/Enums/HttpMethodEnumTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WordPress\AiClient\Tests\Unit\Providers\Http\Enums;
+namespace WordPress\AiClient\Tests\unit\Providers\Http\Enums;
 
 use PHPUnit\Framework\TestCase;
 use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;

--- a/tests/unit/Providers/Http/HttpTransporterFactoryTest.php
+++ b/tests/unit/Providers/Http/HttpTransporterFactoryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WordPress\AiClient\Tests\Providers\Http;
+namespace WordPress\AiClient\Tests\unit\Providers\Http;
 
 use PHPUnit\Framework\TestCase;
 use WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface;

--- a/tests/unit/Providers/Http/HttpTransporterTest.php
+++ b/tests/unit/Providers/Http/HttpTransporterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WordPress\AiClient\Tests\Providers\Http;
+namespace WordPress\AiClient\Tests\unit\Providers\Http;
 
 use GuzzleHttp\Psr7\HttpFactory;
 use GuzzleHttp\Psr7\Response as Psr7Response;


### PR DESCRIPTION
Fixes #201 

A couple test namespaces were not case correct which was throwing warnings when running `composer install`. This corrects that so composer install is now a stress free endeavor. 😌