### PR TITLE
Preserve empty JSON schema object maps

### DIFF
--- a/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
+++ b/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
@@ -492,9 +492,15 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
     {
         $tools = [];
         foreach ($functionDeclarations as $functionDeclaration) {
+            $function = $functionDeclaration->toArray();
+            $parameters = $functionDeclaration->getJsonSerializableParameters();
+            if ($parameters !== null) {
+                $function[FunctionDeclaration::KEY_PARAMETERS] = $parameters;
+            }
+
             $tools[] = [
                 'type' => 'function',
-                'function' => $functionDeclaration->toArray(),
+                'function' => $function,
             ];
         }
 

--- a/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
+++ b/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
@@ -492,15 +492,9 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
     {
         $tools = [];
         foreach ($functionDeclarations as $functionDeclaration) {
-            $function = $functionDeclaration->toArray();
-            $parameters = $functionDeclaration->getJsonSerializableParameters();
-            if ($parameters !== null) {
-                $function[FunctionDeclaration::KEY_PARAMETERS] = $parameters;
-            }
-
             $tools[] = [
                 'type' => 'function',
-                'function' => $function,
+                'function' => $functionDeclaration->jsonSerialize(),
             ];
         }
 

--- a/src/Tools/DTO/FunctionDeclaration.php
+++ b/src/Tools/DTO/FunctionDeclaration.php
@@ -95,28 +95,6 @@ class FunctionDeclaration extends AbstractDataTransferObject
     }
 
     /**
-     * Gets the function parameters schema in a JSON-serializable form.
-     *
-     * JSON Schema object-map fields such as properties must encode as JSON
-     * objects even when empty. PHP arrays cannot preserve that distinction
-     * without casting the empty map before serialization.
-     *
-     * @since 0.1.0
-     *
-     * @return array<string, mixed>|\stdClass|null The JSON-serializable parameters schema.
-     */
-    public function getJsonSerializableParameters()
-    {
-        if ($this->parameters === null) {
-            return null;
-        }
-
-        /** @var array<string, mixed>|\stdClass $parameters */
-        $parameters = $this->prepareJsonSchemaObjectMaps($this->parameters, self::KEY_PARAMETERS);
-        return $parameters;
-    }
-
-    /**
      * {@inheritDoc}
      *
      * @since 0.1.0
@@ -176,7 +154,10 @@ class FunctionDeclaration extends AbstractDataTransferObject
         $data = $this->toArray();
 
         if ($this->parameters !== null) {
-            $data[self::KEY_PARAMETERS] = $this->getJsonSerializableParameters();
+            $data[self::KEY_PARAMETERS] = $this->prepareJsonSchemaObjectMaps(
+                $this->parameters,
+                self::KEY_PARAMETERS
+            );
         }
 
         return $data;
@@ -185,7 +166,7 @@ class FunctionDeclaration extends AbstractDataTransferObject
     /**
      * Recursively prepares JSON Schema object-map fields for JSON serialization.
      *
-     * @since 0.1.0
+     * @since n.e.x.t
      *
      * @param mixed $value The value to prepare.
      * @param string|null $key The current JSON Schema key, if available.
@@ -214,7 +195,7 @@ class FunctionDeclaration extends AbstractDataTransferObject
     /**
      * Checks whether the given JSON Schema key represents an object map.
      *
-     * @since 0.1.0
+     * @since n.e.x.t
      *
      * @param string|null $key The JSON Schema key.
      * @return bool True if the key represents an object map, false otherwise.

--- a/src/Tools/DTO/FunctionDeclaration.php
+++ b/src/Tools/DTO/FunctionDeclaration.php
@@ -95,6 +95,28 @@ class FunctionDeclaration extends AbstractDataTransferObject
     }
 
     /**
+     * Gets the function parameters schema in a JSON-serializable form.
+     *
+     * JSON Schema object-map fields such as properties must encode as JSON
+     * objects even when empty. PHP arrays cannot preserve that distinction
+     * without casting the empty map before serialization.
+     *
+     * @since 0.1.0
+     *
+     * @return array<string, mixed>|\stdClass|null The JSON-serializable parameters schema.
+     */
+    public function getJsonSerializableParameters()
+    {
+        if ($this->parameters === null) {
+            return null;
+        }
+
+        /** @var array<string, mixed>|\stdClass $parameters */
+        $parameters = $this->prepareJsonSchemaObjectMaps($this->parameters, self::KEY_PARAMETERS);
+        return $parameters;
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @since 0.1.0
@@ -141,6 +163,69 @@ class FunctionDeclaration extends AbstractDataTransferObject
         }
 
         return $data;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 0.1.0
+     */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+        $data = $this->toArray();
+
+        if ($this->parameters !== null) {
+            $data[self::KEY_PARAMETERS] = $this->getJsonSerializableParameters();
+        }
+
+        return $data;
+    }
+
+    /**
+     * Recursively prepares JSON Schema object-map fields for JSON serialization.
+     *
+     * @since 0.1.0
+     *
+     * @param mixed $value The value to prepare.
+     * @param string|null $key The current JSON Schema key, if available.
+     * @return mixed The prepared value.
+     */
+    private function prepareJsonSchemaObjectMaps($value, ?string $key = null)
+    {
+        if (!is_array($value)) {
+            return $value;
+        }
+
+        if ($value === [] && $this->isJsonSchemaObjectMapKey($key)) {
+            return new \stdClass();
+        }
+
+        foreach ($value as $childKey => $childValue) {
+            $value[$childKey] = $this->prepareJsonSchemaObjectMaps(
+                $childValue,
+                is_string($childKey) ? $childKey : null
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Checks whether the given JSON Schema key represents an object map.
+     *
+     * @since 0.1.0
+     *
+     * @param string|null $key The JSON Schema key.
+     * @return bool True if the key represents an object map, false otherwise.
+     */
+    private function isJsonSchemaObjectMapKey(?string $key): bool
+    {
+        return in_array(
+            $key,
+            [self::KEY_PARAMETERS, 'properties', 'patternProperties', '$defs', 'definitions', 'dependentSchemas'],
+            true
+        );
     }
 
     /**

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
@@ -927,6 +927,35 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
     }
 
     /**
+     * Tests prepareToolsParam() preserves empty JSON Schema object maps.
+     *
+     * @return void
+     */
+    public function testPrepareToolsParamPreservesEmptySchemaObjectMaps(): void
+    {
+        $functionDeclaration = new FunctionDeclaration(
+            'inspect_object',
+            'Inspects an object with optional nested metadata',
+            [
+                'type' => 'object',
+                'properties' => [
+                    'metadata' => [
+                        'type' => 'object',
+                        'properties' => [],
+                    ],
+                ],
+            ]
+        );
+        $model = $this->createModel();
+
+        $prepared = $model->exposePrepareToolsParam([$functionDeclaration]);
+        $json = json_encode($prepared, JSON_THROW_ON_ERROR);
+
+        $this->assertStringContainsString('"properties":{', $json);
+        $this->assertStringNotContainsString('"properties":[]', $json);
+    }
+
+    /**
      * Tests prepareResponseFormatParam() with null schema.
      *
      * @return void

--- a/tests/unit/Tools/DTO/FunctionDeclarationTest.php
+++ b/tests/unit/Tools/DTO/FunctionDeclarationTest.php
@@ -55,7 +55,6 @@ class FunctionDeclarationTest extends TestCase
         $this->assertEquals($name, $declaration->getName());
         $this->assertEquals($description, $declaration->getDescription());
         $this->assertNull($declaration->getParameters());
-        $this->assertNull($declaration->getJsonSerializableParameters());
     }
 
     /**

--- a/tests/unit/Tools/DTO/FunctionDeclarationTest.php
+++ b/tests/unit/Tools/DTO/FunctionDeclarationTest.php
@@ -207,6 +207,33 @@ class FunctionDeclarationTest extends TestCase
     }
 
     /**
+     * Tests JSON serialization with empty JSON Schema object maps.
+     *
+     * @return void
+     */
+    public function testJsonSerializationPreservesEmptySchemaObjectMaps(): void
+    {
+        $declaration = new FunctionDeclaration(
+            'inspectObject',
+            'Inspects an object with optional nested metadata',
+            [
+                'type' => 'object',
+                'properties' => [
+                    'metadata' => [
+                        'type' => 'object',
+                        'properties' => [],
+                    ],
+                ],
+            ]
+        );
+
+        $json = json_encode($declaration, JSON_THROW_ON_ERROR);
+
+        $this->assertStringContainsString('"properties":{', $json);
+        $this->assertStringNotContainsString('"properties":[]', $json);
+    }
+
+    /**
      * Tests array transformation without parameters.
      *
      * @return void

--- a/tests/unit/Tools/DTO/FunctionDeclarationTest.php
+++ b/tests/unit/Tools/DTO/FunctionDeclarationTest.php
@@ -55,6 +55,7 @@ class FunctionDeclarationTest extends TestCase
         $this->assertEquals($name, $declaration->getName());
         $this->assertEquals($description, $declaration->getDescription());
         $this->assertNull($declaration->getParameters());
+        $this->assertNull($declaration->getJsonSerializableParameters());
     }
 
     /**


### PR DESCRIPTION
## Summary
- Adds a JSON-serializable parameter accessor for `FunctionDeclaration` that preserves empty JSON Schema object-map fields as `{}`.
- Updates `FunctionDeclaration::jsonSerialize()` to use the safe parameter representation.
- Updates the shared OpenAI-compatible tool payload builder to use the safe parameter representation when embedding function declarations.

Fixes https://github.com/WordPress/php-ai-client/issues/233.

## Testing
- `vendor/bin/phpunit tests/unit/Tools/DTO/FunctionDeclarationTest.php --filter testJsonSerializationPreservesEmptySchemaObjectMaps`
- `vendor/bin/phpunit tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php --filter testPrepareToolsParamPreservesEmptySchemaObjectMaps`
- `vendor/bin/phpunit tests/unit/Tools/DTO/FunctionDeclarationTest.php`
- `vendor/bin/phpunit tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php`
- `composer phpcs`
- `composer phpstan`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused serialization fix and tests from the issue reproduction; Chris remains responsible for review and merge.