### PR TITLE
Fix malformed json_schema response_format envelope (#229)

### DIFF
--- a/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
+++ b/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
@@ -514,9 +514,21 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
     protected function prepareResponseFormatParam(?array $outputSchema): array
     {
         if (is_array($outputSchema)) {
+            /*
+             * The OpenAI Structured Outputs spec requires `json_schema` to be an object carrying the
+             * schema under a `schema` key, plus a required `name`. Emitting the bare schema makes
+             * compliant endpoints reject the request with
+             * `400 missing_required_parameter: response_format.json_schema.name`. `strict` is left
+             * unset on purpose: enabling it would impose extra schema constraints (every object
+             * needs `additionalProperties: false`, all properties listed in `required`) that arbitrary
+             * caller schemas rarely satisfy, trading one 400 for another. Only `name` is required.
+             */
             return [
                 'type' => 'json_schema',
-                'json_schema' => $outputSchema,
+                'json_schema' => [
+                    'name' => 'response',
+                    'schema' => $outputSchema,
+                ],
             ];
         }
 

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
@@ -418,7 +418,10 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
         $params = $model->exposePrepareGenerateTextParams($prompt);
 
         $this->assertArrayHasKey('response_format', $params);
-        $this->assertEquals(['type' => 'json_schema', 'json_schema' => $schema], $params['response_format']);
+        $this->assertEquals(
+            ['type' => 'json_schema', 'json_schema' => ['name' => 'response', 'schema' => $schema]],
+            $params['response_format']
+        );
     }
 
     /**
@@ -950,7 +953,34 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
         $model = $this->createModel();
         $format = $model->exposePrepareResponseFormatParam($schema);
 
-        $this->assertEquals(['type' => 'json_schema', 'json_schema' => $schema], $format);
+        $this->assertEquals(
+            ['type' => 'json_schema', 'json_schema' => ['name' => 'response', 'schema' => $schema]],
+            $format
+        );
+    }
+
+    /**
+     * Tests that the json_schema envelope carries the required `name` and wraps the schema (regression for #229).
+     *
+     * The OpenAI Structured Outputs spec rejects a bare schema with
+     * `400 missing_required_parameter: response_format.json_schema.name`; the schema must sit under
+     * `json_schema.schema` alongside a `name`.
+     *
+     * @return void
+     */
+    public function testPrepareResponseFormatParamSchemaEnvelopeHasName(): void
+    {
+        $schema = ['type' => 'object', 'properties' => ['key' => ['type' => 'string']]];
+        $model = $this->createModel();
+        $format = $model->exposePrepareResponseFormatParam($schema);
+
+        $this->assertSame('json_schema', $format['type']);
+        $this->assertArrayHasKey('name', $format['json_schema']);
+        $this->assertNotSame('', $format['json_schema']['name']);
+        $this->assertSame($schema, $format['json_schema']['schema']);
+        $this->assertArrayNotHasKey('strict', $format['json_schema']);
+        // The raw schema must not be emitted directly under `json_schema` (the original #229 bug).
+        $this->assertArrayNotHasKey('type', $format['json_schema']);
     }
 
     /**


### PR DESCRIPTION
Fixes #229.

## Problem

`AbstractOpenAiCompatibleTextGenerationModel::prepareResponseFormatParam()` emitted the bare output schema directly under `json_schema`:

```php
['type' => 'json_schema', 'json_schema' => $outputSchema]
```

The OpenAI [Structured Outputs spec](https://platform.openai.com/docs/api-reference/chat/create#chat-create-response_format) requires `json_schema` to be an **object** carrying the schema under a `schema` key plus a **required** `name`. As a result, any provider extending this base class fails on structured-output requests (`asJsonResponse($schema)`) against a compliant endpoint with:

```
400 missing_required_parameter: response_format.json_schema.name
```

Plain text generation is unaffected (the broken path is gated behind the `application/json` output MIME type). Permissive self-hosted servers may silently accept the malformed payload, which is why this only surfaces on strict endpoints (OpenAI, OpenRouter→Azure, etc.).

## Fix

Wrap the schema in the spec-compliant envelope:

```php
['type' => 'json_schema', 'json_schema' => ['name' => 'response', 'schema' => $outputSchema]]
```

`strict` is intentionally **left unset**. Enabling it imposes extra schema constraints (every object needs `additionalProperties: false`, all properties listed in `required`) that arbitrary caller schemas rarely satisfy — that would trade one 400 for another. Per the spec, only `name` is required.

## Verification

- **Unit:** updates the two existing assertions and adds a regression test (`testPrepareResponseFormatParamSchemaEnvelopeHasName`) asserting the envelope shape — `name` present, schema wrapped under `schema`, `strict` absent, and the raw schema no longer emitted directly under `json_schema`.
- **Live, end-to-end against the OpenAI Chat Completions API:** the previous payload returns the exact `400 missing_required_parameter: response_format.json_schema.name`; the payload produced by the patched method returns `200` with valid JSON content.
- `composer lint` clean (phpcs PSR-12 + phpstan max); `composer test:unit` green.