### PR TITLE
Adds built-in support for basic PSR7 and 17 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,12 @@
     "require": {
         "php": ">=7.4",
         "ext-json": "*",
+        "nyholm/psr7": "^1.8",
         "php-http/discovery": "^1.0",
         "php-http/httplug": "^2.0",
+        "psr/event-dispatcher": "^1.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "psr/event-dispatcher": "^1.0",
         "psr/http-message": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,86 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "454eaacbc800be25f8903c6769b72012",
+    "content-hash": "ba8ef0c4a9742a79115e930f1f4a82f5",
     "packages": [
+        {
+            "name": "nyholm/psr7",
+            "version": "1.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Nyholm/psr7.git",
+                "reference": "a71f2b11690f4b24d099d6b16690a90ae14fc6f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Nyholm/psr7/zipball/a71f2b11690f4b24d099d6b16690a90ae14fc6f3",
+                "reference": "a71f2b11690f4b24d099d6b16690a90ae14fc6f3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "provide": {
+                "php-http/message-factory-implementation": "1.0",
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "http-interop/http-factory-tests": "^0.9",
+                "php-http/message-factory": "^1.0",
+                "php-http/psr7-integration-tests": "^1.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.4",
+                "symfony/error-handler": "^4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nyholm\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                },
+                {
+                    "name": "Martijn van der Ven",
+                    "email": "martijn@vanderven.se"
+                }
+            ],
+            "description": "A fast PHP7 implementation of PSR-7",
+            "homepage": "https://tnyholm.se",
+            "keywords": [
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "issues": "https://github.com/Nyholm/psr7/issues",
+                "source": "https://github.com/Nyholm/psr7/tree/1.8.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Zegnat",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-09-09T07:06:30+00:00"
+        },
         {
             "name": "php-http/discovery",
             "version": "1.20.0",
@@ -3831,5 +3909,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/AiClient.php
+++ b/src/AiClient.php
@@ -86,7 +86,7 @@ class AiClient
     /**
      * @var string The version of the AI Client.
      */
-    public const VERSION = '1.0.0';
+    public const VERSION = '1.1.0';
 
     /**
      * @var ProviderRegistry|null The default provider registry instance.

--- a/src/Providers/Http/Abstracts/AbstractClientDiscoveryStrategy.php
+++ b/src/Providers/Http/Abstracts/AbstractClientDiscoveryStrategy.php
@@ -17,14 +17,14 @@ use Psr\Http\Client\ClientInterface;
  * the createClient() method to provide their specific PSR-18
  * HTTP client instance using the provided Psr17Factory.
  *
- * @since n.e.x.t
+ * @since 1.1.0
  */
 abstract class AbstractClientDiscoveryStrategy implements DiscoveryStrategy
 {
     /**
      * Initializes and registers the discovery strategy.
      *
-     * @since n.e.x.t
+     * @since 1.1.0
      *
      * @return void
      */
@@ -40,7 +40,7 @@ abstract class AbstractClientDiscoveryStrategy implements DiscoveryStrategy
     /**
      * {@inheritDoc}
      *
-     * @since n.e.x.t
+     * @since 1.1.0
      *
      * @param string $type The type of discovery.
      * @return array<array<string, mixed>> The discovery candidates.
@@ -86,7 +86,7 @@ abstract class AbstractClientDiscoveryStrategy implements DiscoveryStrategy
      * all PSR-17 interfaces (RequestFactory, ResponseFactory, StreamFactory,
      * etc.) and can be used to satisfy client constructor dependencies.
      *
-     * @since n.e.x.t
+     * @since 1.1.0
      *
      * @param Psr17Factory $psr17Factory The PSR-17 factory for creating HTTP messages.
      * @return ClientInterface The PSR-18 HTTP client.

--- a/src/Providers/Http/Abstracts/AbstractClientDiscoveryStrategy.php
+++ b/src/Providers/Http/Abstracts/AbstractClientDiscoveryStrategy.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Providers\Http\Abstracts;
+
+use Http\Discovery\Psr18ClientDiscovery;
+use Http\Discovery\Strategy\DiscoveryStrategy;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Client\ClientInterface;
+
+/**
+ * Abstract discovery strategy for HTTP client implementations.
+ *
+ * Provides a base for registering custom HTTP client implementations
+ * with HTTPlug's discovery mechanism. Subclasses must implement
+ * the createClient() method to provide their specific PSR-18
+ * HTTP client instance using the provided Psr17Factory.
+ *
+ * @since n.e.x.t
+ */
+abstract class AbstractClientDiscoveryStrategy implements DiscoveryStrategy
+{
+    /**
+     * Initializes and registers the discovery strategy.
+     *
+     * @since n.e.x.t
+     *
+     * @return void
+     */
+    public static function init(): void
+    {
+        if (!class_exists('\Http\Discovery\Psr18ClientDiscovery')) {
+            return;
+        }
+
+        Psr18ClientDiscovery::prependStrategy(static::class);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     *
+     * @param string $type The type of discovery.
+     * @return array<array<string, mixed>> The discovery candidates.
+     */
+    public static function getCandidates($type)
+    {
+        if (ClientInterface::class === $type) {
+            return [
+                [
+                    'class' => static function () {
+                        $psr17Factory = new Psr17Factory();
+                        return static::createClient($psr17Factory);
+                    },
+                ],
+            ];
+        }
+
+        $psr17Factories = [
+            'Psr\Http\Message\RequestFactoryInterface',
+            'Psr\Http\Message\ResponseFactoryInterface',
+            'Psr\Http\Message\ServerRequestFactoryInterface',
+            'Psr\Http\Message\StreamFactoryInterface',
+            'Psr\Http\Message\UploadedFileFactoryInterface',
+            'Psr\Http\Message\UriFactoryInterface',
+        ];
+
+        if (in_array($type, $psr17Factories, true)) {
+            return [
+                [
+                    'class' => Psr17Factory::class,
+                ],
+            ];
+        }
+
+        return [];
+    }
+
+    /**
+     * Creates an instance of the HTTP client.
+     *
+     * Subclasses must implement this method to return their specific
+     * PSR-18 HTTP client instance. The provided Psr17Factory implements
+     * all PSR-17 interfaces (RequestFactory, ResponseFactory, StreamFactory,
+     * etc.) and can be used to satisfy client constructor dependencies.
+     *
+     * @since n.e.x.t
+     *
+     * @param Psr17Factory $psr17Factory The PSR-17 factory for creating HTTP messages.
+     * @return ClientInterface The PSR-18 HTTP client.
+     */
+    abstract protected static function createClient(Psr17Factory $psr17Factory): ClientInterface;
+}

--- a/tests/mocks/ConcreteClientDiscoveryStrategy.php
+++ b/tests/mocks/ConcreteClientDiscoveryStrategy.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Tests\mocks;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Client\ClientInterface;
+use WordPress\AiClient\Providers\Http\Abstracts\AbstractClientDiscoveryStrategy;
+
+/**
+ * Concrete implementation of AbstractClientDiscoveryStrategy for testing.
+ */
+class ConcreteClientDiscoveryStrategy extends AbstractClientDiscoveryStrategy
+{
+    /**
+     * @var ClientInterface|null The client to return from createClient().
+     */
+    private static ?ClientInterface $clientToReturn = null;
+
+    /**
+     * @var Psr17Factory|null The last Psr17Factory received by createClient().
+     */
+    private static ?Psr17Factory $lastPsr17Factory = null;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param Psr17Factory $psr17Factory The PSR-17 factory for creating HTTP messages.
+     * @return ClientInterface The PSR-18 HTTP client.
+     */
+    protected static function createClient(Psr17Factory $psr17Factory): ClientInterface
+    {
+        self::$lastPsr17Factory = $psr17Factory;
+
+        /** @var ClientInterface $client */
+        $client = self::$clientToReturn;
+
+        return $client;
+    }
+
+    /**
+     * Sets the client instance that createClient() will return.
+     *
+     * @param ClientInterface $client The client to return.
+     * @return void
+     */
+    public static function setClientToReturn(ClientInterface $client): void
+    {
+        self::$clientToReturn = $client;
+    }
+
+    /**
+     * Returns the last Psr17Factory passed to createClient().
+     *
+     * @return Psr17Factory|null The last factory instance, or null if not called.
+     */
+    public static function getLastPsr17Factory(): ?Psr17Factory
+    {
+        return self::$lastPsr17Factory;
+    }
+
+    /**
+     * Resets the static state for test isolation.
+     *
+     * @return void
+     */
+    public static function reset(): void
+    {
+        self::$clientToReturn = null;
+        self::$lastPsr17Factory = null;
+    }
+}

--- a/tests/mocks/MockClientDiscoveryStrategy.php
+++ b/tests/mocks/MockClientDiscoveryStrategy.php
@@ -9,9 +9,9 @@ use Psr\Http\Client\ClientInterface;
 use WordPress\AiClient\Providers\Http\Abstracts\AbstractClientDiscoveryStrategy;
 
 /**
- * Concrete implementation of AbstractClientDiscoveryStrategy for testing.
+ * Mock implementation of AbstractClientDiscoveryStrategy for testing.
  */
-class ConcreteClientDiscoveryStrategy extends AbstractClientDiscoveryStrategy
+class MockClientDiscoveryStrategy extends AbstractClientDiscoveryStrategy
 {
     /**
      * @var ClientInterface|null The client to return from createClient().

--- a/tests/unit/Providers/Http/Abstracts/AbstractClientDiscoveryStrategyTest.php
+++ b/tests/unit/Providers/Http/Abstracts/AbstractClientDiscoveryStrategyTest.php
@@ -9,7 +9,7 @@ use Http\Mock\Client as MockClient;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
-use WordPress\AiClient\Tests\mocks\ConcreteClientDiscoveryStrategy;
+use WordPress\AiClient\Tests\mocks\MockClientDiscoveryStrategy;
 
 /**
  * @covers \WordPress\AiClient\Providers\Http\Abstracts\AbstractClientDiscoveryStrategy
@@ -43,7 +43,7 @@ class AbstractClientDiscoveryStrategyTest extends TestCase
     protected function tearDown(): void
     {
         ClassDiscovery::setStrategies($this->originalStrategies);
-        ConcreteClientDiscoveryStrategy::reset();
+        MockClientDiscoveryStrategy::reset();
 
         parent::tearDown();
     }
@@ -58,7 +58,7 @@ class AbstractClientDiscoveryStrategyTest extends TestCase
     public function testGetCandidatesReturnsClientCandidateForClientInterfaceType(): void
     {
         // Act
-        $candidates = ConcreteClientDiscoveryStrategy::getCandidates(ClientInterface::class);
+        $candidates = MockClientDiscoveryStrategy::getCandidates(ClientInterface::class);
 
         // Assert
         $this->assertIsArray($candidates);
@@ -78,16 +78,16 @@ class AbstractClientDiscoveryStrategyTest extends TestCase
     {
         // Arrange
         $mockClient = new MockClient();
-        ConcreteClientDiscoveryStrategy::setClientToReturn($mockClient);
+        MockClientDiscoveryStrategy::setClientToReturn($mockClient);
 
-        $candidates = ConcreteClientDiscoveryStrategy::getCandidates(ClientInterface::class);
+        $candidates = MockClientDiscoveryStrategy::getCandidates(ClientInterface::class);
 
         // Act
         $result = $candidates[0]['class']();
 
         // Assert
         $this->assertSame($mockClient, $result);
-        $this->assertInstanceOf(Psr17Factory::class, ConcreteClientDiscoveryStrategy::getLastPsr17Factory());
+        $this->assertInstanceOf(Psr17Factory::class, MockClientDiscoveryStrategy::getLastPsr17Factory());
     }
 
     /**
@@ -100,7 +100,7 @@ class AbstractClientDiscoveryStrategyTest extends TestCase
     public function testGetCandidatesReturnsPsr17FactoryForRequestFactoryInterface(): void
     {
         // Act
-        $candidates = ConcreteClientDiscoveryStrategy::getCandidates(
+        $candidates = MockClientDiscoveryStrategy::getCandidates(
             'Psr\Http\Message\RequestFactoryInterface'
         );
 
@@ -120,7 +120,7 @@ class AbstractClientDiscoveryStrategyTest extends TestCase
     public function testGetCandidatesReturnsPsr17FactoryForResponseFactoryInterface(): void
     {
         // Act
-        $candidates = ConcreteClientDiscoveryStrategy::getCandidates(
+        $candidates = MockClientDiscoveryStrategy::getCandidates(
             'Psr\Http\Message\ResponseFactoryInterface'
         );
 
@@ -139,7 +139,7 @@ class AbstractClientDiscoveryStrategyTest extends TestCase
     public function testGetCandidatesReturnsPsr17FactoryForStreamFactoryInterface(): void
     {
         // Act
-        $candidates = ConcreteClientDiscoveryStrategy::getCandidates(
+        $candidates = MockClientDiscoveryStrategy::getCandidates(
             'Psr\Http\Message\StreamFactoryInterface'
         );
 
@@ -158,7 +158,7 @@ class AbstractClientDiscoveryStrategyTest extends TestCase
     public function testGetCandidatesReturnsPsr17FactoryForUriFactoryInterface(): void
     {
         // Act
-        $candidates = ConcreteClientDiscoveryStrategy::getCandidates(
+        $candidates = MockClientDiscoveryStrategy::getCandidates(
             'Psr\Http\Message\UriFactoryInterface'
         );
 
@@ -177,7 +177,7 @@ class AbstractClientDiscoveryStrategyTest extends TestCase
     public function testGetCandidatesReturnsPsr17FactoryForServerRequestFactoryInterface(): void
     {
         // Act
-        $candidates = ConcreteClientDiscoveryStrategy::getCandidates(
+        $candidates = MockClientDiscoveryStrategy::getCandidates(
             'Psr\Http\Message\ServerRequestFactoryInterface'
         );
 
@@ -196,7 +196,7 @@ class AbstractClientDiscoveryStrategyTest extends TestCase
     public function testGetCandidatesReturnsPsr17FactoryForUploadedFileFactoryInterface(): void
     {
         // Act
-        $candidates = ConcreteClientDiscoveryStrategy::getCandidates(
+        $candidates = MockClientDiscoveryStrategy::getCandidates(
             'Psr\Http\Message\UploadedFileFactoryInterface'
         );
 
@@ -215,7 +215,7 @@ class AbstractClientDiscoveryStrategyTest extends TestCase
     public function testGetCandidatesReturnsEmptyArrayForUnknownType(): void
     {
         // Act
-        $candidates = ConcreteClientDiscoveryStrategy::getCandidates('Some\Unknown\Interface');
+        $candidates = MockClientDiscoveryStrategy::getCandidates('Some\Unknown\Interface');
 
         // Assert
         $this->assertIsArray($candidates);
@@ -235,11 +235,11 @@ class AbstractClientDiscoveryStrategyTest extends TestCase
         $strategiesBefore = ClassDiscovery::getStrategies();
 
         // Act
-        ConcreteClientDiscoveryStrategy::init();
+        MockClientDiscoveryStrategy::init();
 
         // Assert
         $strategiesAfter = ClassDiscovery::getStrategies();
-        $this->assertContains(ConcreteClientDiscoveryStrategy::class, $strategiesAfter);
-        $this->assertNotContains(ConcreteClientDiscoveryStrategy::class, $strategiesBefore);
+        $this->assertContains(MockClientDiscoveryStrategy::class, $strategiesAfter);
+        $this->assertNotContains(MockClientDiscoveryStrategy::class, $strategiesBefore);
     }
 }

--- a/tests/unit/Providers/Http/Abstracts/AbstractClientDiscoveryStrategyTest.php
+++ b/tests/unit/Providers/Http/Abstracts/AbstractClientDiscoveryStrategyTest.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Tests\unit\Providers\Http\Abstracts;
+
+use Http\Discovery\ClassDiscovery;
+use Http\Mock\Client as MockClient;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use WordPress\AiClient\Tests\mocks\ConcreteClientDiscoveryStrategy;
+
+/**
+ * @covers \WordPress\AiClient\Providers\Http\Abstracts\AbstractClientDiscoveryStrategy
+ */
+class AbstractClientDiscoveryStrategyTest extends TestCase
+{
+    /**
+     * @var string[] Original discovery strategies to restore after each test.
+     */
+    private array $originalStrategies;
+
+    /**
+     * Saves the original discovery strategies before each test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var string[] $strategies */
+        $strategies = ClassDiscovery::getStrategies();
+        $this->originalStrategies = $strategies;
+    }
+
+    /**
+     * Restores discovery strategies and resets static state after each test.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        ClassDiscovery::setStrategies($this->originalStrategies);
+        ConcreteClientDiscoveryStrategy::reset();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Tests that getCandidates returns a client candidate for PSR-18 ClientInterface type.
+     *
+     * @covers ::getCandidates
+     *
+     * @return void
+     */
+    public function testGetCandidatesReturnsClientCandidateForClientInterfaceType(): void
+    {
+        // Act
+        $candidates = ConcreteClientDiscoveryStrategy::getCandidates(ClientInterface::class);
+
+        // Assert
+        $this->assertIsArray($candidates);
+        $this->assertCount(1, $candidates);
+        $this->assertArrayHasKey('class', $candidates[0]);
+        $this->assertIsCallable($candidates[0]['class']);
+    }
+
+    /**
+     * Tests that the client candidate closure invokes createClient with a Psr17Factory.
+     *
+     * @covers ::getCandidates
+     *
+     * @return void
+     */
+    public function testClientCandidateClosurePassesPsr17FactoryToCreateClient(): void
+    {
+        // Arrange
+        $mockClient = new MockClient();
+        ConcreteClientDiscoveryStrategy::setClientToReturn($mockClient);
+
+        $candidates = ConcreteClientDiscoveryStrategy::getCandidates(ClientInterface::class);
+
+        // Act
+        $result = $candidates[0]['class']();
+
+        // Assert
+        $this->assertSame($mockClient, $result);
+        $this->assertInstanceOf(Psr17Factory::class, ConcreteClientDiscoveryStrategy::getLastPsr17Factory());
+    }
+
+    /**
+     * Tests that getCandidates returns Psr17Factory for PSR-17 request factory type.
+     *
+     * @covers ::getCandidates
+     *
+     * @return void
+     */
+    public function testGetCandidatesReturnsPsr17FactoryForRequestFactoryInterface(): void
+    {
+        // Act
+        $candidates = ConcreteClientDiscoveryStrategy::getCandidates(
+            'Psr\Http\Message\RequestFactoryInterface'
+        );
+
+        // Assert
+        $this->assertIsArray($candidates);
+        $this->assertCount(1, $candidates);
+        $this->assertSame(Psr17Factory::class, $candidates[0]['class']);
+    }
+
+    /**
+     * Tests that getCandidates returns Psr17Factory for PSR-17 response factory type.
+     *
+     * @covers ::getCandidates
+     *
+     * @return void
+     */
+    public function testGetCandidatesReturnsPsr17FactoryForResponseFactoryInterface(): void
+    {
+        // Act
+        $candidates = ConcreteClientDiscoveryStrategy::getCandidates(
+            'Psr\Http\Message\ResponseFactoryInterface'
+        );
+
+        // Assert
+        $this->assertCount(1, $candidates);
+        $this->assertSame(Psr17Factory::class, $candidates[0]['class']);
+    }
+
+    /**
+     * Tests that getCandidates returns Psr17Factory for PSR-17 stream factory type.
+     *
+     * @covers ::getCandidates
+     *
+     * @return void
+     */
+    public function testGetCandidatesReturnsPsr17FactoryForStreamFactoryInterface(): void
+    {
+        // Act
+        $candidates = ConcreteClientDiscoveryStrategy::getCandidates(
+            'Psr\Http\Message\StreamFactoryInterface'
+        );
+
+        // Assert
+        $this->assertCount(1, $candidates);
+        $this->assertSame(Psr17Factory::class, $candidates[0]['class']);
+    }
+
+    /**
+     * Tests that getCandidates returns Psr17Factory for PSR-17 URI factory type.
+     *
+     * @covers ::getCandidates
+     *
+     * @return void
+     */
+    public function testGetCandidatesReturnsPsr17FactoryForUriFactoryInterface(): void
+    {
+        // Act
+        $candidates = ConcreteClientDiscoveryStrategy::getCandidates(
+            'Psr\Http\Message\UriFactoryInterface'
+        );
+
+        // Assert
+        $this->assertCount(1, $candidates);
+        $this->assertSame(Psr17Factory::class, $candidates[0]['class']);
+    }
+
+    /**
+     * Tests that getCandidates returns Psr17Factory for PSR-17 server request factory type.
+     *
+     * @covers ::getCandidates
+     *
+     * @return void
+     */
+    public function testGetCandidatesReturnsPsr17FactoryForServerRequestFactoryInterface(): void
+    {
+        // Act
+        $candidates = ConcreteClientDiscoveryStrategy::getCandidates(
+            'Psr\Http\Message\ServerRequestFactoryInterface'
+        );
+
+        // Assert
+        $this->assertCount(1, $candidates);
+        $this->assertSame(Psr17Factory::class, $candidates[0]['class']);
+    }
+
+    /**
+     * Tests that getCandidates returns Psr17Factory for PSR-17 upload file factory type.
+     *
+     * @covers ::getCandidates
+     *
+     * @return void
+     */
+    public function testGetCandidatesReturnsPsr17FactoryForUploadedFileFactoryInterface(): void
+    {
+        // Act
+        $candidates = ConcreteClientDiscoveryStrategy::getCandidates(
+            'Psr\Http\Message\UploadedFileFactoryInterface'
+        );
+
+        // Assert
+        $this->assertCount(1, $candidates);
+        $this->assertSame(Psr17Factory::class, $candidates[0]['class']);
+    }
+
+    /**
+     * Tests that getCandidates returns an empty array for an unknown type.
+     *
+     * @covers ::getCandidates
+     *
+     * @return void
+     */
+    public function testGetCandidatesReturnsEmptyArrayForUnknownType(): void
+    {
+        // Act
+        $candidates = ConcreteClientDiscoveryStrategy::getCandidates('Some\Unknown\Interface');
+
+        // Assert
+        $this->assertIsArray($candidates);
+        $this->assertCount(0, $candidates);
+    }
+
+    /**
+     * Tests that init registers the strategy with Psr18ClientDiscovery.
+     *
+     * @covers ::init
+     *
+     * @return void
+     */
+    public function testInitRegistersStrategyWithDiscovery(): void
+    {
+        // Arrange
+        $strategiesBefore = ClassDiscovery::getStrategies();
+
+        // Act
+        ConcreteClientDiscoveryStrategy::init();
+
+        // Assert
+        $strategiesAfter = ClassDiscovery::getStrategies();
+        $this->assertContains(ConcreteClientDiscoveryStrategy::class, $strategiesAfter);
+        $this->assertNotContains(ConcreteClientDiscoveryStrategy::class, $strategiesBefore);
+    }
+}


### PR DESCRIPTION
This introduces basic support for PSR7 and PSR17 along with an abstract discovery class. This way implementing systems can use these built-in classes so they don't have to introduce their own and can simply create their own HTTP Client.