### PR TITLE
Adds TokenLimitReachedException for providers

### DIFF
--- a/src/Common/Exception/TokenLimitReachedException.php
+++ b/src/Common/Exception/TokenLimitReachedException.php
@@ -11,14 +11,14 @@ namespace WordPress\AiClient\Common\Exception;
  * exceeds the allowed limit, whether that is the model's context window
  * or a configured maximum.
  *
- * @since 0.4.0
+ * @since n.e.x.t
  */
 class TokenLimitReachedException extends RuntimeException
 {
     /**
      * The token limit that was reached, if known.
      *
-     * @since 0.4.0
+     * @since n.e.x.t
      *
      * @var int|null
      */
@@ -27,7 +27,7 @@ class TokenLimitReachedException extends RuntimeException
     /**
      * Creates a new TokenLimitReachedException.
      *
-     * @since 0.4.0
+     * @since n.e.x.t
      *
      * @param string         $message   The exception message.
      * @param int|null       $maxTokens The token limit that was reached, if known.
@@ -43,7 +43,7 @@ class TokenLimitReachedException extends RuntimeException
     /**
      * Returns the token limit that was reached, if known.
      *
-     * @since 0.4.0
+     * @since n.e.x.t
      *
      * @return int|null The token limit, or null if not provided.
      */

--- a/src/Common/Exception/TokenLimitReachedException.php
+++ b/src/Common/Exception/TokenLimitReachedException.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Common\Exception;
+
+/**
+ * Exception thrown when a token limit is reached during prompt fulfillment.
+ *
+ * Providers should throw this exception when the token usage for a request
+ * exceeds the allowed limit, whether that is the model's context window
+ * or a configured maximum.
+ *
+ * @since 0.4.0
+ */
+class TokenLimitReachedException extends RuntimeException
+{
+    /**
+     * The token limit that was reached, if known.
+     *
+     * @since 0.4.0
+     *
+     * @var int|null
+     */
+    private $maxTokens;
+
+    /**
+     * Creates a new TokenLimitReachedException.
+     *
+     * @since 0.4.0
+     *
+     * @param string         $message   The exception message.
+     * @param int|null       $maxTokens The token limit that was reached, if known.
+     * @param \Throwable|null $previous  The previous throwable used for exception chaining.
+     */
+    public function __construct(string $message = '', ?int $maxTokens = null, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+
+        $this->maxTokens = $maxTokens;
+    }
+
+    /**
+     * Returns the token limit that was reached, if known.
+     *
+     * @since 0.4.0
+     *
+     * @return int|null The token limit, or null if not provided.
+     */
+    public function getMaxTokens(): ?int
+    {
+        return $this->maxTokens;
+    }
+}

--- a/tests/unit/Exceptions/ExceptionsTest.php
+++ b/tests/unit/Exceptions/ExceptionsTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use WordPress\AiClient\Common\Contracts\AiClientExceptionInterface;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Common\Exception\RuntimeException;
+use WordPress\AiClient\Common\Exception\TokenLimitReachedException;
 use WordPress\AiClient\Providers\Http\Exception\ClientException;
 use WordPress\AiClient\Providers\Http\Exception\NetworkException;
 
@@ -18,6 +19,7 @@ use WordPress\AiClient\Providers\Http\Exception\NetworkException;
  * @covers \WordPress\AiClient\Common\Exception\InvalidArgumentException
  * @covers \WordPress\AiClient\Common\Exception\RuntimeException
  * @covers \WordPress\AiClient\Common\Contracts\AiClientExceptionInterface
+ * @covers \WordPress\AiClient\Common\Exception\TokenLimitReachedException
  * @covers \WordPress\AiClient\Providers\Http\Exception\NetworkException
  * @covers \WordPress\AiClient\Providers\Http\Exception\ClientException
  */
@@ -28,6 +30,7 @@ class ExceptionsTest extends TestCase
         $exceptions = [
             new InvalidArgumentException('test'),
             new RuntimeException('test'),
+            new TokenLimitReachedException('test'),
             new NetworkException('test'),
             new ClientException('test'),
         ];
@@ -37,11 +40,33 @@ class ExceptionsTest extends TestCase
         }
     }
 
+    public function testTokenLimitReachedExceptionExtendsRuntimeException(): void
+    {
+        $exception = new TokenLimitReachedException('token limit reached');
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testTokenLimitReachedExceptionMaxTokensDefaultsToNull(): void
+    {
+        $exception = new TokenLimitReachedException('token limit reached');
+
+        $this->assertNull($exception->getMaxTokens());
+    }
+
+    public function testTokenLimitReachedExceptionStoresMaxTokens(): void
+    {
+        $exception = new TokenLimitReachedException('token limit reached', 4096);
+
+        $this->assertSame(4096, $exception->getMaxTokens());
+    }
+
     public function testCatchAllFunctionality(): void
     {
         $exceptions = [
             new InvalidArgumentException('invalid error'),
             new RuntimeException('runtime error'),
+            new TokenLimitReachedException('token limit error'),
             new NetworkException('network error'),
             new ClientException('client error'),
         ];


### PR DESCRIPTION
## Summary
- Adds TokenLimitReachedException for providers to throw when a prompt exceeds the model's context window
   or a configured token maximum
  - Includes an optional $maxTokens parameter so callers catching the exception can programmatically       
  inspect the limit that was hit (e.g., to retry with a shorter prompt or surface a meaningful error to end
   users)

This is a smaller follow up to #194, as the providers are no longer bundled. I didn't bring over all the parameters for the exception in that PR because I wasn't sure what they were all for. Happy to add them back if there's strong reasoning!