### PR TITLE
Fix malformed json_schema envelope for OpenAI-compatible providers

### DIFF
--- a/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
+++ b/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
@@ -504,7 +504,11 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
     /**
      * Prepares the response format parameter for the API request.
      *
-     * This is only called if the output MIME type is `application/json`.
+     * This is only called if the output MIME type is `application/json`. When an output schema is
+     * provided, it is wrapped in the `json_schema` envelope expected by the OpenAI Chat Completions
+     * API, which requires a `name` field and the schema under the `schema` key. If a caller already
+     * supplies a wrapped payload (i.e. an array containing both `name` and `schema` keys), it is
+     * passed through unchanged.
      *
      * @since 0.1.0
      *
@@ -513,15 +517,30 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
      */
     protected function prepareResponseFormatParam(?array $outputSchema): array
     {
-        if (is_array($outputSchema)) {
+        if (!is_array($outputSchema)) {
+            return [
+                'type' => 'json_object',
+            ];
+        }
+
+        // Pass through payloads that are already wrapped in the json_schema envelope.
+        if (isset($outputSchema['name']) && isset($outputSchema['schema']) && is_array($outputSchema['schema'])) {
             return [
                 'type' => 'json_schema',
                 'json_schema' => $outputSchema,
             ];
         }
 
+        $jsonSchema = [
+            'name' => isset($outputSchema['title']) && is_string($outputSchema['title'])
+                ? $outputSchema['title']
+                : 'response',
+            'schema' => $outputSchema,
+        ];
+
         return [
-            'type' => 'json_object',
+            'type' => 'json_schema',
+            'json_schema' => $jsonSchema,
         ];
     }
 

--- a/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
+++ b/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
@@ -520,14 +520,17 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
      */
     protected function prepareResponseFormatParam(?array $outputSchema): array
     {
-        if (!is_array($outputSchema)) {
+        if ($outputSchema === null) {
             return [
                 'type' => 'json_object',
             ];
         }
 
         // Pass through payloads that are already wrapped in the json_schema envelope.
-        if (isset($outputSchema['name']) && isset($outputSchema['schema']) && is_array($outputSchema['schema'])) {
+        $isWrappedEnvelope = isset($outputSchema['name'])
+            && isset($outputSchema['schema'])
+            && is_array($outputSchema['schema']);
+        if ($isWrappedEnvelope) {
             return [
                 'type' => 'json_schema',
                 'json_schema' => $outputSchema,

--- a/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
+++ b/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
@@ -506,9 +506,12 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
      *
      * This is only called if the output MIME type is `application/json`. When an output schema is
      * provided, it is wrapped in the `json_schema` envelope expected by the OpenAI Chat Completions
-     * API, which requires a `name` field and the schema under the `schema` key. If a caller already
+     * API, which requires a `name` field and the schema under the `schema` key. The `name` uses a
+     * fixed identifier that satisfies the API's `^[a-zA-Z0-9_-]{1,64}$` constraint, rather than a
+     * value derived from the schema, to avoid producing an invalid name. If a caller already
      * supplies a wrapped payload (i.e. an array containing both `name` and `schema` keys), it is
-     * passed through unchanged.
+     * passed through unchanged, allowing callers to opt into provider-specific options such as
+     * `strict`.
      *
      * @since 0.1.0
      *
@@ -531,16 +534,12 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
             ];
         }
 
-        $jsonSchema = [
-            'name' => isset($outputSchema['title']) && is_string($outputSchema['title'])
-                ? $outputSchema['title']
-                : 'response',
-            'schema' => $outputSchema,
-        ];
-
         return [
             'type' => 'json_schema',
-            'json_schema' => $jsonSchema,
+            'json_schema' => [
+                'name' => 'response_schema',
+                'schema' => $outputSchema,
+            ],
         ];
     }
 

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
@@ -418,7 +418,16 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
         $params = $model->exposePrepareGenerateTextParams($prompt);
 
         $this->assertArrayHasKey('response_format', $params);
-        $this->assertEquals(['type' => 'json_schema', 'json_schema' => $schema], $params['response_format']);
+        $this->assertEquals(
+            [
+                'type' => 'json_schema',
+                'json_schema' => [
+                    'name' => 'response',
+                    'schema' => $schema,
+                ],
+            ],
+            $params['response_format']
+        );
     }
 
     /**
@@ -950,7 +959,67 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
         $model = $this->createModel();
         $format = $model->exposePrepareResponseFormatParam($schema);
 
-        $this->assertEquals(['type' => 'json_schema', 'json_schema' => $schema], $format);
+        $this->assertEquals(
+            [
+                'type' => 'json_schema',
+                'json_schema' => [
+                    'name' => 'response',
+                    'schema' => $schema,
+                ],
+            ],
+            $format
+        );
+    }
+
+    /**
+     * Tests prepareResponseFormatParam() uses the schema title as the json_schema name.
+     *
+     * @return void
+     */
+    public function testPrepareResponseFormatParamUsesSchemaTitleAsName(): void
+    {
+        $schema = [
+            'title' => 'review_notes',
+            'type' => 'object',
+            'properties' => ['key' => ['type' => 'string']],
+        ];
+        $model = $this->createModel();
+        $format = $model->exposePrepareResponseFormatParam($schema);
+
+        $this->assertEquals(
+            [
+                'type' => 'json_schema',
+                'json_schema' => [
+                    'name' => 'review_notes',
+                    'schema' => $schema,
+                ],
+            ],
+            $format
+        );
+    }
+
+    /**
+     * Tests prepareResponseFormatParam() passes through an already-wrapped envelope.
+     *
+     * @return void
+     */
+    public function testPrepareResponseFormatParamPassesThroughWrappedEnvelope(): void
+    {
+        $envelope = [
+            'name' => 'classification',
+            'strict' => true,
+            'schema' => ['type' => 'object', 'properties' => ['key' => ['type' => 'string']]],
+        ];
+        $model = $this->createModel();
+        $format = $model->exposePrepareResponseFormatParam($envelope);
+
+        $this->assertEquals(
+            [
+                'type' => 'json_schema',
+                'json_schema' => $envelope,
+            ],
+            $format
+        );
     }
 
     /**

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
@@ -422,7 +422,7 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
             [
                 'type' => 'json_schema',
                 'json_schema' => [
-                    'name' => 'response',
+                    'name' => 'response_schema',
                     'schema' => $schema,
                 ],
             ],
@@ -963,7 +963,7 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
             [
                 'type' => 'json_schema',
                 'json_schema' => [
-                    'name' => 'response',
+                    'name' => 'response_schema',
                     'schema' => $schema,
                 ],
             ],
@@ -972,14 +972,18 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
     }
 
     /**
-     * Tests prepareResponseFormatParam() uses the schema title as the json_schema name.
+     * Tests prepareResponseFormatParam() ignores the schema title when naming the envelope.
+     *
+     * The OpenAI API requires the json_schema name to match ^[a-zA-Z0-9_-]{1,64}$, so a
+     * user-supplied title (which may contain spaces or other invalid characters) must not be
+     * used as the name. A fixed, valid identifier is used instead.
      *
      * @return void
      */
-    public function testPrepareResponseFormatParamUsesSchemaTitleAsName(): void
+    public function testPrepareResponseFormatParamIgnoresSchemaTitle(): void
     {
         $schema = [
-            'title' => 'review_notes',
+            'title' => 'Review Notes!',
             'type' => 'object',
             'properties' => ['key' => ['type' => 'string']],
         ];
@@ -990,7 +994,7 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
             [
                 'type' => 'json_schema',
                 'json_schema' => [
-                    'name' => 'review_notes',
+                    'name' => 'response_schema',
                     'schema' => $schema,
                 ],
             ],


### PR DESCRIPTION
## Summary

Fixes #229.

`AbstractOpenAiCompatibleTextGenerationModel::prepareResponseFormatParam()` placed the user-supplied schema directly under the `json_schema` key and never included the required `name` field. Per the OpenAI Chat Completions API spec, `json_schema` must contain a `name` and carry the schema under a `schema` key. The malformed payload caused **HTTP 400** errors on compliant endpoints (OpenRouter, Together, Fireworks, Groq, Azure OpenAI relays — third-party providers extending this base class) whenever `asJsonResponse($schema)` was used.

## Changes

- Wrap the output schema in the required envelope: `['type' => 'json_schema', 'json_schema' => ['name' => 'response_schema', 'schema' => $outputSchema]]`.
- Use a **fixed, spec-valid `name`** (`response_schema`), matching the dedicated `OpenAiTextGenerationModel`. The OpenAI API constrains `name` to `^[a-zA-Z0-9_-]{1,64}$`, so deriving it from a user-supplied schema title (which may contain spaces or exceed 64 chars) would risk reintroducing the exact 400 this fixes.
- Pass through payloads that are **already** wrapped (arrays containing both `name` and `schema` keys) unchanged, so callers supplying a full envelope (e.g. with `strict`) keep working.
- `null` schema still yields `['type' => 'json_object']` (unchanged).

## Notes / decisions

- **`strict` is intentionally not set by default.** The API only requires `name`; `strict` is optional. This base targets many OpenAI-*compatible* providers whose `strict` support varies, and the SDK does no schema sanitization to guarantee strict-compliance (`additionalProperties:false`, all keys `required`), so forcing `strict: true` here could trigger 400s on otherwise-valid schemas. Callers who want it can pass a pre-wrapped envelope, which is passed through.
- No provider in this repo extends the abstract class (the dedicated OpenAI/Anthropic providers roll their own), so there's no in-repo integration path for this code — only unit coverage. Worth keeping in mind for future test coverage.

## Tests

- Updated the assertions that expected the old (malformed) structure.
- Added coverage for: a fixed name being used even when the schema has an invalid `title`, and pass-through of an already-wrapped envelope.
- `composer test:unit` (1090 tests), `composer phpcs` (PSR-12) and `composer phpstan` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)