### PR TITLE
Fix incorrect JSON schema for `FunctionCall` and `FunctionResponse`

### DIFF
--- a/src/Common/AbstractDataTransferObject.php
+++ b/src/Common/AbstractDataTransferObject.php
@@ -132,11 +132,13 @@ abstract class AbstractDataTransferObject implements
                 }
             }
 
-            // Handle oneOf schemas - just use the first one
-            if (isset($schema['oneOf']) && is_array($schema['oneOf'])) {
-                foreach ($schema['oneOf'] as $possibleSchema) {
-                    if (is_array($possibleSchema)) {
-                        return $this->convertEmptyArraysToObjects($data, $possibleSchema);
+            // Handle oneOf/anyOf schemas - just use the first one
+            foreach (['oneOf', 'anyOf'] as $keyword) {
+                if (isset($schema[$keyword]) && is_array($schema[$keyword])) {
+                    foreach ($schema[$keyword] as $possibleSchema) {
+                        if (is_array($possibleSchema)) {
+                            return $this->convertEmptyArraysToObjects($data, $possibleSchema);
+                        }
                     }
                 }
             }

--- a/src/Tools/DTO/FunctionCall.php
+++ b/src/Tools/DTO/FunctionCall.php
@@ -119,7 +119,7 @@ class FunctionCall extends AbstractDataTransferObject
                     'description' => 'The arguments to pass to the function.',
                 ],
             ],
-            'oneOf' => [
+            'anyOf' => [
                 [
                     'required' => [self::KEY_ID],
                 ],

--- a/src/Tools/DTO/FunctionResponse.php
+++ b/src/Tools/DTO/FunctionResponse.php
@@ -163,14 +163,9 @@ class FunctionResponse extends AbstractDataTransferObject
     {
         static::validateFromArrayData($array, [self::KEY_RESPONSE]);
 
-        // Validate that at least one of id or name is provided
-        if (!array_key_exists(self::KEY_ID, $array) && !array_key_exists(self::KEY_NAME, $array)) {
-            throw new InvalidArgumentException('At least one of id or name must be provided.');
-        }
-
         return new self(
-            array_key_exists(self::KEY_ID, $array) ? (string) $array[self::KEY_ID] : null,
-            array_key_exists(self::KEY_NAME, $array) ? (string) $array[self::KEY_NAME] : null,
+            $array[self::KEY_ID] ?? null,
+            $array[self::KEY_NAME] ?? null,
             $array[self::KEY_RESPONSE]
         );
     }

--- a/src/Tools/DTO/FunctionResponse.php
+++ b/src/Tools/DTO/FunctionResponse.php
@@ -114,7 +114,7 @@ class FunctionResponse extends AbstractDataTransferObject
                     'description' => 'The response data from the function.',
                 ],
             ],
-            'oneOf' => [
+            'anyOf' => [
                 [
                     'required' => [self::KEY_RESPONSE, self::KEY_ID],
                 ],

--- a/src/Tools/DTO/FunctionResponse.php
+++ b/src/Tools/DTO/FunctionResponse.php
@@ -15,7 +15,7 @@ use WordPress\AiClient\Common\Exception\InvalidArgumentException;
  *
  * @since 0.1.0
  *
- * @phpstan-type FunctionResponseArrayShape array{id: string, name: string, response: mixed}
+ * @phpstan-type FunctionResponseArrayShape array{id?: string, name?: string, response: mixed}
  *
  * @extends AbstractDataTransferObject<FunctionResponseArrayShape>
  */
@@ -25,14 +25,14 @@ class FunctionResponse extends AbstractDataTransferObject
     public const KEY_NAME = 'name';
     public const KEY_RESPONSE = 'response';
     /**
-     * @var string The ID of the function call this is responding to.
+     * @var string|null The ID of the function call this is responding to.
      */
-    private string $id;
+    private ?string $id;
 
     /**
-     * @var string The name of the function that was called.
+     * @var string|null The name of the function that was called.
      */
-    private string $name;
+    private ?string $name;
 
     /**
      * @var mixed The response data from the function.
@@ -44,12 +44,17 @@ class FunctionResponse extends AbstractDataTransferObject
      *
      * @since 0.1.0
      *
-     * @param string $id The ID of the function call this is responding to.
-     * @param string $name The name of the function that was called.
+     * @param string|null $id The ID of the function call this is responding to.
+     * @param string|null $name The name of the function that was called.
      * @param mixed $response The response data from the function.
+     * @throws InvalidArgumentException If neither id nor name is provided.
      */
-    public function __construct(string $id, string $name, $response)
+    public function __construct(?string $id, ?string $name, $response)
     {
+        if ($id === null && $name === null) {
+            throw new InvalidArgumentException('At least one of id or name must be provided.');
+        }
+
         $this->id = $id;
         $this->name = $name;
         $this->response = $response;
@@ -134,11 +139,19 @@ class FunctionResponse extends AbstractDataTransferObject
      */
     public function toArray(): array
     {
-        return [
-            self::KEY_ID => $this->id,
-            self::KEY_NAME => $this->name,
-            self::KEY_RESPONSE => $this->response,
-        ];
+        $data = [];
+
+        if ($this->id !== null) {
+            $data[self::KEY_ID] = $this->id;
+        }
+
+        if ($this->name !== null) {
+            $data[self::KEY_NAME] = $this->name;
+        }
+
+        $data[self::KEY_RESPONSE] = $this->response;
+
+        return $data;
     }
 
     /**
@@ -156,8 +169,8 @@ class FunctionResponse extends AbstractDataTransferObject
         }
 
         return new self(
-            $array[self::KEY_ID] ?? null,
-            $array[self::KEY_NAME] ?? null,
+            array_key_exists(self::KEY_ID, $array) ? (string) $array[self::KEY_ID] : null,
+            array_key_exists(self::KEY_NAME, $array) ? (string) $array[self::KEY_NAME] : null,
             $array[self::KEY_RESPONSE]
         );
     }

--- a/tests/unit/Common/AbstractDataTransferObjectTest.php
+++ b/tests/unit/Common/AbstractDataTransferObjectTest.php
@@ -246,6 +246,82 @@ class AbstractDataTransferObjectTest extends TestCase
     }
 
     /**
+     * Tests handling of anyOf schemas uses first schema without validation.
+     *
+     * @return void
+     */
+    public function testAnyOfSchemaHandling(): void
+    {
+        $testObject = new class extends AbstractDataTransferObject {
+            public function toArray(): array
+            {
+                return [
+                    'dynamicField' => [
+                        'type' => 'objectType',
+                        'data' => [],
+                    ],
+                ];
+            }
+
+            public static function fromArray(array $array): self
+            {
+                return new static();
+            }
+
+            public static function getJsonSchema(): array
+            {
+                return [
+                    'type' => 'object',
+                    'properties' => [
+                        'dynamicField' => [
+                            'anyOf' => [
+                                [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'type' => [
+                                            'type' => 'string',
+                                            'const' => 'objectType'
+                                        ],
+                                        'data' => [
+                                            'type' => 'object',
+                                            'properties' => []
+                                        ],
+                                    ],
+                                    'required' => ['type', 'data'],
+                                ],
+                                [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'type' => [
+                                            'type' => 'string',
+                                            'const' => 'arrayType'
+                                        ],
+                                        'data' => [
+                                            'type' => 'array',
+                                            'items' => ['type' => 'string']
+                                        ],
+                                    ],
+                                    'required' => ['type', 'data'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ];
+            }
+        };
+
+        $result = $testObject->jsonSerialize();
+
+        $this->assertIsArray($result);
+        $this->assertIsArray($result['dynamicField']);
+        $this->assertInstanceOf(stdClass::class, $result['dynamicField']['data']);
+
+        $json = json_encode($result);
+        $this->assertIsString($json);
+        $this->assertStringContainsString('"data":{}', $json);
+    }
+
+    /**
      * Tests that arrays of objects are processed recursively.
      *
      * @return void

--- a/tests/unit/Tools/DTO/FunctionCallTest.php
+++ b/tests/unit/Tools/DTO/FunctionCallTest.php
@@ -127,15 +127,15 @@ class FunctionCallTest extends TestCase
         $this->assertContains('array', $schema['properties'][FunctionCall::KEY_ARGS]['type']);
         $this->assertContains('null', $schema['properties'][FunctionCall::KEY_ARGS]['type']);
 
-        // Check oneOf for required fields
-        $this->assertArrayHasKey('oneOf', $schema);
-        $this->assertCount(2, $schema['oneOf']);
+        // Check anyOf for required fields
+        $this->assertArrayHasKey('anyOf', $schema);
+        $this->assertCount(2, $schema['anyOf']);
 
         // First option: only id required
-        $this->assertEquals([FunctionCall::KEY_ID], $schema['oneOf'][0]['required']);
+        $this->assertEquals([FunctionCall::KEY_ID], $schema['anyOf'][0]['required']);
 
         // Second option: only name required
-        $this->assertEquals([FunctionCall::KEY_NAME], $schema['oneOf'][1]['required']);
+        $this->assertEquals([FunctionCall::KEY_NAME], $schema['anyOf'][1]['required']);
     }
 
     /**

--- a/tests/unit/Tools/DTO/FunctionResponseTest.php
+++ b/tests/unit/Tools/DTO/FunctionResponseTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace WordPress\AiClient\Tests\unit\Tools\DTO;
 
 use PHPUnit\Framework\TestCase;
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Tests\traits\ArrayTransformationTestTrait;
 use WordPress\AiClient\Tools\DTO\FunctionResponse;
 
@@ -35,6 +36,45 @@ class FunctionResponseTest extends TestCase
         $this->assertEquals($id, $functionResponse->getId());
         $this->assertEquals($name, $functionResponse->getName());
         $this->assertEquals($response, $functionResponse->getResponse());
+    }
+
+    /**
+     * Tests creating FunctionResponse with only id.
+     *
+     * @return void
+     */
+    public function testCreateWithIdOnly(): void
+    {
+        $functionResponse = new FunctionResponse('func_123', null, 'result');
+
+        $this->assertEquals('func_123', $functionResponse->getId());
+        $this->assertNull($functionResponse->getName());
+        $this->assertEquals('result', $functionResponse->getResponse());
+    }
+
+    /**
+     * Tests creating FunctionResponse with only name.
+     *
+     * @return void
+     */
+    public function testCreateWithNameOnly(): void
+    {
+        $functionResponse = new FunctionResponse(null, 'getWeather', 'result');
+
+        $this->assertNull($functionResponse->getId());
+        $this->assertEquals('getWeather', $functionResponse->getName());
+        $this->assertEquals('result', $functionResponse->getResponse());
+    }
+
+    /**
+     * Tests that creating FunctionResponse without id or name throws exception.
+     *
+     * @return void
+     */
+    public function testCreateWithoutIdOrNameThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new FunctionResponse(null, null, 'result');
     }
 
     /**
@@ -216,6 +256,36 @@ class FunctionResponseTest extends TestCase
     }
 
     /**
+     * Tests array transformation with only id.
+     *
+     * @return void
+     */
+    public function testToArrayWithIdOnly(): void
+    {
+        $response = new FunctionResponse('func_123', null, 'result');
+        $json = $this->assertToArrayReturnsArray($response);
+
+        $this->assertArrayHasKey(FunctionResponse::KEY_ID, $json);
+        $this->assertArrayNotHasKey(FunctionResponse::KEY_NAME, $json);
+        $this->assertArrayHasKey(FunctionResponse::KEY_RESPONSE, $json);
+    }
+
+    /**
+     * Tests array transformation with only name.
+     *
+     * @return void
+     */
+    public function testToArrayWithNameOnly(): void
+    {
+        $response = new FunctionResponse(null, 'calculate', 'result');
+        $json = $this->assertToArrayReturnsArray($response);
+
+        $this->assertArrayNotHasKey(FunctionResponse::KEY_ID, $json);
+        $this->assertArrayHasKey(FunctionResponse::KEY_NAME, $json);
+        $this->assertArrayHasKey(FunctionResponse::KEY_RESPONSE, $json);
+    }
+
+    /**
      * Tests fromJson method.
      *
      * @return void
@@ -234,6 +304,57 @@ class FunctionResponseTest extends TestCase
         $this->assertEquals('func_456', $response->getId());
         $this->assertEquals('search', $response->getName());
         $this->assertEquals(['found' => true, 'count' => 5], $response->getResponse());
+    }
+
+    /**
+     * Tests fromArray with only id.
+     *
+     * @return void
+     */
+    public function testFromArrayWithIdOnly(): void
+    {
+        $json = [
+            FunctionResponse::KEY_ID => 'func_456',
+            FunctionResponse::KEY_RESPONSE => 'result',
+        ];
+
+        $response = FunctionResponse::fromArray($json);
+
+        $this->assertEquals('func_456', $response->getId());
+        $this->assertNull($response->getName());
+        $this->assertEquals('result', $response->getResponse());
+    }
+
+    /**
+     * Tests fromArray with only name.
+     *
+     * @return void
+     */
+    public function testFromArrayWithNameOnly(): void
+    {
+        $json = [
+            FunctionResponse::KEY_NAME => 'search',
+            FunctionResponse::KEY_RESPONSE => 'result',
+        ];
+
+        $response = FunctionResponse::fromArray($json);
+
+        $this->assertNull($response->getId());
+        $this->assertEquals('search', $response->getName());
+        $this->assertEquals('result', $response->getResponse());
+    }
+
+    /**
+     * Tests fromArray without id or name throws exception.
+     *
+     * @return void
+     */
+    public function testFromArrayWithoutIdOrNameThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        FunctionResponse::fromArray([
+            FunctionResponse::KEY_RESPONSE => 'result',
+        ]);
     }
 
     /**

--- a/tests/unit/Tools/DTO/FunctionResponseTest.php
+++ b/tests/unit/Tools/DTO/FunctionResponseTest.php
@@ -122,20 +122,20 @@ class FunctionResponseTest extends TestCase
         $this->assertContains('array', $responseTypes);
         $this->assertContains('null', $responseTypes);
 
-        // Check oneOf for required fields
-        $this->assertArrayHasKey('oneOf', $schema);
-        $this->assertCount(2, $schema['oneOf']);
+        // Check anyOf for required fields
+        $this->assertArrayHasKey('anyOf', $schema);
+        $this->assertCount(2, $schema['anyOf']);
 
         // First option: response and id required
         $this->assertEquals(
             [FunctionResponse::KEY_RESPONSE, FunctionResponse::KEY_ID],
-            $schema['oneOf'][0]['required']
+            $schema['anyOf'][0]['required']
         );
 
         // Second option: response and name required
         $this->assertEquals(
             [FunctionResponse::KEY_RESPONSE, FunctionResponse::KEY_NAME],
-            $schema['oneOf'][1]['required']
+            $schema['anyOf'][1]['required']
         );
     }
 


### PR DESCRIPTION
* `FunctionCall` and `FunctionResponse` are currently using `oneOf`, which is not correct. It is totally valid for a function call or a function response to have _both_ `id` and `name` set. So this needs to be `anyOf` instead.
    * It doesn't show in any PHP-only usage, but as soon as you do something where the schema matters (e.g. REST API), this schema will lead to errors.
    * Regardless of whether or not it errors though, it is simply semantically incorrect.
* Somewhat related, the `FunctionResponse` was not handling its `id` and `name` the same way as `FunctionCall`. The properties weren't nullable, even though they should be - only one is required, though both are allowed. This was already reflected in parts of the class, but not consistently.

This PR fixes both of these bugs.