### PR TITLE
Prepare 1.4.0 release

### DIFF
--- a/src/AiClient.php
+++ b/src/AiClient.php
@@ -90,7 +90,7 @@ class AiClient
     /**
      * @var string The version of the AI Client.
      */
-    public const VERSION = '1.3.1';
+    public const VERSION = '1.4.0';
 
     /**
      * @var ProviderRegistry|null The default provider registry instance.
@@ -250,7 +250,7 @@ class AiClient
      * embedding generation method such as generateEmbedding() or generateEmbeddings() to produce
      * one vector per input.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param EmbeddingInput|list<EmbeddingInput>|null $input Optional initial input(s) to embed.
      * @param ProviderRegistry|null $registry Optional custom registry. If null, uses default.
@@ -415,7 +415,7 @@ class AiClient
     /**
      * Generates embeddings using the traditional API approach.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param EmbeddingInput|list<EmbeddingInput> $input The input(s) to embed.
      * @param ModelInterface|ModelConfig|null $modelOrConfig Optional specific model to use,
@@ -440,7 +440,7 @@ class AiClient
     /**
      * Generates an embedding using the traditional API approach.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param EmbeddingInput $input The input to embed.
      * @param ModelInterface|ModelConfig|null $modelOrConfig Optional specific model to use,
@@ -460,7 +460,7 @@ class AiClient
     /**
      * Generates embeddings for a list of inputs using the traditional API approach.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param list<EmbeddingInput> $inputs The inputs to embed.
      * @param ModelInterface|ModelConfig|null $modelOrConfig Optional specific model to use,

--- a/src/Builders/EmbeddingBuilder.php
+++ b/src/Builders/EmbeddingBuilder.php
@@ -29,7 +29,7 @@ use WordPress\AiClient\Results\DTO\EmbeddingResult;
  * input. Model selection and configuration are shared with {@see PromptBuilder} via the
  * {@see ModelResolutionTrait}.
  *
- * @since n.e.x.t
+ * @since 1.4.0
  *
  * @phpstan-import-type MessagePartArrayShape from MessagePart
  *
@@ -52,7 +52,7 @@ class EmbeddingBuilder
     /**
      * Constructor.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param ProviderRegistry $registry The provider registry for finding suitable models.
      * @param EmbeddingInput|list<EmbeddingInput>|null $input Optional initial input(s) to embed.
@@ -87,7 +87,7 @@ class EmbeddingBuilder
      * Clones the inputs and model configuration. Service objects (registry, event dispatcher) are
      * intentionally NOT cloned as they are shared dependencies.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      */
     public function __clone()
     {
@@ -107,7 +107,7 @@ class EmbeddingBuilder
     /**
      * Adds one or more inputs to embed.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param EmbeddingInput ...$input The inputs to embed, each treated as an independent input.
      * @return self
@@ -129,7 +129,7 @@ class EmbeddingBuilder
     /**
      * Sets the embedding dimensions.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param int $dimensions The embedding dimensions.
      * @return self
@@ -143,7 +143,7 @@ class EmbeddingBuilder
     /**
      * Checks whether the current inputs and configuration are supported by an available model.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return bool True if a suitable embedding model is available.
      */
@@ -157,7 +157,7 @@ class EmbeddingBuilder
     /**
      * Generates an embedding result from the configured inputs.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return EmbeddingResult The generated embedding result.
      * @throws InvalidArgumentException If no inputs are configured or model validation fails.
@@ -208,7 +208,7 @@ class EmbeddingBuilder
     /**
      * Generates a single embedding from the configured input.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return Embedding The generated embedding vector.
      * @throws InvalidArgumentException If no inputs are configured, model validation fails, or
@@ -228,7 +228,7 @@ class EmbeddingBuilder
     /**
      * Generates embeddings from the configured inputs.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return list<Embedding> The generated embedding vectors.
      * @throws InvalidArgumentException If no inputs are configured or model validation fails.
@@ -243,7 +243,7 @@ class EmbeddingBuilder
     /**
      * Parses a single input into a message part.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param mixed $input The input to parse. Accepts a string, MessagePart, File, or
      *                     MessagePartArrayShape.
@@ -279,7 +279,7 @@ class EmbeddingBuilder
     /**
      * Validates that a message part is a valid embedding input.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param MessagePart $part The part to validate.
      * @return MessagePart The validated part.
@@ -298,7 +298,7 @@ class EmbeddingBuilder
     /**
      * Dispatches an event if an event dispatcher is registered.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param object $event The event to dispatch.
      * @return void

--- a/src/Builders/Traits/ModelResolutionTrait.php
+++ b/src/Builders/Traits/ModelResolutionTrait.php
@@ -18,7 +18,7 @@ use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
  * fluent API for choosing a model, provider, preferences, request options, and model configuration.
  * Model selection state and logic live on the {@see ModelResolver} owned by the builder.
  *
- * @since n.e.x.t
+ * @since 1.4.0
  */
 trait ModelResolutionTrait
 {

--- a/src/Events/AfterGenerateEmbeddingEvent.php
+++ b/src/Events/AfterGenerateEmbeddingEvent.php
@@ -12,7 +12,7 @@ use WordPress\AiClient\Results\DTO\EmbeddingResult;
 /**
  * Event dispatched after embeddings have been generated.
  *
- * @since n.e.x.t
+ * @since 1.4.0
  */
 class AfterGenerateEmbeddingEvent
 {
@@ -39,7 +39,7 @@ class AfterGenerateEmbeddingEvent
     /**
      * Constructor.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param list<MessagePart> $inputs The inputs that were sent to the model.
      * @param ModelInterface    $model The model that generated embeddings.
@@ -61,7 +61,7 @@ class AfterGenerateEmbeddingEvent
     /**
      * Gets the inputs that were sent to the model.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return list<MessagePart> The inputs.
      */
@@ -73,7 +73,7 @@ class AfterGenerateEmbeddingEvent
     /**
      * Gets the model that generated embeddings.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return ModelInterface The model.
      */
@@ -85,7 +85,7 @@ class AfterGenerateEmbeddingEvent
     /**
      * Gets the capability that was used for generation.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return CapabilityEnum The capability.
      */
@@ -97,7 +97,7 @@ class AfterGenerateEmbeddingEvent
     /**
      * Gets the result from the model.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return EmbeddingResult The result.
      */
@@ -109,7 +109,7 @@ class AfterGenerateEmbeddingEvent
     /**
      * Performs a deep clone of the event.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      */
     public function __clone()
     {

--- a/src/Events/BeforeGenerateEmbeddingEvent.php
+++ b/src/Events/BeforeGenerateEmbeddingEvent.php
@@ -11,7 +11,7 @@ use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 /**
  * Event dispatched before inputs are sent to an embedding generation model.
  *
- * @since n.e.x.t
+ * @since 1.4.0
  */
 class BeforeGenerateEmbeddingEvent
 {
@@ -33,7 +33,7 @@ class BeforeGenerateEmbeddingEvent
     /**
      * Constructor.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param list<MessagePart> $inputs The inputs to be sent to the model.
      * @param ModelInterface    $model The model that will generate embeddings.
@@ -49,7 +49,7 @@ class BeforeGenerateEmbeddingEvent
     /**
      * Gets the inputs to be sent to the model.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return list<MessagePart> The inputs.
      */
@@ -61,7 +61,7 @@ class BeforeGenerateEmbeddingEvent
     /**
      * Gets the model that will generate embeddings.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return ModelInterface The model.
      */
@@ -73,7 +73,7 @@ class BeforeGenerateEmbeddingEvent
     /**
      * Gets the capability being used for generation.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return CapabilityEnum The capability.
      */
@@ -85,7 +85,7 @@ class BeforeGenerateEmbeddingEvent
     /**
      * Performs a deep clone of the event.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      */
     public function __clone()
     {

--- a/src/Messages/Util/ModalityCombinationsUtil.php
+++ b/src/Messages/Util/ModalityCombinationsUtil.php
@@ -9,7 +9,7 @@ use WordPress\AiClient\Messages\Enums\ModalityEnum;
 /**
  * Utility class for building modality combinations.
  *
- * @since n.e.x.t
+ * @since 1.4.0
  */
 class ModalityCombinationsUtil
 {
@@ -22,7 +22,7 @@ class ModalityCombinationsUtil
      * complete combination. Modality lists are unordered, so only unique
      * combinations (not permutations) are produced.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param list<ModalityEnum> $required Required modalities included in every combination.
      * @param list<ModalityEnum> $optional Optional modalities to generate subsets from.

--- a/src/Providers/ModelResolver.php
+++ b/src/Providers/ModelResolver.php
@@ -20,7 +20,7 @@ use WordPress\AiClient\Providers\Models\DTO\ModelRequirements;
  * is shared between the builders (via the model resolution trait) so that model
  * selection behaves identically regardless of what is being generated.
  *
- * @since n.e.x.t
+ * @since 1.4.0
  */
 class ModelResolver
 {
@@ -52,7 +52,7 @@ class ModelResolver
     /**
      * Constructor.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param ProviderRegistry $registry The provider registry for finding suitable models.
      */
@@ -68,7 +68,7 @@ class ModelResolver
      * explicitly set model are service objects and are intentionally NOT cloned, as
      * they should be shared references.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      */
     public function __clone()
     {
@@ -80,7 +80,7 @@ class ModelResolver
     /**
      * Sets the model to use for generation.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param ModelInterface $model The model to use.
      * @return void
@@ -93,7 +93,7 @@ class ModelResolver
     /**
      * Gets the explicitly set model, if any.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return ModelInterface|null The explicitly set model, or null if none was set.
      */
@@ -105,7 +105,7 @@ class ModelResolver
     /**
      * Sets preferred models to evaluate in order.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param string|ModelInterface|array{0:string,1:string} ...$preferredModels The preferred models as model IDs,
      * model instances, or [provider ID, model ID] tuples. For broader compatibility, it is recommended you specify
@@ -169,7 +169,7 @@ class ModelResolver
     /**
      * Sets the provider to use for generation.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param string $providerIdOrClassName The provider ID or class name.
      * @return void
@@ -182,7 +182,7 @@ class ModelResolver
     /**
      * Sets the request options for HTTP transport.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param RequestOptions $requestOptions The request options.
      * @return void
@@ -199,7 +199,7 @@ class ModelResolver
      * and returns it. Otherwise, finds a suitable model based on the requirements,
      * honoring any configured model preferences and provider constraint.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param ModelRequirements $requirements The requirements the model must satisfy.
      * @param ModelConfig $modelConfig The model configuration to apply.
@@ -304,7 +304,7 @@ class ModelResolver
     /**
      * Checks whether any model can satisfy the given requirements.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param ModelRequirements $requirements The requirements to check support for.
      * @return bool True if the set model or any registered model meets the requirements.
@@ -331,7 +331,7 @@ class ModelResolver
      *
      * Request options are only applicable to API-based models that make HTTP requests.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param ModelInterface $model The model to bind request options to.
      * @return void
@@ -346,7 +346,7 @@ class ModelResolver
     /**
      * Builds a map of candidate models that satisfy the requirements for efficient lookup.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param ModelRequirements $requirements The requirements derived from the prompt.
      * @return array<string, array{0:string,1:string}> Map of preference keys to [providerId, modelId] tuples.
@@ -384,7 +384,7 @@ class ModelResolver
     /**
      * Generates a candidate map from model metadata with both provider-specific and model-only keys.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param string $providerId The provider ID.
      * @param list<ModelMetadata> $modelsMetadata The models metadata to map.
@@ -412,7 +412,7 @@ class ModelResolver
     /**
      * Normalizes and validates a preference identifier string.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param mixed $value The value to normalize.
      * @param string $emptyMessage The message for empty or invalid values.
@@ -439,7 +439,7 @@ class ModelResolver
     /**
      * Creates a preference key for a provider/model combination.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param string $providerId The provider identifier.
      * @param string $modelId The model identifier.
@@ -453,7 +453,7 @@ class ModelResolver
     /**
      * Creates a preference key for a model identifier.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param string $modelId The model identifier.
      * @return string The generated preference key.

--- a/src/Providers/Models/DTO/ModelConfig.php
+++ b/src/Providers/Models/DTO/ModelConfig.php
@@ -781,7 +781,7 @@ class ModelConfig extends AbstractDataTransferObject
     /**
      * Sets the embedding dimensions.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param int $dimensions The embedding dimensions.
      */
@@ -797,7 +797,7 @@ class ModelConfig extends AbstractDataTransferObject
     /**
      * Gets the embedding dimensions.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return int|null The embedding dimensions.
      */

--- a/src/Providers/Models/DTO/ModelRequirements.php
+++ b/src/Providers/Models/DTO/ModelRequirements.php
@@ -207,7 +207,7 @@ class ModelRequirements extends AbstractDataTransferObject
      * conversation, so no chat history capability is inferred. Each input contributes its input
      * modality (text or file) to the requirements.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param list<MessagePart> $inputs The embedding inputs.
      * @param ModelConfig $modelConfig The model configuration.
@@ -246,7 +246,7 @@ class ModelRequirements extends AbstractDataTransferObject
     /**
      * Determines the input modality contributed by a message part, if any.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param MessagePart $part The message part to analyze.
      * @return ModalityEnum|null The input modality, or null if the part contributes none.

--- a/src/Providers/Models/EmbeddingGeneration/Contracts/EmbeddingGenerationModelInterface.php
+++ b/src/Providers/Models/EmbeddingGeneration/Contracts/EmbeddingGenerationModelInterface.php
@@ -10,14 +10,14 @@ use WordPress\AiClient\Results\DTO\EmbeddingResult;
 /**
  * Interface for models that support embedding generation.
  *
- * @since n.e.x.t
+ * @since 1.4.0
  */
 interface EmbeddingGenerationModelInterface
 {
     /**
      * Generates embeddings from one or more inputs.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param list<MessagePart> $inputs The inputs to embed, one embedding generated per input.
      * @return EmbeddingResult Result containing one embedding per input, in input order.

--- a/src/Results/DTO/Embedding.php
+++ b/src/Results/DTO/Embedding.php
@@ -14,7 +14,7 @@ use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 /**
  * Represents a single generated embedding vector.
  *
- * @since n.e.x.t
+ * @since 1.4.0
  *
  * @phpstan-type EmbeddingList list<float|int>
  *
@@ -35,7 +35,7 @@ final class Embedding implements Countable, IteratorAggregate, JsonSerializable
     /**
      * Constructor.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param EmbeddingList $values The embedding vector values.
      * @param int $dimensions The vector dimension count.
@@ -65,7 +65,7 @@ final class Embedding implements Countable, IteratorAggregate, JsonSerializable
     /**
      * Checks whether the value is a list of integers or floats.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param mixed $values The value to check.
      * @return bool True if the value is an embedding list.
@@ -90,7 +90,7 @@ final class Embedding implements Countable, IteratorAggregate, JsonSerializable
     /**
      * Gets the vector values.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return EmbeddingList The embedding vector values.
      */
@@ -102,7 +102,7 @@ final class Embedding implements Countable, IteratorAggregate, JsonSerializable
     /**
      * Gets the vector dimension count.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return int The vector dimension count.
      */
@@ -114,7 +114,7 @@ final class Embedding implements Countable, IteratorAggregate, JsonSerializable
     /**
      * Gets the number of vector values.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return int The number of vector values.
      */
@@ -126,7 +126,7 @@ final class Embedding implements Countable, IteratorAggregate, JsonSerializable
     /**
      * Gets an iterator for the vector values.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return Traversable<int, float|int> The vector value iterator.
      */
@@ -138,7 +138,7 @@ final class Embedding implements Countable, IteratorAggregate, JsonSerializable
     /**
      * Gets the JSON schema for embedding vectors.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return array<string, mixed> The JSON schema.
      */
@@ -156,7 +156,7 @@ final class Embedding implements Countable, IteratorAggregate, JsonSerializable
     /**
      * Converts the embedding to an array.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return EmbeddingList The embedding vector values.
      */
@@ -168,7 +168,7 @@ final class Embedding implements Countable, IteratorAggregate, JsonSerializable
     /**
      * Creates an embedding from an array.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param EmbeddingList $array The embedding vector values.
      * @param int $dimensions The vector dimension count.
@@ -182,7 +182,7 @@ final class Embedding implements Countable, IteratorAggregate, JsonSerializable
     /**
      * Converts the embedding to a JSON-serializable value.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return EmbeddingList The embedding vector values.
      */

--- a/src/Results/DTO/EmbeddingResult.php
+++ b/src/Results/DTO/EmbeddingResult.php
@@ -13,7 +13,7 @@ use WordPress\AiClient\Results\Contracts\ResultInterface;
 /**
  * Represents the result of an embedding generation operation.
  *
- * @since n.e.x.t
+ * @since 1.4.0
  *
  * @phpstan-import-type TokenUsageArrayShape from TokenUsage
  * @phpstan-import-type ProviderMetadataArrayShape from ProviderMetadata
@@ -80,7 +80,7 @@ class EmbeddingResult extends AbstractDataTransferObject implements ResultInterf
     /**
      * Constructor.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param string $id Unique identifier for this result.
      * @param list<Embedding|EmbeddingList> $embeddings The generated embedding vectors.
@@ -130,7 +130,7 @@ class EmbeddingResult extends AbstractDataTransferObject implements ResultInterf
     /**
      * {@inheritDoc}
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      */
     public function getId(): string
     {
@@ -140,7 +140,7 @@ class EmbeddingResult extends AbstractDataTransferObject implements ResultInterf
     /**
      * Gets the generated embedding vectors.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return list<Embedding> The embeddings.
      */
@@ -152,7 +152,7 @@ class EmbeddingResult extends AbstractDataTransferObject implements ResultInterf
     /**
      * Gets the first generated embedding vector.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return Embedding The first embedding.
      */
@@ -164,7 +164,7 @@ class EmbeddingResult extends AbstractDataTransferObject implements ResultInterf
     /**
      * Gets the vector dimension count.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return int The vector dimension count.
      */
@@ -176,7 +176,7 @@ class EmbeddingResult extends AbstractDataTransferObject implements ResultInterf
     /**
      * {@inheritDoc}
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      */
     public function getTokenUsage(): TokenUsage
     {
@@ -186,7 +186,7 @@ class EmbeddingResult extends AbstractDataTransferObject implements ResultInterf
     /**
      * {@inheritDoc}
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      */
     public function getProviderMetadata(): ProviderMetadata
     {
@@ -196,7 +196,7 @@ class EmbeddingResult extends AbstractDataTransferObject implements ResultInterf
     /**
      * {@inheritDoc}
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      */
     public function getModelMetadata(): ModelMetadata
     {
@@ -206,7 +206,7 @@ class EmbeddingResult extends AbstractDataTransferObject implements ResultInterf
     /**
      * {@inheritDoc}
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      */
     public function getAdditionalData(): array
     {
@@ -216,7 +216,7 @@ class EmbeddingResult extends AbstractDataTransferObject implements ResultInterf
     /**
      * Gets the JSON schema for embedding results.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return array<string, mixed> The JSON schema.
      */
@@ -262,7 +262,7 @@ class EmbeddingResult extends AbstractDataTransferObject implements ResultInterf
     /**
      * Converts the embedding result to an array.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @return EmbeddingResultArrayShape The embedding result array.
      */
@@ -290,7 +290,7 @@ class EmbeddingResult extends AbstractDataTransferObject implements ResultInterf
     /**
      * Creates an embedding result from an array.
      *
-     * @since n.e.x.t
+     * @since 1.4.0
      *
      * @param EmbeddingResultArrayShape $array The embedding result array.
      * @return self The embedding result instance.


### PR DESCRIPTION
Replaces `@since n.e.x.t` tags with `@since 1.4.0` and bumps the `AiClient::VERSION` constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)