### PR TITLE
Fix: SupportedOption::isSupportedValue() fails after Redis deserialization

### DIFF
--- a/src/Providers/Models/DTO/SupportedOption.php
+++ b/src/Providers/Models/DTO/SupportedOption.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace WordPress\AiClient\Providers\Models\DTO;
 
 use WordPress\AiClient\Common\AbstractDataTransferObject;
+use WordPress\AiClient\Common\AbstractEnum;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Providers\Models\Enums\OptionEnum;
 
@@ -87,20 +88,65 @@ class SupportedOption extends AbstractDataTransferObject
 
         // If the value is an array, consider it a set (i.e. order doesn't matter).
         if (is_array($value)) {
-            sort($value);
+            $normalizedValue = self::normalizeArrayForComparison($value);
             foreach ($this->supportedValues as $supportedValue) {
                 if (!is_array($supportedValue)) {
                     continue;
                 }
-                sort($supportedValue);
-                if ($value === $supportedValue) {
+                $normalizedSupported = self::normalizeArrayForComparison($supportedValue);
+                if ($normalizedValue === $normalizedSupported) {
                     return true;
                 }
             }
             return false;
         }
 
-        return in_array($value, $this->supportedValues, true);
+        $normalizedValue = self::normalizeValue($value);
+        foreach ($this->supportedValues as $supportedValue) {
+            if (self::normalizeValue($supportedValue) === $normalizedValue) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Normalizes an AbstractEnum instance to its string value.
+     *
+     * This ensures comparisons work correctly even after deserialization
+     * (e.g. Redis/Memcached object cache), where AbstractEnum singletons
+     * are reconstructed as separate instances.
+     *
+     * @since 1.2.1
+     *
+     * @param mixed $value The value to normalize.
+     * @return mixed The normalized value.
+     */
+    private static function normalizeValue($value)
+    {
+        if ($value instanceof AbstractEnum) {
+            return $value->value;
+        }
+        return $value;
+    }
+
+    /**
+     * Normalizes and sorts an array for comparison.
+     *
+     * Maps each element through normalizeValue() and sorts the result,
+     * ensuring consistent comparison regardless of element order or
+     * AbstractEnum instance identity.
+     *
+     * @since 1.2.1
+     *
+     * @param array<mixed> $items The array to normalize.
+     * @return array<mixed> The normalized, sorted array.
+     */
+    private static function normalizeArrayForComparison(array $items): array
+    {
+        $normalized = array_map([self::class, 'normalizeValue'], $items);
+        sort($normalized);
+        return $normalized;
     }
 
     /**

--- a/tests/unit/Providers/Models/DTO/SupportedOptionTest.php
+++ b/tests/unit/Providers/Models/DTO/SupportedOptionTest.php
@@ -598,7 +598,8 @@ class SupportedOptionTest extends TestCase
         // Fresh singleton enums in arrays should still match
         $this->assertTrue($deserialized->isSupportedValue([ModalityEnum::text()]));
         $this->assertTrue($deserialized->isSupportedValue([ModalityEnum::text(), ModalityEnum::image()]));
-        $this->assertTrue($deserialized->isSupportedValue([ModalityEnum::image(), ModalityEnum::text()])); // Order shouldn't matter
+        // Order shouldn't matter
+        $this->assertTrue($deserialized->isSupportedValue([ModalityEnum::image(), ModalityEnum::text()]));
         $this->assertFalse($deserialized->isSupportedValue([ModalityEnum::audio()]));
         $this->assertFalse($deserialized->isSupportedValue([ModalityEnum::text(), ModalityEnum::audio()]));
     }

--- a/tests/unit/Providers/Models/DTO/SupportedOptionTest.php
+++ b/tests/unit/Providers/Models/DTO/SupportedOptionTest.php
@@ -8,6 +8,7 @@ use JsonSerializable;
 use PHPUnit\Framework\TestCase;
 use WordPress\AiClient\Common\Contracts\WithArrayTransformationInterface;
 use WordPress\AiClient\Common\Contracts\WithJsonSchemaInterface;
+use WordPress\AiClient\Messages\Enums\ModalityEnum;
 use WordPress\AiClient\Providers\Models\DTO\SupportedOption;
 use WordPress\AiClient\Providers\Models\Enums\OptionEnum;
 
@@ -545,5 +546,60 @@ class SupportedOptionTest extends TestCase
         $this->assertArrayHasKey('required', $schema);
         $this->assertEquals([SupportedOption::KEY_NAME], $schema['required']);
         $this->assertNotContains(SupportedOption::KEY_SUPPORTED_VALUES, $schema['required']);
+    }
+
+    /**
+     * Tests isSupportedValue works after serialize/unserialize with scalar enum values.
+     *
+     * When WordPress uses a persistent object cache (Redis/Memcached), model metadata
+     * gets serialized. AbstractEnum singletons are reconstructed as new instances on
+     * unserialize, breaking strict identity (===) comparison.
+     *
+     * @return void
+     */
+    public function testIsSupportedValueWithDeserializedEnumInSupportedValues(): void
+    {
+        $option = new SupportedOption(
+            OptionEnum::outputModalities(),
+            [ModalityEnum::text(), ModalityEnum::image(), ModalityEnum::audio()]
+        );
+
+        // Simulate Redis/Memcached round-trip
+        $deserialized = unserialize(serialize($option));
+
+        // Fresh singleton enums should still match deserialized supported values
+        $this->assertTrue($deserialized->isSupportedValue(ModalityEnum::text()));
+        $this->assertTrue($deserialized->isSupportedValue(ModalityEnum::image()));
+        $this->assertTrue($deserialized->isSupportedValue(ModalityEnum::audio()));
+        $this->assertFalse($deserialized->isSupportedValue(ModalityEnum::video()));
+    }
+
+    /**
+     * Tests isSupportedValue works after serialize/unserialize with array enum values.
+     *
+     * This covers the pattern used in model metadata where supported values are arrays
+     * of enums, e.g. [[ModalityEnum::text()], [ModalityEnum::text(), ModalityEnum::image()]].
+     *
+     * @return void
+     */
+    public function testIsSupportedValueWithDeserializedEnumArrayValues(): void
+    {
+        $option = new SupportedOption(
+            OptionEnum::outputModalities(),
+            [
+                [ModalityEnum::text()],
+                [ModalityEnum::text(), ModalityEnum::image()],
+            ]
+        );
+
+        // Simulate Redis/Memcached round-trip
+        $deserialized = unserialize(serialize($option));
+
+        // Fresh singleton enums in arrays should still match
+        $this->assertTrue($deserialized->isSupportedValue([ModalityEnum::text()]));
+        $this->assertTrue($deserialized->isSupportedValue([ModalityEnum::text(), ModalityEnum::image()]));
+        $this->assertTrue($deserialized->isSupportedValue([ModalityEnum::image(), ModalityEnum::text()])); // Order shouldn't matter
+        $this->assertFalse($deserialized->isSupportedValue([ModalityEnum::audio()]));
+        $this->assertFalse($deserialized->isSupportedValue([ModalityEnum::text(), ModalityEnum::audio()]));
     }
 }


### PR DESCRIPTION
## Summary

- Fixes `SupportedOption::isSupportedValue()` failing when `AbstractEnum` singletons are deserialized from a persistent object cache (Redis/Memcached)
- Normalizes `AbstractEnum` instances to their string `->value` before comparison, so object identity (`===`) no longer breaks after `unserialize()`
- Adds tests verifying both scalar and array enum values survive serialize/unserialize round-trips

Closes #212

## Test plan

- [ ] `vendor/bin/phpunit --filter SupportedOptionTest` — passing
- [ ] `vendor/bin/phpcs --standard=phpcs.xml.dist src/Providers/Models/DTO/SupportedOption.php` — clean
- [ ] `vendor/bin/phpstan analyse src/Providers/Models/DTO/SupportedOption.php` — no errors
- [ ] Verify on a WordPress site with Redis object cache that model discovery no longer fails after cache is populated