### PR TITLE
Add cached token fields to TokenUsage and parse OpenAI-compatible cache usage

### DIFF
--- a/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
+++ b/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
@@ -55,7 +55,10 @@ use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
  * @phpstan-type UsageData array{
  *     prompt_tokens?: int,
  *     completion_tokens?: int,
- *     total_tokens?: int
+ *     total_tokens?: int,
+ *     prompt_tokens_details?: array{
+ *         cached_tokens?: int
+ *     }
  * }
  * @phpstan-type ResponseData array{
  *     id?: string,
@@ -607,7 +610,9 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
             $tokenUsage = new TokenUsage(
                 $usage['prompt_tokens'] ?? 0,
                 $usage['completion_tokens'] ?? 0,
-                $usage['total_tokens'] ?? 0
+                $usage['total_tokens'] ?? 0,
+                null,
+                $usage['prompt_tokens_details']['cached_tokens'] ?? null
             );
         } else {
             $tokenUsage = new TokenUsage(0, 0, 0);

--- a/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
+++ b/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
@@ -57,7 +57,8 @@ use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
  *     completion_tokens?: int,
  *     total_tokens?: int,
  *     prompt_tokens_details?: array{
- *         cached_tokens?: int
+ *         cached_tokens?: int,
+ *         cache_write_tokens?: int
  *     }
  * }
  * @phpstan-type ResponseData array{
@@ -612,7 +613,8 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
                 $usage['completion_tokens'] ?? 0,
                 $usage['total_tokens'] ?? 0,
                 null,
-                $usage['prompt_tokens_details']['cached_tokens'] ?? null
+                $usage['prompt_tokens_details']['cached_tokens'] ?? null,
+                $usage['prompt_tokens_details']['cache_write_tokens'] ?? null
             );
         } else {
             $tokenUsage = new TokenUsage(0, 0, 0);

--- a/src/Results/DTO/TokenUsage.php
+++ b/src/Results/DTO/TokenUsage.php
@@ -15,13 +15,18 @@ use WordPress\AiClient\Common\AbstractDataTransferObject;
  * Note that thought tokens are a subset of completion tokens, not additive.
  * In other words: completionTokens - thoughtTokens = tokens of actual output content.
  *
+ * Similarly, cached tokens are a subset of prompt tokens, not additive.
+ * In other words: promptTokens - cachedTokens = prompt tokens that were not served from a provider cache.
+ *
  * @since 0.1.0
  *
  * @phpstan-type TokenUsageArrayShape array{
  *     promptTokens: int,
  *     completionTokens: int,
  *     totalTokens: int,
- *     thoughtTokens?: int
+ *     thoughtTokens?: int,
+ *     cachedTokens?: int,
+ *     cacheCreationTokens?: int
  * }
  *
  * @extends AbstractDataTransferObject<TokenUsageArrayShape>
@@ -32,6 +37,8 @@ class TokenUsage extends AbstractDataTransferObject
     public const KEY_COMPLETION_TOKENS = 'completionTokens';
     public const KEY_TOTAL_TOKENS = 'totalTokens';
     public const KEY_THOUGHT_TOKENS = 'thoughtTokens';
+    public const KEY_CACHED_TOKENS = 'cachedTokens';
+    public const KEY_CACHE_CREATION_TOKENS = 'cacheCreationTokens';
     /**
      * @var int Number of tokens in the prompt.
      */
@@ -53,6 +60,16 @@ class TokenUsage extends AbstractDataTransferObject
     private ?int $thoughtTokens;
 
     /**
+     * @var int|null Number of prompt tokens served from a provider cache, as a subset of prompt tokens.
+     */
+    private ?int $cachedTokens;
+
+    /**
+     * @var int|null Number of tokens written to a provider cache while processing the request.
+     */
+    private ?int $cacheCreationTokens;
+
+    /**
      * Constructor.
      *
      * @since 0.1.0
@@ -61,13 +78,24 @@ class TokenUsage extends AbstractDataTransferObject
      * @param int $completionTokens Number of tokens in the completion, including any thought tokens.
      * @param int $totalTokens Total number of tokens used.
      * @param int|null $thoughtTokens Number of tokens used for thinking, as a subset of completion tokens.
+     * @param int|null $cachedTokens Number of prompt tokens served from a provider cache, as a subset of prompt
+     *                               tokens.
+     * @param int|null $cacheCreationTokens Number of tokens written to a provider cache while processing the request.
      */
-    public function __construct(int $promptTokens, int $completionTokens, int $totalTokens, ?int $thoughtTokens = null)
-    {
+    public function __construct(
+        int $promptTokens,
+        int $completionTokens,
+        int $totalTokens,
+        ?int $thoughtTokens = null,
+        ?int $cachedTokens = null,
+        ?int $cacheCreationTokens = null
+    ) {
         $this->promptTokens = $promptTokens;
         $this->completionTokens = $completionTokens;
         $this->totalTokens = $totalTokens;
         $this->thoughtTokens = $thoughtTokens;
+        $this->cachedTokens = $cachedTokens;
+        $this->cacheCreationTokens = $cacheCreationTokens;
     }
 
     /**
@@ -119,6 +147,30 @@ class TokenUsage extends AbstractDataTransferObject
     }
 
     /**
+     * Gets the number of cached tokens, which is a subset of the prompt token count.
+     *
+     * @since n.e.x.t
+     *
+     * @return int|null The cached token count or null if not available.
+     */
+    public function getCachedTokens(): ?int
+    {
+        return $this->cachedTokens;
+    }
+
+    /**
+     * Gets the number of tokens written to a provider cache while processing the request.
+     *
+     * @since n.e.x.t
+     *
+     * @return int|null The cache creation token count or null if not available.
+     */
+    public function getCacheCreationTokens(): ?int
+    {
+        return $this->cacheCreationTokens;
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @since 0.1.0
@@ -144,6 +196,15 @@ class TokenUsage extends AbstractDataTransferObject
                     'type' => 'integer',
                     'description' => 'Number of tokens used for thinking, as a subset of completion tokens.',
                 ],
+                self::KEY_CACHED_TOKENS => [
+                    'type' => 'integer',
+                    'description' => 'Number of prompt tokens served from a provider cache, as a subset of prompt'
+                        . ' tokens.',
+                ],
+                self::KEY_CACHE_CREATION_TOKENS => [
+                    'type' => 'integer',
+                    'description' => 'Number of tokens written to a provider cache while processing the request.',
+                ],
             ],
             'required' => [self::KEY_PROMPT_TOKENS, self::KEY_COMPLETION_TOKENS, self::KEY_TOTAL_TOKENS],
         ];
@@ -168,6 +229,14 @@ class TokenUsage extends AbstractDataTransferObject
             $data[self::KEY_THOUGHT_TOKENS] = $this->thoughtTokens;
         }
 
+        if ($this->cachedTokens !== null) {
+            $data[self::KEY_CACHED_TOKENS] = $this->cachedTokens;
+        }
+
+        if ($this->cacheCreationTokens !== null) {
+            $data[self::KEY_CACHE_CREATION_TOKENS] = $this->cacheCreationTokens;
+        }
+
         return $data;
     }
 
@@ -188,7 +257,9 @@ class TokenUsage extends AbstractDataTransferObject
             $array[self::KEY_PROMPT_TOKENS],
             $array[self::KEY_COMPLETION_TOKENS],
             $array[self::KEY_TOTAL_TOKENS],
-            $array[self::KEY_THOUGHT_TOKENS] ?? null
+            $array[self::KEY_THOUGHT_TOKENS] ?? null,
+            $array[self::KEY_CACHED_TOKENS] ?? null,
+            $array[self::KEY_CACHE_CREATION_TOKENS] ?? null
         );
     }
 }

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
@@ -138,7 +138,7 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
     }
 
     /**
-     * Tests generateTextResult() surfaces cached tokens from prompt tokens details.
+     * Tests generateTextResult() surfaces cache token counts from prompt tokens details.
      *
      * @return void
      */
@@ -165,6 +165,7 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
                     'total_tokens' => 2053,
                     'prompt_tokens_details' => [
                         'cached_tokens' => 1024,
+                        'cache_write_tokens' => 512,
                     ],
                 ],
             ])
@@ -185,6 +186,7 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
 
         $this->assertEquals(2048, $result->getTokenUsage()->getPromptTokens());
         $this->assertEquals(1024, $result->getTokenUsage()->getCachedTokens());
+        $this->assertEquals(512, $result->getTokenUsage()->getCacheCreationTokens());
     }
 
     /**

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
@@ -138,6 +138,103 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
     }
 
     /**
+     * Tests generateTextResult() surfaces cached tokens from prompt tokens details.
+     *
+     * @return void
+     */
+    public function testGenerateTextResultParsesCachedTokens(): void
+    {
+        $prompt = [new Message(MessageRoleEnum::user(), [new MessagePart('Hello')])];
+        $response = new Response(
+            200,
+            [],
+            json_encode([
+                'id' => 'chatcmpl-123',
+                'choices' => [
+                    [
+                        'message' => [
+                            'role' => 'assistant',
+                            'content' => 'Hi there!',
+                        ],
+                        'finish_reason' => 'stop',
+                    ],
+                ],
+                'usage' => [
+                    'prompt_tokens' => 2048,
+                    'completion_tokens' => 5,
+                    'total_tokens' => 2053,
+                    'prompt_tokens_details' => [
+                        'cached_tokens' => 1024,
+                    ],
+                ],
+            ])
+        );
+
+        $this->mockRequestAuthentication
+            ->expects($this->once())
+            ->method('authenticateRequest')
+            ->willReturnArgument(0);
+
+        $this->mockHttpTransporter
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn($response);
+
+        $model = $this->createModel();
+        $result = $model->generateTextResult($prompt);
+
+        $this->assertEquals(2048, $result->getTokenUsage()->getPromptTokens());
+        $this->assertEquals(1024, $result->getTokenUsage()->getCachedTokens());
+    }
+
+    /**
+     * Tests generateTextResult() returns null cached tokens when the provider omits prompt tokens details.
+     *
+     * @return void
+     */
+    public function testGenerateTextResultWithoutCachedTokens(): void
+    {
+        $prompt = [new Message(MessageRoleEnum::user(), [new MessagePart('Hello')])];
+        $response = new Response(
+            200,
+            [],
+            json_encode([
+                'id' => 'chatcmpl-123',
+                'choices' => [
+                    [
+                        'message' => [
+                            'role' => 'assistant',
+                            'content' => 'Hi there!',
+                        ],
+                        'finish_reason' => 'stop',
+                    ],
+                ],
+                'usage' => [
+                    'prompt_tokens' => 10,
+                    'completion_tokens' => 5,
+                    'total_tokens' => 15,
+                ],
+            ])
+        );
+
+        $this->mockRequestAuthentication
+            ->expects($this->once())
+            ->method('authenticateRequest')
+            ->willReturnArgument(0);
+
+        $this->mockHttpTransporter
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn($response);
+
+        $model = $this->createModel();
+        $result = $model->generateTextResult($prompt);
+
+        $this->assertNull($result->getTokenUsage()->getCachedTokens());
+        $this->assertNull($result->getTokenUsage()->getCacheCreationTokens());
+    }
+
+    /**
      * Tests generateTextResult() method on API failure.
      *
      * @return void

--- a/tests/unit/Results/DTO/TokenUsageTest.php
+++ b/tests/unit/Results/DTO/TokenUsageTest.php
@@ -432,4 +432,142 @@ class TokenUsageTest extends TestCase
         $this->assertArrayHasKey('description', $schema['properties'][TokenUsage::KEY_THOUGHT_TOKENS]);
         $this->assertNotContains(TokenUsage::KEY_THOUGHT_TOKENS, $schema['required']);
     }
+
+    /**
+     * Tests creating TokenUsage with cache tokens.
+     *
+     * @return void
+     */
+    public function testCreateWithCacheTokens(): void
+    {
+        $tokenUsage = new TokenUsage(100, 50, 150, null, 80, 15);
+
+        $this->assertEquals(100, $tokenUsage->getPromptTokens());
+        $this->assertEquals(50, $tokenUsage->getCompletionTokens());
+        $this->assertEquals(150, $tokenUsage->getTotalTokens());
+        $this->assertEquals(80, $tokenUsage->getCachedTokens());
+        $this->assertEquals(15, $tokenUsage->getCacheCreationTokens());
+    }
+
+    /**
+     * Tests that cache tokens are null by default.
+     *
+     * @return void
+     */
+    public function testCreateWithoutCacheTokens(): void
+    {
+        $tokenUsage = new TokenUsage(100, 50, 150);
+
+        $this->assertNull($tokenUsage->getCachedTokens());
+        $this->assertNull($tokenUsage->getCacheCreationTokens());
+    }
+
+    /**
+     * Tests toArray includes cache tokens when set.
+     *
+     * @return void
+     */
+    public function testToArrayIncludesCacheTokens(): void
+    {
+        $tokenUsage = new TokenUsage(100, 50, 150, null, 80, 15);
+        $array = $tokenUsage->toArray();
+
+        $this->assertArrayHasKey(TokenUsage::KEY_CACHED_TOKENS, $array);
+        $this->assertEquals(80, $array[TokenUsage::KEY_CACHED_TOKENS]);
+        $this->assertArrayHasKey(TokenUsage::KEY_CACHE_CREATION_TOKENS, $array);
+        $this->assertEquals(15, $array[TokenUsage::KEY_CACHE_CREATION_TOKENS]);
+    }
+
+    /**
+     * Tests toArray excludes cache tokens when not set.
+     *
+     * @return void
+     */
+    public function testToArrayExcludesCacheTokens(): void
+    {
+        $tokenUsage = new TokenUsage(100, 50, 150);
+        $array = $tokenUsage->toArray();
+
+        $this->assertArrayNotHasKey(TokenUsage::KEY_CACHED_TOKENS, $array);
+        $this->assertArrayNotHasKey(TokenUsage::KEY_CACHE_CREATION_TOKENS, $array);
+    }
+
+    /**
+     * Tests fromArray with cache tokens.
+     *
+     * @return void
+     */
+    public function testFromArrayWithCacheTokens(): void
+    {
+        $array = [
+            TokenUsage::KEY_PROMPT_TOKENS => 100,
+            TokenUsage::KEY_COMPLETION_TOKENS => 50,
+            TokenUsage::KEY_TOTAL_TOKENS => 150,
+            TokenUsage::KEY_CACHED_TOKENS => 80,
+            TokenUsage::KEY_CACHE_CREATION_TOKENS => 15,
+        ];
+
+        $tokenUsage = TokenUsage::fromArray($array);
+
+        $this->assertEquals(80, $tokenUsage->getCachedTokens());
+        $this->assertEquals(15, $tokenUsage->getCacheCreationTokens());
+    }
+
+    /**
+     * Tests fromArray without cache tokens still works.
+     *
+     * @return void
+     */
+    public function testFromArrayWithoutCacheTokens(): void
+    {
+        $array = [
+            TokenUsage::KEY_PROMPT_TOKENS => 100,
+            TokenUsage::KEY_COMPLETION_TOKENS => 50,
+            TokenUsage::KEY_TOTAL_TOKENS => 150,
+        ];
+
+        $tokenUsage = TokenUsage::fromArray($array);
+
+        $this->assertNull($tokenUsage->getCachedTokens());
+        $this->assertNull($tokenUsage->getCacheCreationTokens());
+    }
+
+    /**
+     * Tests round-trip array transformation with cache tokens.
+     *
+     * @return void
+     */
+    public function testArrayRoundTripWithCacheTokens(): void
+    {
+        $original = new TokenUsage(200, 100, 300, 40, 160, 25);
+        $array = $original->toArray();
+        $restored = TokenUsage::fromArray($array);
+
+        $this->assertEquals($original->getPromptTokens(), $restored->getPromptTokens());
+        $this->assertEquals($original->getCompletionTokens(), $restored->getCompletionTokens());
+        $this->assertEquals($original->getTotalTokens(), $restored->getTotalTokens());
+        $this->assertEquals($original->getThoughtTokens(), $restored->getThoughtTokens());
+        $this->assertEquals($original->getCachedTokens(), $restored->getCachedTokens());
+        $this->assertEquals($original->getCacheCreationTokens(), $restored->getCacheCreationTokens());
+    }
+
+    /**
+     * Tests JSON schema includes cache token properties but not in required.
+     *
+     * @return void
+     */
+    public function testJsonSchemaIncludesCacheTokens(): void
+    {
+        $schema = TokenUsage::getJsonSchema();
+
+        $this->assertArrayHasKey(TokenUsage::KEY_CACHED_TOKENS, $schema['properties']);
+        $this->assertEquals('integer', $schema['properties'][TokenUsage::KEY_CACHED_TOKENS]['type']);
+        $this->assertArrayHasKey('description', $schema['properties'][TokenUsage::KEY_CACHED_TOKENS]);
+        $this->assertNotContains(TokenUsage::KEY_CACHED_TOKENS, $schema['required']);
+
+        $this->assertArrayHasKey(TokenUsage::KEY_CACHE_CREATION_TOKENS, $schema['properties']);
+        $this->assertEquals('integer', $schema['properties'][TokenUsage::KEY_CACHE_CREATION_TOKENS]['type']);
+        $this->assertArrayHasKey('description', $schema['properties'][TokenUsage::KEY_CACHE_CREATION_TOKENS]);
+        $this->assertNotContains(TokenUsage::KEY_CACHE_CREATION_TOKENS, $schema['required']);
+    }
 }


### PR DESCRIPTION
### Summary

Adds nullable `cachedTokens` and `cacheCreationTokens` fields to the `TokenUsage` DTO and parses them in `AbstractOpenAiCompatibleTextGenerationModel`, so prompt-cache usage reported by OpenAI-compatible providers is no longer discarded.

OpenAI returns `usage.prompt_tokens_details.cached_tokens` (and, more recently, `cache_write_tokens`) on every text-generation response for cache-eligible models, but the base class previously read only the three top-level `usage` fields and then stripped `usage` from `additionalData`, making cache hit rate unobservable to callers. Prompt caching is a major cost lever (50-75% input discount on hit), and without this data downstream applications cannot measure whether their prompt structure is actually cache-friendly.

### What changed

- `src/Results/DTO/TokenUsage.php`: new nullable `cachedTokens` and `cacheCreationTokens` properties following the existing `thoughtTokens` pattern (constants, optional constructor params, getters, JSON schema entries, conditional `toArray()` emission, `fromArray()` support). Semantics are documented in the class docblock: cached tokens are a subset of prompt tokens, not additive.
- `src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php`: the usage parser now reads `prompt_tokens_details.cached_tokens` into `cachedTokens` and `prompt_tokens_details.cache_write_tokens` into `cacheCreationTokens`. The `UsageData` PHPStan shape is extended accordingly. Field names were verified against the current OpenAI API spec.
- Both fields stay `null` when a provider does not supply them, so "not reported" is distinguishable from a real `0`.

### Backward compatibility

- The new constructor parameters are optional with `null` defaults, so every existing `new TokenUsage(...)` call site behaves identically.
- `toArray()` emits the new keys only when non-null, so serialized output is unchanged for existing consumers, and the JSON schema `required` list is untouched.
- The naming is provider-agnostic and also fits Anthropic's `cache_read_input_tokens` / `cache_creation_input_tokens` for when a first-class Anthropic implementation surfaces them.
- The fields are nullable from the start, consistent with the direction proposed in #158.

### Testing

- 10 new unit tests: DTO construction and getters, `toArray()`/`fromArray()` round trips (including key omission when unset), JSON schema coverage, and parser tests with `prompt_tokens_details` present and absent.
- `composer lint` (PHPCS including PHPCompatibility 7.4- and PHPStan) and `composer test:unit` pass (1110 tests).
- Verified end to end with a minimal OpenAI-compatible provider pointed at a mocked `chat/completions` endpoint: both values surface through `PromptBuilder -> generateTextResult() -> getTokenUsage()`, and both return `null` when the provider omits the details object.

### Issue

Fixes #236

Note: the `wordpress/openai-ai-provider` package (now on the Responses API) has a parallel gap in its own parser, where `input_tokens_details.cached_tokens` is dropped. Happy to file a follow-up issue in that repo.
