### PR TITLE
GitHub Actions workflow updates

### DIFF
--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -32,11 +32,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   php-lint:
     name: PHP
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read # Required to check out the repository.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -34,6 +34,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     name: Test with PHP ${{matrix.php-version}} ${{ matrix.coverage && ' (coverage)' || '' }}
+    timeout-minutes: 20
     permissions:
       contents: read # Required to check out the repository.
     strategy:

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -26,10 +26,16 @@ on:
       - reopened
       - synchronize
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
     name: Test with PHP ${{matrix.php-version}} ${{ matrix.coverage && ' (coverage)' || '' }}
+    permissions:
+      contents: read # Required to check out the repository.
     strategy:
       matrix:
         php-version: ['7.4', '8.0', '8.4', '8.5']

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -50,9 +50,8 @@ jobs:
     name: Generate a list of props
     runs-on: ubuntu-24.04
     permissions:
-      # The action needs permission `write` permission for PRs in order to add a comment.
-      pull-requests: write
-      contents: read
+      pull-requests: write # Required to post the props comment to the PR and update its labels.
+      contents: read       # Required to check out the repository.
     timeout-minutes: 20
     # The job will run when pull requests are open, ready for review and:
     #


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/php-ai-client/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Claude Code was used to create the initial changes. All permissions and timeouts changes were reviewed and adjusted by me where necessary.
