### PR TITLE
Fix article typo in README max-tokens example

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $texts = AiClient::prompt('Write a 2-verse poem about PHP.')
 ```php
 use WordPress\AiClient\AiClient;
 
-$text = AiClient::prompt('Write a 80-verse poem with long stanzas about PHP.')
+$text = AiClient::prompt('Write an 80-verse poem with long stanzas about PHP.')
     ->usingSystemInstruction('You are a famous poet from the 17th century.')
     ->usingTemperature(0.8)
     ->usingMaxTokens(8000);


### PR DESCRIPTION
## Summary

Fixes a small article typo in the README's "Text generation using max tokens" example. The example prompt read `'Write a 80-verse poem ...'`; since "eighty" begins with a vowel sound, it should be `'Write an 80-verse poem ...'`.

## Changes

- `README.md`: `a 80-verse` → `an 80-verse` in the max-tokens code example.

## Props

Props @vyskoczilova for surfacing the issue.

- https://github.com/vyskoczilova
- https://profiles.wordpress.org/vyskoczilova/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
