### PR TITLE
fix: Throw TokenLimitReachedException on truncated tool calls

### DIFF
--- a/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
+++ b/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
@@ -6,6 +6,7 @@ namespace WordPress\AiClient\Providers\OpenAiCompatibleImplementation;
 
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Common\Exception\RuntimeException;
+use WordPress\AiClient\Common\Exception\TokenLimitReachedException;
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\Enums\MessagePartChannelEnum;
@@ -658,6 +659,23 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
         }
 
         $messageData = $choiceData['message'];
+
+        if (
+            'length' === $choiceData['finish_reason']
+            && isset($messageData['tool_calls'])
+            && is_array($messageData['tool_calls'])
+            && count($messageData['tool_calls']) > 0
+        ) {
+            throw new TokenLimitReachedException(
+                sprintf(
+                    '%s response was truncated while generating a tool call.'
+                    . ' Increase the max tokens or simplify the prompt.',
+                    $this->providerMetadata()->getName()
+                ),
+                $this->getConfig()->getMaxTokens()
+            );
+        }
+
         $message = $this->parseResponseChoiceMessage($messageData, $index);
 
         switch ($choiceData['finish_reason']) {
@@ -765,9 +783,18 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
             return null;
         }
 
-        $functionArguments = is_string($toolCallData['function']['arguments'])
-            ? json_decode($toolCallData['function']['arguments'], true)
-            : $toolCallData['function']['arguments'];
+        if (is_string($toolCallData['function']['arguments'])) {
+            $functionArguments = json_decode($toolCallData['function']['arguments'], true);
+            if (null === $functionArguments && JSON_ERROR_NONE !== json_last_error()) {
+                throw ResponseException::fromInvalidData(
+                    $this->providerMetadata()->getName(),
+                    'tool_call.function.arguments',
+                    sprintf('Invalid JSON in tool call arguments: %s', json_last_error_msg())
+                );
+            }
+        } else {
+            $functionArguments = $toolCallData['function']['arguments'];
+        }
 
         $functionCall = new FunctionCall(
             isset($toolCallData['id']) && is_string($toolCallData['id']) ?

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
@@ -6,6 +6,7 @@ namespace WordPress\AiClient\Tests\unit\Providers\OpenAiCompatibleImplementation
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use WordPress\AiClient\Common\Exception\TokenLimitReachedException;
 use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
@@ -1327,5 +1328,129 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
 
         // Should be skipped because OpenAI API doesn't support receiving thoughts.
         $this->assertNull($data);
+    }
+
+    /**
+     * Tests parseResponseChoiceToCandidate() throws TokenLimitReachedException
+     * when finish_reason is 'length' and tool calls are present.
+     *
+     * @return void
+     */
+    public function testParseResponseChoiceToCandidateThrowsOnLengthWithToolCalls(): void
+    {
+        $choiceData = [
+            'message' => [
+                'role' => 'assistant',
+                'content' => null,
+                'tool_calls' => [
+                    [
+                        'id' => 'call_123',
+                        'type' => 'function',
+                        'function' => [
+                            'name' => 'get_weather',
+                            'arguments' => '{"location": "Lon',
+                        ],
+                    ],
+                ],
+            ],
+            'finish_reason' => 'length',
+        ];
+        $model = $this->createModel();
+
+        $this->expectException(TokenLimitReachedException::class);
+        $this->expectExceptionMessage('TestProvider response was truncated while generating a tool call.');
+
+        $model->exposeParseResponseChoiceToCandidate($choiceData);
+    }
+
+    /**
+     * Tests parseResponseChoiceToCandidate() includes maxTokens in the
+     * TokenLimitReachedException when configured.
+     *
+     * @return void
+     */
+    public function testParseResponseChoiceToCandidateTokenLimitIncludesMaxTokens(): void
+    {
+        $choiceData = [
+            'message' => [
+                'role' => 'assistant',
+                'content' => null,
+                'tool_calls' => [
+                    [
+                        'id' => 'call_456',
+                        'type' => 'function',
+                        'function' => [
+                            'name' => 'get_weather',
+                            'arguments' => '{"loc',
+                        ],
+                    ],
+                ],
+            ],
+            'finish_reason' => 'length',
+        ];
+        $modelConfig = new ModelConfig();
+        $modelConfig->setMaxTokens(500);
+        $model = $this->createModel($modelConfig);
+
+        try {
+            $model->exposeParseResponseChoiceToCandidate($choiceData);
+            $this->fail('Expected TokenLimitReachedException was not thrown.');
+        } catch (TokenLimitReachedException $e) {
+            $this->assertSame(500, $e->getMaxTokens());
+        }
+    }
+
+    /**
+     * Tests parseResponseChoiceToCandidate() does not throw when
+     * finish_reason is 'length' but no tool calls are present.
+     *
+     * @return void
+     */
+    public function testParseResponseChoiceToCandidateLengthWithoutToolCallsDoesNotThrow(): void
+    {
+        $choiceData = [
+            'message' => [
+                'role' => 'assistant',
+                'content' => 'This is a truncated respon',
+            ],
+            'finish_reason' => 'length',
+        ];
+        $model = $this->createModel();
+        $candidate = $model->exposeParseResponseChoiceToCandidate($choiceData);
+
+        $this->assertInstanceOf(Candidate::class, $candidate);
+        $this->assertEquals(FinishReasonEnum::length(), $candidate->getFinishReason());
+    }
+
+    /**
+     * Tests parseResponseChoiceToCandidate() does not throw when
+     * finish_reason is 'tool_calls' with valid tool calls.
+     *
+     * @return void
+     */
+    public function testParseResponseChoiceToCandidateToolCallsFinishReasonDoesNotThrow(): void
+    {
+        $choiceData = [
+            'message' => [
+                'role' => 'assistant',
+                'content' => null,
+                'tool_calls' => [
+                    [
+                        'id' => 'call_789',
+                        'type' => 'function',
+                        'function' => [
+                            'name' => 'get_weather',
+                            'arguments' => '{"location":"London"}',
+                        ],
+                    ],
+                ],
+            ],
+            'finish_reason' => 'tool_calls',
+        ];
+        $model = $this->createModel();
+        $candidate = $model->exposeParseResponseChoiceToCandidate($choiceData);
+
+        $this->assertInstanceOf(Candidate::class, $candidate);
+        $this->assertEquals(FinishReasonEnum::toolCalls(), $candidate->getFinishReason());
     }
 }

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
@@ -1316,6 +1316,54 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
     }
 
     /**
+     * Tests parseResponseChoiceMessageToolCallPart() throws ResponseException
+     * when tool call arguments contain invalid JSON.
+     *
+     * @return void
+     */
+    public function testParseResponseChoiceMessageToolCallPartInvalidJsonArguments(): void
+    {
+        $toolCallData = [
+            'id' => 'call_123',
+            'type' => 'function',
+            'function' => [
+                'name' => 'test_function',
+                'arguments' => '{invalid json',
+            ],
+        ];
+        $model = $this->createModel();
+
+        $this->expectException(ResponseException::class);
+        $this->expectExceptionMessage('Invalid JSON in tool call arguments');
+
+        $model->exposeParseResponseChoiceMessageToolCallPart($toolCallData);
+    }
+
+    /**
+     * Tests parseResponseChoiceMessageToolCallPart() handles non-string
+     * (already decoded) arguments.
+     *
+     * @return void
+     */
+    public function testParseResponseChoiceMessageToolCallPartArrayArguments(): void
+    {
+        $toolCallData = [
+            'id' => 'call_123',
+            'type' => 'function',
+            'function' => [
+                'name' => 'test_function',
+                'arguments' => ['key' => 'value'],
+            ],
+        ];
+        $model = $this->createModel();
+        $part = $model->exposeParseResponseChoiceMessageToolCallPart($toolCallData);
+
+        $this->assertInstanceOf(MessagePart::class, $part);
+        $this->assertInstanceOf(FunctionCall::class, $part->getFunctionCall());
+        $this->assertEquals(['key' => 'value'], $part->getFunctionCall()->getArgs());
+    }
+
+    /**
      * Tests getMessagePartContentData() with text part in thought channel.
      *
      * @return void


### PR DESCRIPTION
## Summary
Fixes #193.

- When an API response hits the max token limit mid-way through generating a tool call (`finish_reason=length` with `tool_calls` present), throw `TokenLimitReachedException` instead of silently returning a `FunctionCall` with null/incomplete arguments.
- Add a secondary `json_last_error()` check in `parseResponseChoiceMessageToolCallPart()` to catch malformed tool call JSON regardless of finish reason.
- Exception includes the configured `maxTokens` value so callers can handle gracefully (e.g. increase the limit and retry).

## Changes

**`src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php`**
- In `parseResponseChoiceToCandidate()`: detect `finish_reason=length` + `tool_calls` present in raw message data and throw `TokenLimitReachedException` before parsing the message.
- In `parseResponseChoiceMessageToolCallPart()`: replace silent `json_decode` with an explicit `json_last_error()` check that throws `ResponseException` on invalid JSON.

**`tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php`**
- `testParseResponseChoiceToCandidateThrowsOnLengthWithToolCalls` — truncated tool call throws exception.
- `testParseResponseChoiceToCandidateTokenLimitIncludesMaxTokens` — exception carries configured maxTokens (500).
- `testParseResponseChoiceToCandidateLengthWithoutToolCallsDoesNotThrow` — text-only + length still works.
- `testParseResponseChoiceToCandidateToolCallsFinishReasonDoesNotThrow` — normal tool calls unaffected.

## Test plan
- [x] `vendor/bin/phpunit --filter "testParseResponseChoiceToCandidate"` — all 12 tests pass.
- [x] `vendor/bin/phpunit` — full suite passes (1059 tests, 3921 assertions).
- [x] `vendor/bin/phpstan analyse` — no errors on source file.

> **Note:** The Anthropic and Google providers would benefit from similar checks for their truncation signals (`stop_reason=max_tokens` and `finishReason=MAX_TOKENS` respectively).