### PR TITLE
Validate provider IDs

### DIFF
--- a/src/Providers/DTO/ProviderMetadata.php
+++ b/src/Providers/DTO/ProviderMetadata.php
@@ -104,6 +104,7 @@ class ProviderMetadata extends AbstractDataTransferObject
         if (!preg_match('/^[a-z0-9\-_]+$/', $id)) {
             throw new InvalidArgumentException(
                 sprintf(
+                    // phpcs:ignore Generic.Files.LineLength.TooLong
                     'Invalid provider ID "%s". Only lowercase alphanumeric characters, hyphens, and underscores are allowed.',
                     $id
                 )

--- a/src/Providers/DTO/ProviderMetadata.php
+++ b/src/Providers/DTO/ProviderMetadata.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace WordPress\AiClient\Providers\DTO;
 
 use WordPress\AiClient\Common\AbstractDataTransferObject;
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
 use WordPress\AiClient\Providers\Http\Enums\RequestAuthenticationMethod;
 
@@ -89,6 +90,7 @@ class ProviderMetadata extends AbstractDataTransferObject
      * @param RequestAuthenticationMethod|null $authenticationMethod The authentication method.
      * @param string|null $description The provider's description.
      * @param string|null $logoPath The full path to the provider's logo image file.
+     * @throws InvalidArgumentException If the provider ID contains invalid characters.
      */
     public function __construct(
         string $id,
@@ -99,6 +101,15 @@ class ProviderMetadata extends AbstractDataTransferObject
         ?string $description = null,
         ?string $logoPath = null
     ) {
+        if (!preg_match('/^[a-z0-9\-_]+$/', $id)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid provider ID "%s". Only lowercase alphanumeric characters, hyphens, and underscores are allowed.',
+                    $id
+                )
+            );
+        }
+
         $this->id = $id;
         $this->name = $name;
         $this->description = $description;

--- a/tests/unit/Providers/DTO/ProviderMetadataTest.php
+++ b/tests/unit/Providers/DTO/ProviderMetadataTest.php
@@ -8,6 +8,7 @@ use JsonSerializable;
 use PHPUnit\Framework\TestCase;
 use WordPress\AiClient\Common\Contracts\WithArrayTransformationInterface;
 use WordPress\AiClient\Common\Contracts\WithJsonSchemaInterface;
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Providers\DTO\ProviderMetadata;
 use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
 
@@ -264,20 +265,64 @@ class ProviderMetadataTest extends TestCase
     }
 
     /**
-     * Tests with empty strings.
+     * Tests that empty string ID throws an exception.
      *
      * @return void
      */
-    public function testEmptyStrings(): void
+    public function testEmptyIdThrowsException(): void
     {
-        $metadata = new ProviderMetadata('', '', ProviderTypeEnum::cloud());
+        $this->expectException(InvalidArgumentException::class);
+        new ProviderMetadata('', '', ProviderTypeEnum::cloud());
+    }
 
-        $this->assertEquals('', $metadata->getId());
-        $this->assertEquals('', $metadata->getName());
+    /**
+     * Tests that uppercase characters in ID throw an exception.
+     *
+     * @return void
+     */
+    public function testUppercaseIdThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new ProviderMetadata('OpenAI', 'OpenAI', ProviderTypeEnum::cloud());
+    }
 
-        $array = $metadata->toArray();
-        $this->assertEquals('', $array[ProviderMetadata::KEY_ID]);
-        $this->assertEquals('', $array[ProviderMetadata::KEY_NAME]);
+    /**
+     * Tests that spaces in ID throw an exception.
+     *
+     * @return void
+     */
+    public function testSpacesInIdThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new ProviderMetadata('my provider', 'My Provider', ProviderTypeEnum::cloud());
+    }
+
+    /**
+     * Tests that special characters in ID throw an exception.
+     *
+     * @return void
+     */
+    public function testSpecialCharsInIdThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new ProviderMetadata('provider!', 'Provider', ProviderTypeEnum::cloud());
+    }
+
+    /**
+     * Tests that valid IDs with hyphens and underscores are accepted.
+     *
+     * @return void
+     */
+    public function testValidIdFormats(): void
+    {
+        $metadata1 = new ProviderMetadata('my-provider', 'My Provider', ProviderTypeEnum::cloud());
+        $this->assertEquals('my-provider', $metadata1->getId());
+
+        $metadata2 = new ProviderMetadata('provider_v2', 'Provider V2', ProviderTypeEnum::cloud());
+        $this->assertEquals('provider_v2', $metadata2->getId());
+
+        $metadata3 = new ProviderMetadata('a1-b2_c3', 'Test', ProviderTypeEnum::cloud());
+        $this->assertEquals('a1-b2_c3', $metadata3->getId());
     }
 
     /**


### PR DESCRIPTION
Only allow lower-case alphanumeric characters, hyphens, and underscores.