### PR TITLE
Fix: register providers and load .env in cli.php

### DIFF
--- a/cli-providers.php.example
+++ b/cli-providers.php.example
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Example CLI providers configuration.
+ *
+ * Copy this file to cli-providers.php and customize it with your desired providers.
+ * The cli-providers.php file is git-ignored so your configuration won't be committed.
+ *
+ * This file is loaded in a closure with only $registry in scope, ensuring isolation.
+ */
+
+declare(strict_types=1);
+
+use WordPress\AnthropicAiProvider\Provider\AnthropicProvider;
+use WordPress\GoogleAiProvider\Provider\GoogleProvider;
+use WordPress\OpenAiAiProvider\Provider\OpenAiProvider;
+
+// Register the providers you need for the CLI.
+// Only register providers that you have installed and configured.
+
+if (class_exists(AnthropicProvider::class)) {
+    $registry->registerProvider(AnthropicProvider::class);
+}
+
+if (class_exists(GoogleProvider::class)) {
+    $registry->registerProvider(GoogleProvider::class);
+}
+
+if (class_exists(OpenAiProvider::class)) {
+    $registry->registerProvider(OpenAiProvider::class);
+}

--- a/cli.php
+++ b/cli.php
@@ -23,6 +23,31 @@ use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 
 require_once __DIR__ . '/vendor/autoload.php';
 
+use Symfony\Component\Dotenv\Dotenv;
+use WordPress\AnthropicAiProvider\Provider\AnthropicProvider;
+use WordPress\GoogleAiProvider\Provider\GoogleProvider;
+use WordPress\OpenAiAiProvider\Provider\OpenAiProvider;
+
+// Load .env file if it exists (same approach as integration test bootstrap).
+$envFile = __DIR__ . '/.env';
+if (file_exists($envFile)) {
+    $dotenv = new Dotenv();
+    $dotenv->usePutenv(true);
+    $dotenv->load($envFile);
+}
+
+// Register provider packages so the registry can discover them.
+$registry = AiClient::defaultRegistry();
+if (class_exists(AnthropicProvider::class)) {
+    $registry->registerProvider(AnthropicProvider::class);
+}
+if (class_exists(GoogleProvider::class)) {
+    $registry->registerProvider(GoogleProvider::class);
+}
+if (class_exists(OpenAiProvider::class)) {
+    $registry->registerProvider(OpenAiProvider::class);
+}
+
 /**
  * Prints the output to stdout.
  *

--- a/cli.php
+++ b/cli.php
@@ -1,14 +1,20 @@
 <?php
+
 /**
  * CLI script for interacting with the AI client.
  *
  * This script allows users to send prompts to the AI and receive responses.
  * It supports named arguments for provider and model selection.
  *
+ * Setup:
+ *   1. Copy cli-providers.php.example to cli-providers.php
+ *   2. Customize cli-providers.php to register the providers you need
+ *   3. Create a .env file with your API keys (see .env.example)
+ *
  * Usage:
- *   GOOGLE_API_KEY=123456 php cli.php 'Your prompt here' --providerId=google --modelId=gemini-2.5-flash
- *   OPENAI_API_KEY=123456 php cli.php 'Your prompt here' --providerId=openai
- *   GOOGLE_API_KEY=123456 OPENAI_API_KEY=123456 php cli.php 'Your prompt here'
+ *   php cli.php 'Your prompt here' --providerId=google --modelId=gemini-2.5-flash
+ *   php cli.php 'Your prompt here' --providerId=openai
+ *   php cli.php 'Your prompt here'
  *
  * For large prompts (e.g., with images), use stdin or file input:
  *   cat prompt.json | php cli.php - --providerId=openai --modelId=gpt-4o
@@ -17,16 +23,12 @@
 
 declare(strict_types=1);
 
+use Symfony\Component\Dotenv\Dotenv;
 use WordPress\AiClient\AiClient;
 use WordPress\AiClient\Providers\Http\Exception\ResponseException;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 
 require_once __DIR__ . '/vendor/autoload.php';
-
-use Symfony\Component\Dotenv\Dotenv;
-use WordPress\AnthropicAiProvider\Provider\AnthropicProvider;
-use WordPress\GoogleAiProvider\Provider\GoogleProvider;
-use WordPress\OpenAiAiProvider\Provider\OpenAiProvider;
 
 // Load .env file if it exists (same approach as integration test bootstrap).
 $envFile = __DIR__ . '/.env';
@@ -37,15 +39,14 @@ if (file_exists($envFile)) {
 }
 
 // Register provider packages so the registry can discover them.
+// This is done via a user-controlled file to avoid hardcoding specific providers.
+// Copy cli-providers.php.example to cli-providers.php to get started.
 $registry = AiClient::defaultRegistry();
-if (class_exists(AnthropicProvider::class)) {
-    $registry->registerProvider(AnthropicProvider::class);
-}
-if (class_exists(GoogleProvider::class)) {
-    $registry->registerProvider(GoogleProvider::class);
-}
-if (class_exists(OpenAiProvider::class)) {
-    $registry->registerProvider(OpenAiProvider::class);
+$cliProvidersFile = __DIR__ . '/cli-providers.php';
+if (file_exists($cliProvidersFile)) {
+    (static function () use ($registry, $cliProvidersFile): void {
+        require $cliProvidersFile;
+    })();
 }
 
 /**


### PR DESCRIPTION
### What

`cli.php` was missing two bootstrapping steps, causing every run to fail with:

```
[ERROR] Invalid arguments while trying to set up prompt builder: Provider not registered: google
```

### Why

The `ProviderRegistry` has no built-in knowledge of provider packages they must be explicitly registered. Additionally, API keys stored in `.env` were never loaded into the environment, so providers could not authenticate even if registered.

### Changes

Added to `cli.php` (mirroring `tests/integration/bootstrap.php`):

1. **`.env` loading** via `symfony/dotenv` (already a dev dependency).
2. **Provider registration** for `AnthropicProvider`, `GoogleProvider`, and `OpenAiProvider`, guarded with `class_exists()` so the script works even if only a subset of provider packages are installed.

### Testing

```bash
# With a key in .env, e.g. GOOGLE_API_KEY=...
php cli.php 'Write a 2-verse poem about PHP.' --providerId=google --modelId=gemini-2.5-flash
```

### References

Fixes  : https://github.com/WordPress/php-ai-client/issues/223
