### PR TITLE
Change docblock to reflect media orientation

### DIFF
--- a/src/Files/Enums/MediaOrientationEnum.php
+++ b/src/Files/Enums/MediaOrientationEnum.php
@@ -7,7 +7,7 @@ namespace WordPress\AiClient\Files\Enums;
 use WordPress\AiClient\Common\AbstractEnum;
 
 /**
- * Represents the type of file storage.
+ * Represents the media orientation.
  *
  * @method static self square() Returns the square orientation
  * @method static self landscape() Returns the landscape orientation.


### PR DESCRIPTION
I noticed this copy pasta from `FileTypeEnum` as I was browsing the source.

Introduced in a6a83cb391af300328546a384ce865aa3fa740c0.