### PR TITLE
Throw when no requested model preference is available

### DIFF
--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -275,6 +275,11 @@ class PromptBuilder
     /**
      * Sets preferred models to evaluate in order.
      *
+     * The preferences are evaluated in order, and the first one that is available for the prompt's
+     * requirements is used. If none of the provided preferences are available, generation throws an
+     * InvalidArgumentException rather than silently falling back to an arbitrary (potentially far more
+     * expensive) model. To allow automatic discovery instead, omit this method entirely.
+     *
      * @since 0.2.0
      *
      * @param string|ModelInterface|array{0:string,1:string} ...$preferredModels The preferred models as model IDs,
@@ -1320,7 +1325,8 @@ class PromptBuilder
      *
      * @param CapabilityEnum $capability The capability the model will be using.
      * @return ModelInterface The model to use.
-     * @throws InvalidArgumentException If no suitable model is found or set model doesn't meet requirements.
+     * @throws InvalidArgumentException If no suitable model is found, the set model doesn't meet requirements, or
+     *                                  explicit model preferences were provided but none are available.
      */
     private function getConfiguredModel(CapabilityEnum $capability): ModelInterface
     {
@@ -1363,18 +1369,24 @@ class PromptBuilder
                 $candidateMap
             );
 
-            if (!empty($matchingPreferences)) {
-                // Get the first matching preference key
-                $firstMatchKey = key($matchingPreferences);
-                [$providerId, $modelId] = $candidateMap[$firstMatchKey];
-
-                $model = $this->registry->getProviderModel($providerId, $modelId, $this->modelConfig);
-                $this->bindModelRequestOptions($model);
-                return $model;
+            if (empty($matchingPreferences)) {
+                // Explicit model preferences were provided, but none of them are available from the
+                // resolved provider(s). Silently falling back to an arbitrary discovered model would
+                // route the request to a different (potentially far more expensive) model than the
+                // caller asked for, with no signal. Fail loudly instead. See issue #241.
+                throw new InvalidArgumentException($this->buildUnmatchedPreferenceMessage($capability));
             }
+
+            // Get the first matching preference key
+            $firstMatchKey = key($matchingPreferences);
+            [$providerId, $modelId] = $candidateMap[$firstMatchKey];
+
+            $model = $this->registry->getProviderModel($providerId, $modelId, $this->modelConfig);
+            $this->bindModelRequestOptions($model);
+            return $model;
         }
 
-        // No preference matched; fall back to the first candidate discovered.
+        // No preference specified; fall back to the first candidate discovered.
         [$providerId, $modelId] = reset($candidateMap);
 
         $model = $this->registry->getProviderModel($providerId, $modelId, $this->modelConfig);
@@ -1517,6 +1529,49 @@ class PromptBuilder
     private function createModelPreferenceKey(string $modelId): string
     {
         return 'model::' . $modelId;
+    }
+
+    /**
+     * Builds the exception message for when no requested model preference is available.
+     *
+     * Reconstructs a human-readable list of the requested preferences from their internal
+     * keys so a typo or stale model identifier is obvious to the caller.
+     *
+     * @since n.e.x.t
+     *
+     * @param CapabilityEnum $capability The capability the model would be used for.
+     * @return string The exception message.
+     */
+    private function buildUnmatchedPreferenceMessage(CapabilityEnum $capability): string
+    {
+        $requested = [];
+        foreach ($this->modelPreferenceKeys as $preferenceKey) {
+            if (strpos($preferenceKey, 'providerModel::') === 0) {
+                [$providerId, $modelId] = explode('::', substr($preferenceKey, strlen('providerModel::')), 2);
+                $requested[] = sprintf('"%s" (provider "%s")', $modelId, $providerId);
+            } else {
+                $requested[] = sprintf('"%s"', substr($preferenceKey, strlen('model::')));
+            }
+        }
+
+        if ($this->providerIdOrClassName !== null) {
+            return sprintf(
+                'None of the requested model preferences (%s) are available from provider "%s" for %s. '
+                . 'Use a model identifier that the provider exposes, or call usingModelPreference() with an '
+                . 'available model.',
+                implode(', ', $requested),
+                $this->providerIdOrClassName,
+                $capability->value
+            );
+        }
+
+        return sprintf(
+            'None of the requested model preferences (%s) are available from any registered provider for %s. '
+            . 'Use a model identifier that a provider exposes, or call usingModelPreference() with an '
+            . 'available model.',
+            implode(', ', $requested),
+            $capability->value
+        );
     }
 
     /**

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -1546,7 +1546,7 @@ class PromptBuilder
     {
         $requested = [];
         foreach ($this->modelPreferenceKeys as $preferenceKey) {
-            if (strpos($preferenceKey, 'providerModel::') === 0) {
+            if (str_starts_with($preferenceKey, 'providerModel::')) {
                 [$providerId, $modelId] = explode('::', substr($preferenceKey, strlen('providerModel::')), 2);
                 $requested[] = sprintf('"%s" (provider "%s")', $modelId, $providerId);
             } else {

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -1546,19 +1546,23 @@ class PromptBuilder
     {
         $requested = [];
         foreach ($this->modelPreferenceKeys as $preferenceKey) {
-            if (str_starts_with($preferenceKey, 'providerModel::')) {
-                [$providerId, $modelId] = explode('::', substr($preferenceKey, strlen('providerModel::')), 2);
-                $requested[] = sprintf('"%s" (provider "%s")', $modelId, $providerId);
-            } else {
+            $providerModelParts = explode('::', $preferenceKey, 3);
+
+            if ($providerModelParts[0] === 'providerModel' && count($providerModelParts) === 3) {
+                $requested[] = sprintf('"%s" (provider "%s")', $providerModelParts[2], $providerModelParts[1]);
+            } elseif ($providerModelParts[0] === 'model' && count($providerModelParts) >= 2) {
                 $requested[] = sprintf('"%s"', substr($preferenceKey, strlen('model::')));
+            } else {
+                // Unexpected key shape; surface the raw value rather than a misleading substring.
+                $requested[] = sprintf('"%s"', $preferenceKey);
             }
         }
 
         if ($this->providerIdOrClassName !== null) {
             return sprintf(
                 'None of the requested model preferences (%s) are available from provider "%s" for %s. '
-                . 'Use a model identifier that the provider exposes, or call usingModelPreference() with an '
-                . 'available model.',
+                . 'Use a model identifier that the provider exposes, or remove the usingModelPreference() '
+                . 'call to allow automatic model discovery.',
                 implode(', ', $requested),
                 $this->providerIdOrClassName,
                 $capability->value
@@ -1567,8 +1571,8 @@ class PromptBuilder
 
         return sprintf(
             'None of the requested model preferences (%s) are available from any registered provider for %s. '
-            . 'Use a model identifier that a provider exposes, or call usingModelPreference() with an '
-            . 'available model.',
+            . 'Use a model identifier that a provider exposes, or remove the usingModelPreference() '
+            . 'call to allow automatic model discovery.',
             implode(', ', $requested),
             $capability->value
         );

--- a/tests/unit/Builders/PromptBuilderTest.php
+++ b/tests/unit/Builders/PromptBuilderTest.php
@@ -902,11 +902,82 @@ class PromptBuilderTest extends TestCase
     }
 
     /**
-     * Tests usingModelPreference falls back to discovery when no preferences are available.
+     * Tests usingModelPreference throws when none of the requested preferences are available.
+     *
+     * Requesting a specific model id that no provider exposes must fail loudly rather than
+     * silently routing the request to an arbitrary (potentially far more expensive) model.
+     * See issue #241.
      *
      * @return void
      */
-    public function testUsingModelPreferenceFallsBackToDiscovery(): void
+    public function testUsingModelPreferenceThrowsWhenNoPreferenceAvailable(): void
+    {
+        $metadata = $this->createTextModelMetadataWithInputSupport('discovered-id');
+        $providerMetadata = $this->createTestProviderMetadata();
+        $providerModelsMetadata = new ProviderModelsMetadata($providerMetadata, [$metadata]);
+
+        $this->registry->expects($this->once())
+            ->method('findModelsMetadataForSupport')
+            ->with($this->isInstanceOf(ModelRequirements::class))
+            ->willReturn([$providerModelsMetadata]);
+
+        // No model must be instantiated when the requested preference is unavailable.
+        $this->registry->expects($this->never())
+            ->method('getProviderModel');
+
+        $this->registry->expects($this->never())
+            ->method('findProviderModelsMetadataForSupport');
+
+        $builder = new PromptBuilder($this->registry, 'Test prompt');
+        $builder->usingModelPreference('unavailable-model');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('None of the requested model preferences ("unavailable-model")');
+
+        $builder->generateTextResult();
+    }
+
+    /**
+     * Tests usingModelPreference throws for an unavailable preference when a provider is locked in.
+     *
+     * @return void
+     */
+    public function testUsingModelPreferenceThrowsWhenNoPreferenceAvailableForProvider(): void
+    {
+        $metadata = $this->createTextModelMetadataWithInputSupport('available-id');
+
+        $this->registry->expects($this->once())
+            ->method('getProviderId')
+            ->with('test-provider')
+            ->willReturn('test-provider');
+
+        $this->registry->expects($this->once())
+            ->method('findProviderModelsMetadataForSupport')
+            ->with('test-provider', $this->isInstanceOf(ModelRequirements::class))
+            ->willReturn([$metadata]);
+
+        $this->registry->expects($this->never())
+            ->method('getProviderModel');
+
+        $this->registry->expects($this->never())
+            ->method('findModelsMetadataForSupport');
+
+        $builder = new PromptBuilder($this->registry, 'Test prompt');
+        $builder->usingProvider('test-provider');
+        $builder->usingModelPreference('unavailable-model');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('provider "test-provider"');
+
+        $builder->generateTextResult();
+    }
+
+    /**
+     * Tests automatic discovery is still used when no model preference is set.
+     *
+     * @return void
+     */
+    public function testFallsBackToDiscoveryWhenNoPreferenceSet(): void
     {
         $result = $this->createTestResult('Discovered model result');
         $metadata = $this->createTextModelMetadataWithInputSupport('discovered-id');
@@ -929,7 +1000,6 @@ class PromptBuilderTest extends TestCase
             ->method('findProviderModelsMetadataForSupport');
 
         $builder = new PromptBuilder($this->registry, 'Test prompt');
-        $builder->usingModelPreference('unavailable-model');
 
         $actualResult = $builder->generateTextResult();
 

--- a/tests/unit/Builders/PromptBuilderTest.php
+++ b/tests/unit/Builders/PromptBuilderTest.php
@@ -973,6 +973,37 @@ class PromptBuilderTest extends TestCase
     }
 
     /**
+     * Tests usingModelPreference throws and attributes the provider for an unavailable tuple preference.
+     *
+     * @return void
+     */
+    public function testUsingModelPreferenceThrowsWhenTuplePreferenceUnavailable(): void
+    {
+        $metadata = $this->createTextModelMetadataWithInputSupport('available-id');
+        $providerMetadata = $this->createTestProviderMetadata();
+        $providerModelsMetadata = new ProviderModelsMetadata($providerMetadata, [$metadata]);
+
+        $this->registry->expects($this->once())
+            ->method('findModelsMetadataForSupport')
+            ->with($this->isInstanceOf(ModelRequirements::class))
+            ->willReturn([$providerModelsMetadata]);
+
+        $this->registry->expects($this->never())
+            ->method('getProviderModel');
+
+        $this->registry->expects($this->never())
+            ->method('findProviderModelsMetadataForSupport');
+
+        $builder = new PromptBuilder($this->registry, 'Test prompt');
+        $builder->usingModelPreference(['missing-provider', 'missing-model']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"missing-model" (provider "missing-provider")');
+
+        $builder->generateTextResult();
+    }
+
+    /**
      * Tests automatic discovery is still used when no model preference is set.
      *
      * @return void


### PR DESCRIPTION
## Summary

Fixes #241.

Requesting a specific model id via `usingModelPreference()` that the resolved provider doesn't expose previously did **not** error — model resolution silently fell through to the first discovered model. A typo, a stale id, or a non-dated alias would silently route traffic to a potentially far more expensive model (e.g. Haiku → Opus) with no signal to the caller.

### Root cause

In `PromptBuilder::getConfiguredModel()`, preferences are matched against the candidate map by exact string. When **no** preference matched, the code fell through to `reset($candidateMap)` — the first model discovered for the prompt's capability — with no error or warning.

### Fix

When explicit model preferences were provided but **none** are available from the resolved provider(s), generation now throws an `InvalidArgumentException` instead of silently substituting a model. The message names the requested preference(s) (and the provider, if one was locked in via `usingProvider()`) so a typo or stale id is obvious.

Unchanged behavior:
- **No preference set** → automatic discovery still picks a suitable model.
- **Partial match** → when at least one requested preference is available, it is used in priority order (preference fallback among the stated preferences is still honored).
- **`usingModel()`** → the explicit path already validates the id and is unaffected.

## Behavior change note

This changes resolution from silent-fallback to throw for the unmatched-preference case. The unit test that codified the old silent fallback (`testUsingModelPreferenceFallsBackToDiscovery`) has been updated accordingly. Maintainers may want to reflect this in the version bump (currently 1.3.1).

## Out of scope (per the issue)

- **Alias resolution** (`claude-haiku-4-5` → latest dated model) — this mirrors provider-specific behavior and belongs in the individual provider plugins, not the core client.
- **"Cheapest available" fallback** — `ModelMetadata` carries no pricing/cost data, so models can't be ranked by cost in core.

## Testing

- `composer test:unit` — 1090 tests pass (added `testUsingModelPreferenceThrowsWhenNoPreferenceAvailable`, `testUsingModelPreferenceThrowsWhenNoPreferenceAvailableForProvider`, and `testFallsBackToDiscoveryWhenNoPreferenceSet`).
- `composer phpcs` — clean.
- `composer phpstan` — no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)