### PR TITLE
Use `non-empty-string` instead of `string` for Provider properties 

### DIFF
--- a/src/Common/AbstractEnum.php
+++ b/src/Common/AbstractEnum.php
@@ -32,20 +32,20 @@ use WordPress\AiClient\Common\Exception\RuntimeException;
  * $enum->is(PersonEnum::firstName()); // Returns true
  * PersonEnum::cases(); // Returns array of all enum instances
  *
- * @property-read string $value The value of the enum instance.
- * @property-read string $name The name of the enum constant.
+ * @property-read non-empty-string $value The value of the enum instance.
+ * @property-read non-empty-string $name The name of the enum constant.
  *
  * @since 0.1.0
  */
 abstract class AbstractEnum implements JsonSerializable
 {
     /**
-     * @var string The value of the enum instance.
+     * @var non-empty-string The value of the enum instance.
      */
     private string $value;
 
     /**
-     * @var string The name of the enum constant.
+     * @var non-empty-string The name of the enum constant.
      */
     private string $name;
 
@@ -64,8 +64,8 @@ abstract class AbstractEnum implements JsonSerializable
      *
      * @since 0.1.0
      *
-     * @param string $value The enum value.
-     * @param string $name The constant name.
+     * @param non-empty-string $value The enum value.
+     * @param non-empty-string $name The constant name.
      */
     final private function __construct(string $value, string $name)
     {

--- a/src/Providers/DTO/ProviderMetadata.php
+++ b/src/Providers/DTO/ProviderMetadata.php
@@ -20,13 +20,13 @@ use WordPress\AiClient\Providers\Http\Enums\RequestAuthenticationMethod;
  * @since 1.3.0 Added optional logoPath property.
  *
  * @phpstan-type ProviderMetadataArrayShape array{
- *     id: string,
- *     name: string,
- *     description?: ?string,
- *     type: string,
- *     credentialsUrl?: ?string,
- *     authenticationMethod?: ?string,
- *     logoPath?: ?string
+ *     id: non-empty-string,
+ *     name: non-empty-string,
+ *     description?: ?non-empty-string,
+ *     type: non-empty-string,
+ *     credentialsUrl?: ?non-empty-string,
+ *     authenticationMethod?: ?non-empty-string,
+ *     logoPath?: ?non-empty-string
  * }
  *
  * @extends AbstractDataTransferObject<ProviderMetadataArrayShape>
@@ -42,17 +42,17 @@ class ProviderMetadata extends AbstractDataTransferObject
     public const KEY_LOGO_PATH = 'logoPath';
 
     /**
-     * @var string The provider's unique identifier.
+     * @var non-empty-string The provider's unique identifier.
      */
     protected string $id;
 
     /**
-     * @var string The provider's display name.
+     * @var non-empty-string The provider's display name.
      */
     protected string $name;
 
     /**
-     * @var string|null The provider's description.
+     * @var non-empty-string|null The provider's description.
      */
     protected ?string $description;
 
@@ -62,7 +62,7 @@ class ProviderMetadata extends AbstractDataTransferObject
     protected ProviderTypeEnum $type;
 
     /**
-     * @var string|null The URL where users can get credentials.
+     * @var non-empty-string|null The URL where users can get credentials.
      */
     protected ?string $credentialsUrl;
 
@@ -72,7 +72,7 @@ class ProviderMetadata extends AbstractDataTransferObject
     protected ?RequestAuthenticationMethod $authenticationMethod;
 
     /**
-     * @var string|null The full path to the provider's logo image file.
+     * @var non-empty-string|null The full path to the provider's logo image file.
      */
     protected ?string $logoPath;
 
@@ -83,13 +83,13 @@ class ProviderMetadata extends AbstractDataTransferObject
      * @since 1.2.0 Added optional $description parameter.
      * @since 1.3.0 Added optional $logoPath parameter.
      *
-     * @param string $id The provider's unique identifier.
-     * @param string $name The provider's display name.
+     * @param non-empty-string $id The provider's unique identifier.
+     * @param non-empty-string $name The provider's display name.
      * @param ProviderTypeEnum $type The provider type.
-     * @param string|null $credentialsUrl The URL where users can get credentials.
+     * @param non-empty-string|null $credentialsUrl The URL where users can get credentials.
      * @param RequestAuthenticationMethod|null $authenticationMethod The authentication method.
-     * @param string|null $description The provider's description.
-     * @param string|null $logoPath The full path to the provider's logo image file.
+     * @param non-empty-string|null $description The provider's description.
+     * @param non-empty-string|null $logoPath The full path to the provider's logo image file.
      * @throws InvalidArgumentException If the provider ID contains invalid characters.
      */
     public function __construct(
@@ -125,7 +125,7 @@ class ProviderMetadata extends AbstractDataTransferObject
      *
      * @since 0.1.0
      *
-     * @return string The provider ID.
+     * @return non-empty-string The provider ID.
      */
     public function getId(): string
     {
@@ -137,7 +137,7 @@ class ProviderMetadata extends AbstractDataTransferObject
      *
      * @since 0.1.0
      *
-     * @return string The provider name.
+     * @return non-empty-string The provider name.
      */
     public function getName(): string
     {

--- a/src/Providers/ProviderRegistry.php
+++ b/src/Providers/ProviderRegistry.php
@@ -37,12 +37,12 @@ class ProviderRegistry implements WithHttpTransporterInterface
     }
 
     /**
-     * @var array<string, class-string<ProviderInterface>> Mapping of provider IDs to class names.
+     * @var array<non-empty-string, class-string<ProviderInterface>> Mapping of provider IDs to class names.
      */
     private array $registeredIdsToClassNames = [];
 
     /**
-     * @var array<class-string<ProviderInterface>, string> Mapping of provider class names to IDs.
+     * @var array<class-string<ProviderInterface>, non-empty-string> Mapping of provider class names to IDs.
      */
     private array $registeredClassNamesToIds = [];
 
@@ -132,7 +132,7 @@ class ProviderRegistry implements WithHttpTransporterInterface
      *
      * @since 0.1.0
      *
-     * @return list<string> List of registered provider IDs.
+     * @return list<non-empty-string> List of registered provider IDs.
      */
     public function getRegisteredProviderIds(): array
     {


### PR DESCRIPTION
The `non-empty-string` is a more specific type than `string`. It's clear that this is the intended type. For example, a `ProviderMetadata` constructor throws an exception if an empty string is provided: `!preg_match('/^[a-z0-9\-_]+$/', $id)`.

This addresses some issues uncovered in https://github.com/WordPress/wordpress-develop/pull/11701.
