### PR TITLE
Fix article typo and broken method chain in README max-tokens example

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ $texts = AiClient::prompt('Write a 2-verse poem about PHP.')
 ```php
 use WordPress\AiClient\AiClient;
 
-$text = AiClient::prompt('Write a 80-verse poem with long stanzas about PHP.')
+$text = AiClient::prompt('Write an 80-verse poem with long stanzas about PHP.')
     ->usingSystemInstruction('You are a famous poet from the 17th century.')
     ->usingTemperature(0.8)
-    ->usingMaxTokens(8000);
+    ->usingMaxTokens(8000)
     ->generateText();
 ```
 


### PR DESCRIPTION
## Summary

Two small fixes to the "Text generation using max tokens" code example in `README.md`:

1. **Article typo:** `'Write a 80-verse poem ...'` → `'Write an 80-verse poem ...'` ("eighty" begins with a vowel sound, so it takes *an*).
2. **Broken method chain:** the stray semicolon after `->usingMaxTokens(8000)` terminated the statement mid-chain, making the following `->generateText()` a parse error. Removing it lets the fluent builder chain flow through as intended.

```diff
-$text = AiClient::prompt('Write a 80-verse poem with long stanzas about PHP.')
+$text = AiClient::prompt('Write an 80-verse poem with long stanzas about PHP.')
     ->usingSystemInstruction('You are a famous poet from the 17th century.')
     ->usingTemperature(0.8)
-    ->usingMaxTokens(8000);
+    ->usingMaxTokens(8000)
     ->generateText();
```

This supersedes and consolidates #246 and #249, which each touched this same code block.

## Props

Props @vyskoczilova for the contribution.

- https://github.com/vyskoczilova
- https://profiles.wordpress.org/vyskoczilova/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
