### PR TITLE
Fix broken method chain in README max-tokens example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ use WordPress\AiClient\AiClient;
 $text = AiClient::prompt('Write a 80-verse poem with long stanzas about PHP.')
     ->usingSystemInstruction('You are a famous poet from the 17th century.')
     ->usingTemperature(0.8)
-    ->usingMaxTokens(8000);
+    ->usingMaxTokens(8000)
     ->generateText();
 ```
 


### PR DESCRIPTION
## Summary

The "Text generation using max tokens" example in `README.md` has a stray semicolon after `->usingMaxTokens(8000)`, which terminates the statement mid-chain and makes the following `->generateText()` a parse error. Removing it lets the fluent builder chain flow through to `->generateText()` as intended.

## Changes

- `README.md`: remove the `;` after `->usingMaxTokens(8000)` so the method chain continues to `->generateText();`.

```diff
 $text = AiClient::prompt('Write a 80-verse poem with long stanzas about PHP.')
     ->usingSystemInstruction('You are a famous poet from the 17th century.')
     ->usingTemperature(0.8)
-    ->usingMaxTokens(8000);
+    ->usingMaxTokens(8000)
     ->generateText();
```

## Props

Props @vyskoczilova for the contribution.

- https://github.com/vyskoczilova
- https://profiles.wordpress.org/vyskoczilova/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
