### PR TITLE
Complete partial video generation foundation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -350,6 +350,7 @@ direction LR
             +generateImageResult() GenerativeAiResult
             +generateSpeechResult() GenerativeAiResult
             +convertTextToSpeechResult() GenerativeAiResult
+            +generateVideoResult() GenerativeAiResult
             +generateText() string
             +generateTexts(?int $candidateCount) string[]
             +generateImage() File
@@ -358,6 +359,8 @@ direction LR
             +convertTextToSpeeches(?int $candidateCount) File[]
             +generateSpeech() File
             +generateSpeeches(?int $candidateCount) File[]
+            +generateVideo() File
+            +generateVideos(?int $candidateCount) File[]
             +isSupported(?CapabilityEnum $capability) bool
             +isSupportedForTextGeneration() bool
             +isSupportedForImageGeneration() bool
@@ -406,11 +409,13 @@ direction LR
             +generateImageResult(string|MessagePart|MessagePart[]|Message|Message[] $prompt, ModelInterface $model) GenerativeAiResult$
             +convertTextToSpeechResult(string|MessagePart|MessagePart[]|Message|Message[] $prompt, ModelInterface $model) GenerativeAiResult$
             +generateSpeechResult(string|MessagePart|MessagePart[]|Message|Message[] $prompt, ModelInterface $model) GenerativeAiResult$
+            +generateVideoResult(string|MessagePart|MessagePart[]|Message|Message[] $prompt, ModelInterface $model) GenerativeAiResult$
             +generateEmbeddingsResult(string[]|Message[] $input, ModelInterface $model) EmbeddingResult$
             +generateTextOperation(string|MessagePart|MessagePart[]|Message|Message[] $prompt, ModelInterface $model) GenerativeAiOperation$
             +generateImageOperation(string|MessagePart|MessagePart[]|Message|Message[] $prompt, ModelInterface $model) GenerativeAiOperation$
             +convertTextToSpeechOperation(string|MessagePart|MessagePart[]|Message|Message[] $prompt, ModelInterface $model) GenerativeAiOperation$
             +generateSpeechOperation(string|MessagePart|MessagePart[]|Message|Message[] $prompt, ModelInterface $model) GenerativeAiOperation$
+            +generateVideoOperation(string|MessagePart|MessagePart[]|Message|Message[] $prompt, ModelInterface $model) GenerativeAiOperation$
             +generateEmbeddingsOperation(string[]|Message[] $input, ModelInterface $model) EmbeddingOperation$
         }
     }
@@ -473,11 +478,13 @@ direction LR
             +generateImageResult(string|MessagePart|MessagePart[]|Message|Message[] $prompt, ModelInterface $model) GenerativeAiResult$
             +convertTextToSpeechResult(string|MessagePart|MessagePart[]|Message|Message[] $prompt, ModelInterface $model) GenerativeAiResult$
             +generateSpeechResult(string|MessagePart|MessagePart[]|Message|Message[] $prompt, ModelInterface $model) GenerativeAiResult$
+            +generateVideoResult(string|MessagePart|MessagePart[]|Message|Message[] $prompt, ModelInterface $model) GenerativeAiResult$
             +generateEmbeddingsResult(string[]|Message[] $input, ModelInterface $model) EmbeddingResult$
             +generateTextOperation(string|MessagePart|MessagePart[]|Message|Message[] $prompt, ModelInterface $model) GenerativeAiOperation$
             +generateImageOperation(string|MessagePart|MessagePart[]|Message|Message[] $prompt, ModelInterface $model) GenerativeAiOperation$
             +convertTextToSpeechOperation(string|MessagePart|MessagePart[]|Message|Message[] $prompt, ModelInterface $model) GenerativeAiOperation$
             +generateSpeechOperation(string|MessagePart|MessagePart[]|Message|Message[] $prompt, ModelInterface $model) GenerativeAiOperation$
+            +generateVideoOperation(string|MessagePart|MessagePart[]|Message|Message[] $prompt, ModelInterface $model) GenerativeAiOperation$
             +generateEmbeddingsOperation(string[]|Message[] $input, ModelInterface $model) EmbeddingOperation$
         }
     }
@@ -514,6 +521,7 @@ direction LR
             +generateImageResult() GenerativeAiResult
             +generateSpeechResult() GenerativeAiResult
             +convertTextToSpeechResult() GenerativeAiResult
+            +generateVideoResult() GenerativeAiResult
             +generateText() string
             +generateTexts(?int $candidateCount) string[]
             +generateImage() File
@@ -522,6 +530,8 @@ direction LR
             +convertTextToSpeeches(?int $candidateCount) File[]
             +generateSpeech() File
             +generateSpeeches(?int $candidateCount) File[]
+            +generateVideo() File
+            +generateVideos(?int $candidateCount) File[]
             +isSupportedForTextGeneration() bool
             +isSupportedForImageGeneration() bool
             +isSupportedForTextToSpeechConversion() bool
@@ -1090,6 +1100,15 @@ direction LR
         }
         class SpeechGenerationOperationModelInterface {
             +generateSpeechOperation(Message[] $prompt) GenerativeAiOperation
+        }
+    }
+
+    namespace AiClientNamespace.Providers.Models.VideoGeneration.Contracts {
+        class VideoGenerationModelInterface {
+            +generateVideoResult(Message[] $prompt) GenerativeAiResult
+        }
+        class VideoGenerationOperationModelInterface {
+            +generateVideoOperation(Message[] $prompt) GenerativeAiOperation
         }
     }
 

--- a/src/AiClient.php
+++ b/src/AiClient.php
@@ -363,6 +363,30 @@ class AiClient
     }
 
     /**
+     * Generates a video using the traditional API approach.
+     *
+     * @since n.e.x.t
+     *
+     * @param Prompt $prompt The prompt content.
+     * @param ModelInterface|ModelConfig|null $modelOrConfig Optional specific model to use,
+     *                                                        or model configuration for auto-discovery,
+     *                                                        or null for defaults.
+     * @param ProviderRegistry|null $registry Optional custom registry. If null, uses default.
+     * @return GenerativeAiResult The generation result.
+     *
+     * @throws \InvalidArgumentException If the prompt format is invalid.
+     * @throws \RuntimeException If no suitable model is found.
+     */
+    public static function generateVideoResult(
+        $prompt,
+        $modelOrConfig = null,
+        ?ProviderRegistry $registry = null
+    ): GenerativeAiResult {
+        self::validateModelOrConfigParameter($modelOrConfig);
+        return self::getConfiguredPromptBuilder($prompt, $modelOrConfig, $registry)->generateVideoResult();
+    }
+
+    /**
      * Creates a new message builder for fluent API usage.
      *
      * This method will be implemented once MessageBuilder is available.

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -27,6 +27,7 @@ use WordPress\AiClient\Providers\Models\ImageGeneration\Contracts\ImageGeneratio
 use WordPress\AiClient\Providers\Models\SpeechGeneration\Contracts\SpeechGenerationModelInterface;
 use WordPress\AiClient\Providers\Models\TextGeneration\Contracts\TextGenerationModelInterface;
 use WordPress\AiClient\Providers\Models\TextToSpeechConversion\Contracts\TextToSpeechConversionModelInterface;
+use WordPress\AiClient\Providers\Models\VideoGeneration\Contracts\VideoGenerationModelInterface;
 use WordPress\AiClient\Providers\ProviderRegistry;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
@@ -711,6 +712,9 @@ class PromptBuilder
         if ($model instanceof SpeechGenerationModelInterface) {
             return CapabilityEnum::speechGeneration();
         }
+        if ($model instanceof VideoGenerationModelInterface) {
+            return CapabilityEnum::videoGeneration();
+        }
 
         // No supported interface found
         return null;
@@ -962,9 +966,16 @@ class PromptBuilder
             return $model->generateSpeechResult($messages);
         }
 
-        // Video generation is not yet implemented
         if ($capability->isVideoGeneration()) {
-            throw new RuntimeException('Output modality "video" is not yet supported.');
+            if (!$model instanceof VideoGenerationModelInterface) {
+                throw new RuntimeException(
+                    sprintf(
+                        'Model "%s" does not support video generation.',
+                        $model->metadata()->getId()
+                    )
+                );
+            }
+            return $model->generateVideoResult($messages);
         }
 
         // TODO: Add support for other capabilities when interfaces are available
@@ -1043,6 +1054,24 @@ class PromptBuilder
 
         // Generate and return the result with text-to-speech conversion capability
         return $this->generateResult(CapabilityEnum::textToSpeechConversion());
+    }
+
+    /**
+     * Generates a video result from the prompt.
+     *
+     * @since n.e.x.t
+     *
+     * @return GenerativeAiResult The generated result containing video candidates.
+     * @throws InvalidArgumentException If the prompt or model validation fails.
+     * @throws RuntimeException If the model doesn't support video generation.
+     */
+    public function generateVideoResult(): GenerativeAiResult
+    {
+        // Include video in output modalities
+        $this->includeOutputModalities(ModalityEnum::video());
+
+        // Generate and return the result with video generation capability
+        return $this->generateResult(CapabilityEnum::videoGeneration());
     }
 
     /**
@@ -1174,6 +1203,39 @@ class PromptBuilder
         }
 
         return $this->generateSpeechResult()->toFiles();
+    }
+
+    /**
+     * Generates a video from the prompt.
+     *
+     * @since n.e.x.t
+     *
+     * @return File The generated video file.
+     * @throws InvalidArgumentException If the prompt or model validation fails.
+     * @throws RuntimeException If no video is generated.
+     */
+    public function generateVideo(): File
+    {
+        return $this->generateVideoResult()->toFile();
+    }
+
+    /**
+     * Generates multiple videos from the prompt.
+     *
+     * @since n.e.x.t
+     *
+     * @param int|null $candidateCount The number of videos to generate.
+     * @return list<File> The generated video files.
+     * @throws InvalidArgumentException If the prompt or model validation fails.
+     * @throws RuntimeException If no videos are generated.
+     */
+    public function generateVideos(?int $candidateCount = null): array
+    {
+        if ($candidateCount !== null) {
+            $this->usingCandidateCount($candidateCount);
+        }
+
+        return $this->generateVideoResult()->toFiles();
     }
 
     /**

--- a/src/Providers/Models/VideoGeneration/Contracts/VideoGenerationModelInterface.php
+++ b/src/Providers/Models/VideoGeneration/Contracts/VideoGenerationModelInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Providers\Models\VideoGeneration\Contracts;
+
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+
+/**
+ * Interface for models that support video generation.
+ *
+ * Provides synchronous methods for generating videos from prompts.
+ *
+ * @since n.e.x.t
+ */
+interface VideoGenerationModelInterface
+{
+    /**
+     * Generates videos from a prompt.
+     *
+     * @since n.e.x.t
+     *
+     * @param list<Message> $prompt Array of messages containing the video generation prompt.
+     * @return GenerativeAiResult Result containing generated videos.
+     */
+    public function generateVideoResult(array $prompt): GenerativeAiResult;
+}

--- a/src/Providers/Models/VideoGeneration/Contracts/VideoGenerationOperationModelInterface.php
+++ b/src/Providers/Models/VideoGeneration/Contracts/VideoGenerationOperationModelInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Providers\Models\VideoGeneration\Contracts;
+
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Operations\DTO\GenerativeAiOperation;
+
+/**
+ * Interface for models that support asynchronous video generation operations.
+ *
+ * Provides methods for initiating long-running video generation tasks.
+ *
+ * @since n.e.x.t
+ */
+interface VideoGenerationOperationModelInterface
+{
+    /**
+     * Creates a video generation operation.
+     *
+     * @since n.e.x.t
+     *
+     * @param list<Message> $prompt Array of messages containing the video generation prompt.
+     * @return GenerativeAiOperation The initiated video generation operation.
+     */
+    public function generateVideoOperation(array $prompt): GenerativeAiOperation;
+}

--- a/tests/traits/MockModelCreationTrait.php
+++ b/tests/traits/MockModelCreationTrait.php
@@ -14,6 +14,7 @@ use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 use WordPress\AiClient\Providers\Models\ImageGeneration\Contracts\ImageGenerationModelInterface;
 use WordPress\AiClient\Providers\Models\TextGeneration\Contracts\TextGenerationModelInterface;
+use WordPress\AiClient\Providers\Models\VideoGeneration\Contracts\VideoGenerationModelInterface;
 use WordPress\AiClient\Providers\ProviderRegistry;
 use WordPress\AiClient\Results\DTO\Candidate;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
@@ -109,6 +110,25 @@ trait MockModelCreationTrait
             $id,
             $name,
             [CapabilityEnum::imageGeneration()],
+            []
+        );
+    }
+
+    /**
+     * Creates a test model metadata instance for video generation.
+     *
+     * @param string $id   Optional model ID.
+     * @param string $name Optional model name.
+     * @return ModelMetadata
+     */
+    protected function createTestVideoModelMetadata(
+        string $id = 'test-video-model',
+        string $name = 'Test Video Model'
+    ): ModelMetadata {
+        return new ModelMetadata(
+            $id,
+            $name,
+            [CapabilityEnum::videoGeneration()],
             []
         );
     }
@@ -241,6 +261,73 @@ trait MockModelCreationTrait
             }
 
             public function generateImageResult(array $prompt): GenerativeAiResult
+            {
+                return $this->result;
+            }
+        };
+    }
+
+    /**
+     * Creates a mock video generation model using anonymous class.
+     *
+     * @param GenerativeAiResult $result   The result to return from generation.
+     * @param ModelMetadata|null $metadata Optional metadata (uses default if not provided).
+     * @return ModelInterface&VideoGenerationModelInterface The mock model.
+     */
+    protected function createMockVideoGenerationModel(
+        GenerativeAiResult $result,
+        ?ModelMetadata $metadata = null
+    ): ModelInterface {
+        $metadata = $metadata ?? $this->createTestVideoModelMetadata();
+
+        $providerMetadata = new ProviderMetadata(
+            'mock',
+            'Mock Provider',
+            ProviderTypeEnum::cloud()
+        );
+
+        return new class (
+            $metadata,
+            $providerMetadata,
+            $result
+        ) implements ModelInterface, VideoGenerationModelInterface {
+            private ModelMetadata $metadata;
+            private ProviderMetadata $providerMetadata;
+            private GenerativeAiResult $result;
+            private ModelConfig $config;
+
+            public function __construct(
+                ModelMetadata $metadata,
+                ProviderMetadata $providerMetadata,
+                GenerativeAiResult $result
+            ) {
+                $this->metadata = $metadata;
+                $this->providerMetadata = $providerMetadata;
+                $this->result = $result;
+                $this->config = new ModelConfig();
+            }
+
+            public function metadata(): ModelMetadata
+            {
+                return $this->metadata;
+            }
+
+            public function providerMetadata(): ProviderMetadata
+            {
+                return $this->providerMetadata;
+            }
+
+            public function setConfig(ModelConfig $config): void
+            {
+                $this->config = $config;
+            }
+
+            public function getConfig(): ModelConfig
+            {
+                return $this->config;
+            }
+
+            public function generateVideoResult(array $prompt): GenerativeAiResult
             {
                 return $this->result;
             }

--- a/tests/unit/AiClientTest.php
+++ b/tests/unit/AiClientTest.php
@@ -136,6 +136,36 @@ class AiClientTest extends TestCase
         AiClient::generateImageResult($prompt, $invalidModel, $registry);
     }
 
+    /**
+     * Tests generateVideoResult with string prompt and provided model.
+     */
+    public function testGenerateVideoResultWithStringAndModel(): void
+    {
+        $prompt = 'Generate video';
+        $expectedResult = $this->createTestResult();
+        $mockModel = $this->createMockVideoGenerationModel($expectedResult);
+        $registry = $this->createRegistryWithMockProvider();
+
+        $result = AiClient::generateVideoResult($prompt, $mockModel, $registry);
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    /**
+     * Tests generateVideoResult throws exception for model without video generation interface.
+     */
+    public function testGenerateVideoResultWithInvalidModel(): void
+    {
+        $prompt = 'Generate video';
+        $invalidModel = $this->createMockUnsupportedModel('invalid-video-model');
+        $registry = $this->createRegistryWithMockProvider();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Model "invalid-video-model" does not support video generation.');
+
+        AiClient::generateVideoResult($prompt, $invalidModel, $registry);
+    }
+
 
     /**
      * Tests generateTextResult with Message object.
@@ -380,6 +410,21 @@ class AiClientTest extends TestCase
     }
 
     /**
+     * Tests generateResult delegates to generateVideoResult when model supports video generation.
+     */
+    public function testGenerateResultDelegatesToVideoGeneration(): void
+    {
+        $prompt = 'Generate video prompt';
+        $expectedResult = $this->createTestResult();
+        $mockModel = $this->createMockVideoGenerationModel($expectedResult);
+        $registry = $this->createRegistryWithMockProvider();
+
+        $result = AiClient::generateResult($prompt, $mockModel, $registry);
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    /**
      * Tests generateResult with null model delegates to PromptBuilder.
      */
     public function testGenerateResultWithNullModelDelegatesToPromptBuilder(): void
@@ -424,6 +469,21 @@ class AiClientTest extends TestCase
     }
 
     /**
+     * Tests generateResult with video generation model.
+     */
+    public function testGenerateResultWithVideoGenerationModel(): void
+    {
+        $prompt = 'Generate a video';
+        $expectedResult = $this->createTestResult();
+        $mockModel = $this->createMockVideoGenerationModel($expectedResult);
+        $registry = $this->createRegistryWithMockProvider();
+
+        $result = AiClient::generateResult($prompt, $mockModel, $registry);
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    /**
      * Tests that generateResult accepts ModelConfig and delegates to PromptBuilder.
      */
     public function testGenerateResultWithModelConfigDelegatesToPromptBuilder(): void
@@ -453,7 +513,8 @@ class AiClientTest extends TestCase
             'generateTextResult',
             'generateImageResult',
             'convertTextToSpeechResult',
-            'generateSpeechResult'
+            'generateSpeechResult',
+            'generateVideoResult'
         ];
 
         $mockRegistry = $this->createMockEmptyRegistry();
@@ -512,6 +573,7 @@ class AiClientTest extends TestCase
             'generateImageResult' => ['generateImageResult'],
             'convertTextToSpeechResult' => ['convertTextToSpeechResult'],
             'generateSpeechResult' => ['generateSpeechResult'],
+            'generateVideoResult' => ['generateVideoResult'],
         ];
     }
 
@@ -642,7 +704,8 @@ class AiClientTest extends TestCase
             'generateTextResult',
             'generateImageResult',
             'convertTextToSpeechResult',
-            'generateSpeechResult'
+            'generateSpeechResult',
+            'generateVideoResult'
         ];
 
         $mockRegistry = $this->createMockEmptyRegistry();

--- a/tests/unit/Builders/PromptBuilderTest.php
+++ b/tests/unit/Builders/PromptBuilderTest.php
@@ -29,6 +29,7 @@ use WordPress\AiClient\Providers\Models\Enums\OptionEnum;
 use WordPress\AiClient\Providers\Models\SpeechGeneration\Contracts\SpeechGenerationModelInterface;
 use WordPress\AiClient\Providers\Models\TextGeneration\Contracts\TextGenerationModelInterface;
 use WordPress\AiClient\Providers\Models\TextToSpeechConversion\Contracts\TextToSpeechConversionModelInterface;
+use WordPress\AiClient\Providers\Models\VideoGeneration\Contracts\VideoGenerationModelInterface;
 use WordPress\AiClient\Providers\ProviderRegistry;
 use WordPress\AiClient\Results\DTO\Candidate;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
@@ -137,6 +138,69 @@ class PromptBuilderTest extends TestCase
             }
 
             public function generateSpeechResult(array $prompt): GenerativeAiResult
+            {
+                return $this->result;
+            }
+        };
+    }
+
+    /**
+     * Creates a mock model that implements both ModelInterface and VideoGenerationModelInterface.
+     *
+     * @param ModelMetadata      $metadata The metadata for the model.
+     * @param GenerativeAiResult $result   The result to return from generation.
+     * @return ModelInterface&VideoGenerationModelInterface The mock model.
+     */
+    private function createVideoGenerationModel(ModelMetadata $metadata, GenerativeAiResult $result): ModelInterface
+    {
+        $providerMetadata = new ProviderMetadata(
+            'mock-provider',
+            'Mock Provider',
+            ProviderTypeEnum::cloud()
+        );
+
+        return new class (
+            $metadata,
+            $providerMetadata,
+            $result
+        ) implements ModelInterface, VideoGenerationModelInterface {
+            private ModelMetadata $metadata;
+            private ProviderMetadata $providerMetadata;
+            private GenerativeAiResult $result;
+            private ModelConfig $config;
+
+            public function __construct(
+                ModelMetadata $metadata,
+                ProviderMetadata $providerMetadata,
+                GenerativeAiResult $result
+            ) {
+                $this->metadata = $metadata;
+                $this->providerMetadata = $providerMetadata;
+                $this->result = $result;
+                $this->config = new ModelConfig();
+            }
+
+            public function metadata(): ModelMetadata
+            {
+                return $this->metadata;
+            }
+
+            public function providerMetadata(): ProviderMetadata
+            {
+                return $this->providerMetadata;
+            }
+
+            public function setConfig(ModelConfig $config): void
+            {
+                $this->config = $config;
+            }
+
+            public function getConfig(): ModelConfig
+            {
+                return $this->config;
+            }
+
+            public function generateVideoResult(array $prompt): GenerativeAiResult
             {
                 return $this->result;
             }
@@ -1667,10 +1731,10 @@ class PromptBuilderTest extends TestCase
 
         $builder = new PromptBuilder($this->registry, 'Test prompt');
         $builder->usingModel($model);
-        $builder->asOutputModalities(ModalityEnum::video());
+        $builder->asOutputModalities(ModalityEnum::document());
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Output modality "video" is not yet supported');
+        $this->expectExceptionMessage('Output modality "document" is not yet supported');
 
         $builder->generateResult();
     }
@@ -1752,6 +1816,47 @@ class PromptBuilderTest extends TestCase
         $modalities = $config->getOutputModalities();
         $this->assertNotNull($modalities);
         $this->assertTrue($modalities[0]->isImage());
+    }
+
+    /**
+     * Tests generateVideoResult method.
+     *
+     * @return void
+     */
+    public function testGenerateVideoResult(): void
+    {
+        $result = new GenerativeAiResult(
+            'test-result',
+            [new Candidate(
+                new ModelMessage([new MessagePart(new File('data:video/mp4;base64,AAAAIGZ0eXA=', 'video/mp4'))]),
+                FinishReasonEnum::stop()
+            )],
+            new TokenUsage(100, 50, 150),
+            $this->createTestProviderMetadata(),
+            $this->createTestTextModelMetadata()
+        );
+
+        $metadata = $this->createMock(ModelMetadata::class);
+        $metadata->method('getId')->willReturn('test-model');
+
+        $model = $this->createVideoGenerationModel($metadata, $result);
+
+        $builder = new PromptBuilder($this->registry, 'Generate video');
+        $builder->usingModel($model);
+
+        $actualResult = $builder->generateVideoResult();
+        $this->assertSame($result, $actualResult);
+
+        // Verify video modality was included
+        $reflection = new \ReflectionClass($builder);
+        $configProperty = $reflection->getProperty('modelConfig');
+        $configProperty->setAccessible(true);
+        /** @var ModelConfig $config */
+        $config = $configProperty->getValue($builder);
+
+        $modalities = $config->getOutputModalities();
+        $this->assertNotNull($modalities);
+        $this->assertTrue($modalities[0]->isVideo());
     }
 
     /**
@@ -2251,6 +2356,114 @@ class PromptBuilderTest extends TestCase
         $builder->usingModel($model);
 
         $generatedFiles = $builder->generateImages(2);
+
+        $this->assertCount(2, $generatedFiles);
+        $this->assertSame($files[0], $generatedFiles[0]);
+        $this->assertSame($files[1], $generatedFiles[1]);
+    }
+
+    /**
+     * Tests generateVideo method.
+     *
+     * @return void
+     */
+    public function testGenerateVideo(): void
+    {
+        $file = new File('https://example.com/generated.mp4', 'video/mp4');
+        $messagePart = new MessagePart($file);
+        $message = new ModelMessage([$messagePart]);
+        $candidate = new Candidate($message, FinishReasonEnum::stop());
+
+        $result = new GenerativeAiResult(
+            'test-result',
+            [$candidate],
+            new TokenUsage(100, 50, 150),
+            $this->createTestProviderMetadata(),
+            $this->createTestTextModelMetadata()
+        );
+
+        $metadata = $this->createMock(ModelMetadata::class);
+        $metadata->method('getId')->willReturn('test-model');
+
+        $model = $this->createVideoGenerationModel($metadata, $result);
+
+        $builder = new PromptBuilder($this->registry, 'Generate video');
+        $builder->usingModel($model);
+
+        $generatedFile = $builder->generateVideo();
+        $this->assertSame($file, $generatedFile);
+    }
+
+    /**
+     * Tests generateVideo throws exception when no video file.
+     *
+     * @return void
+     */
+    public function testGenerateVideoThrowsExceptionWhenNoFile(): void
+    {
+        $messagePart = new MessagePart('Text instead of video');
+        $message = new ModelMessage([$messagePart]);
+        $candidate = new Candidate($message, FinishReasonEnum::stop());
+
+        $result = new GenerativeAiResult(
+            'test-result',
+            [$candidate],
+            new TokenUsage(100, 50, 150),
+            $this->createTestProviderMetadata(),
+            $this->createTestTextModelMetadata()
+        );
+
+        $metadata = $this->createMock(ModelMetadata::class);
+        $metadata->method('getId')->willReturn('test-model');
+
+        $model = $this->createVideoGenerationModel($metadata, $result);
+
+        $builder = new PromptBuilder($this->registry, 'Generate video');
+        $builder->usingModel($model);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No file content found in first candidate');
+
+        $builder->generateVideo();
+    }
+
+    /**
+     * Tests generateVideos method.
+     *
+     * @return void
+     */
+    public function testGenerateVideos(): void
+    {
+        $files = [
+            new File('https://example.com/vid1.mp4', 'video/mp4'),
+            new File('https://example.com/vid2.mp4', 'video/mp4'),
+        ];
+
+        $candidates = [];
+        foreach ($files as $file) {
+            $candidates[] = new Candidate(
+                new Message(MessageRoleEnum::model(), [new MessagePart($file)]),
+                FinishReasonEnum::stop()
+            );
+        }
+
+        $result = new GenerativeAiResult(
+            'test-result-id',
+            $candidates,
+            new TokenUsage(100, 50, 150),
+            $this->createTestProviderMetadata(),
+            $this->createTestTextModelMetadata()
+        );
+
+        $metadata = $this->createMock(ModelMetadata::class);
+        $metadata->method('getId')->willReturn('test-model');
+
+        $model = $this->createVideoGenerationModel($metadata, $result);
+
+        $builder = new PromptBuilder($this->registry, 'Generate videos');
+        $builder->usingModel($model);
+
+        $generatedFiles = $builder->generateVideos(2);
 
         $this->assertCount(2, $generatedFiles);
         $this->assertSame($files[0], $generatedFiles[0]);
@@ -2798,6 +3011,81 @@ class PromptBuilderTest extends TestCase
         $this->assertSame($file, $generatedFile);
     }
 
+    /**
+     * Tests generateVideoResult method creates proper operation.
+     *
+     * @return void
+     */
+    public function testGenerateVideoResultCreatesProperOperation(): void
+    {
+        $result = new GenerativeAiResult(
+            'test-result',
+            [new Candidate(
+                new ModelMessage([new MessagePart(new File('data:video/mp4;base64,AAAAIGZ0eXA=', 'video/mp4'))]),
+                FinishReasonEnum::stop()
+            )],
+            new TokenUsage(100, 50, 150),
+            $this->createTestProviderMetadata(),
+            $this->createTestTextModelMetadata()
+        );
+
+        $metadata = $this->createMock(ModelMetadata::class);
+        $metadata->method('getId')->willReturn('test-model');
+
+        $model = $this->createVideoGenerationModel($metadata, $result);
+
+        $builder = new PromptBuilder($this->registry, 'Generate a video');
+        $builder->usingModel($model);
+
+        $actualResult = $builder->generateVideoResult();
+        $this->assertSame($result, $actualResult);
+
+        // Verify that video modality was included in the model config
+        $reflection = new \ReflectionClass($builder);
+        $configProperty = $reflection->getProperty('modelConfig');
+        $configProperty->setAccessible(true);
+        /** @var ModelConfig $config */
+        $config = $configProperty->getValue($builder);
+
+        $outputModalities = $config->getOutputModalities();
+        $this->assertCount(1, $outputModalities);
+        $this->assertTrue($outputModalities[0]->isVideo());
+    }
+
+
+    /**
+     * Tests generateVideo shorthand method returns file directly.
+     *
+     * @return void
+     */
+    public function testGenerateVideoReturnsFileDirectly(): void
+    {
+        $file = new File('https://example.com/generated.mp4', 'video/mp4');
+        $candidate = new Candidate(
+            new Message(MessageRoleEnum::model(), [new MessagePart($file)]),
+            FinishReasonEnum::stop()
+        );
+
+        $result = new GenerativeAiResult(
+            'test-result',
+            [$candidate],
+            new TokenUsage(100, 50, 150),
+            $this->createTestProviderMetadata(),
+            $this->createTestTextModelMetadata()
+        );
+
+        $metadata = $this->createMock(ModelMetadata::class);
+        $metadata->method('getId')->willReturn('test-model');
+
+        $model = $this->createVideoGenerationModel($metadata, $result);
+
+        $builder = new PromptBuilder($this->registry, 'Generate a video');
+        $builder->usingModel($model);
+
+        $generatedFile = $builder->generateVideo();
+        $this->assertSame($file, $generatedFile);
+    }
+
 
 
     /**
@@ -2941,6 +3229,33 @@ class PromptBuilderTest extends TestCase
             ->willReturn([]);
 
         $this->assertFalse($builder->isSupportedForVideoGeneration());
+    }
+
+    /**
+     * Tests isSupportedForVideoGeneration returns true when a video generation model is set.
+     *
+     * @return void
+     */
+    public function testIsSupportedForVideoGenerationWithModel(): void
+    {
+        $metadata = new ModelMetadata(
+            'video-model',
+            'Video Model',
+            [CapabilityEnum::videoGeneration()],
+            [
+                new SupportedOption(OptionEnum::inputModalities(), [
+                    [ModalityEnum::text()]
+                ]),
+            ]
+        );
+
+        $result = $this->createTestResult();
+        $model = $this->createVideoGenerationModel($metadata, $result);
+
+        $builder = new PromptBuilder($this->registry, 'Generate video');
+        $builder->usingModel($model);
+
+        $this->assertTrue($builder->isSupportedForVideoGeneration());
     }
 
     /**

--- a/tests/unit/Builders/PromptBuilderTest.php
+++ b/tests/unit/Builders/PromptBuilderTest.php
@@ -1860,6 +1860,89 @@ class PromptBuilderTest extends TestCase
     }
 
     /**
+     * Tests generateVideoResult throws exception for unsupported model.
+     *
+     * @return void
+     */
+    public function testGenerateVideoResultThrowsExceptionForUnsupportedModel(): void
+    {
+        $metadata = $this->createMock(ModelMetadata::class);
+        $metadata->method('getId')->willReturn('test-model');
+
+        $model = $this->createMock(ModelInterface::class);
+        $model->method('metadata')->willReturn($metadata);
+
+        $builder = new PromptBuilder($this->registry, 'Generate video');
+        $builder->usingModel($model);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Model "test-model" does not support video generation');
+
+        $builder->generateVideoResult();
+    }
+
+    /**
+     * Tests generateResult infers video capability from model interface.
+     *
+     * @return void
+     */
+    public function testGenerateResultInfersVideoCapabilityFromModel(): void
+    {
+        $result = new GenerativeAiResult(
+            'test-result',
+            [new Candidate(
+                new ModelMessage([new MessagePart(new File('data:video/mp4;base64,AAAAIGZ0eXA=', 'video/mp4'))]),
+                FinishReasonEnum::stop()
+            )],
+            new TokenUsage(100, 50, 150),
+            $this->createTestProviderMetadata(),
+            $this->createTestTextModelMetadata()
+        );
+
+        $metadata = $this->createMock(ModelMetadata::class);
+        $metadata->method('getId')->willReturn('test-model');
+
+        $model = $this->createVideoGenerationModel($metadata, $result);
+
+        $builder = new PromptBuilder($this->registry, 'Generate video');
+        $builder->usingModel($model);
+
+        $actualResult = $builder->generateResult();
+        $this->assertSame($result, $actualResult);
+    }
+
+    /**
+     * Tests generateResult infers video capability from video output modality.
+     *
+     * @return void
+     */
+    public function testGenerateResultInfersVideoCapabilityFromOutputModality(): void
+    {
+        $result = new GenerativeAiResult(
+            'test-result',
+            [new Candidate(
+                new ModelMessage([new MessagePart(new File('data:video/mp4;base64,AAAAIGZ0eXA=', 'video/mp4'))]),
+                FinishReasonEnum::stop()
+            )],
+            new TokenUsage(100, 50, 150),
+            $this->createTestProviderMetadata(),
+            $this->createTestTextModelMetadata()
+        );
+
+        $metadata = $this->createMock(ModelMetadata::class);
+        $metadata->method('getId')->willReturn('test-model');
+
+        $model = $this->createVideoGenerationModel($metadata, $result);
+
+        $builder = new PromptBuilder($this->registry, 'Generate video');
+        $builder->usingModel($model);
+        $builder->asOutputModalities(ModalityEnum::video());
+
+        $actualResult = $builder->generateResult();
+        $this->assertSame($result, $actualResult);
+    }
+
+    /**
      * Tests generateSpeechResult method.
      *
      * @return void
@@ -2468,6 +2551,40 @@ class PromptBuilderTest extends TestCase
         $this->assertCount(2, $generatedFiles);
         $this->assertSame($files[0], $generatedFiles[0]);
         $this->assertSame($files[1], $generatedFiles[1]);
+    }
+
+    /**
+     * Tests generateVideos method without candidate count.
+     *
+     * @return void
+     */
+    public function testGenerateVideosWithoutCandidateCount(): void
+    {
+        $file = new File('https://example.com/vid1.mp4', 'video/mp4');
+
+        $result = new GenerativeAiResult(
+            'test-result-id',
+            [new Candidate(
+                new Message(MessageRoleEnum::model(), [new MessagePart($file)]),
+                FinishReasonEnum::stop()
+            )],
+            new TokenUsage(100, 50, 150),
+            $this->createTestProviderMetadata(),
+            $this->createTestTextModelMetadata()
+        );
+
+        $metadata = $this->createMock(ModelMetadata::class);
+        $metadata->method('getId')->willReturn('test-model');
+
+        $model = $this->createVideoGenerationModel($metadata, $result);
+
+        $builder = new PromptBuilder($this->registry, 'Generate videos');
+        $builder->usingModel($model);
+
+        $generatedFiles = $builder->generateVideos();
+
+        $this->assertCount(1, $generatedFiles);
+        $this->assertSame($file, $generatedFiles[0]);
     }
 
     /**


### PR DESCRIPTION
While we partially had the required pieces for video generation already present, for some reason we were missing part of the foundation. This PR fixes that.

This does not actually implement any video generation features - it just completes the API. It will allow providers to implement video support in the future.

Nothing special here, this entirely follows the existing patterns we already use for e.g. text generation, image generation, speech generation, ...