### PR TITLE
Reject non-finite values in embedding vectors

### DIFF
--- a/src/Results/DTO/Embedding.php
+++ b/src/Results/DTO/Embedding.php
@@ -54,6 +54,12 @@ final class Embedding implements Countable, IteratorAggregate, JsonSerializable
             throw new InvalidArgumentException('Embedding values must be integers or floats.');
         }
 
+        foreach ($values as $value) {
+            if (is_float($value) && !is_finite($value)) {
+                throw new InvalidArgumentException('Embedding values must be finite numbers.');
+            }
+        }
+
         if (count($values) !== $dimensions) {
             throw new InvalidArgumentException('Embedding vector length must match dimensions.');
         }

--- a/tests/unit/Results/DTO/EmbeddingTest.php
+++ b/tests/unit/Results/DTO/EmbeddingTest.php
@@ -73,4 +73,27 @@ class EmbeddingTest extends TestCase
 
         new Embedding([0.1, '0.2'], 2);
     }
+
+    /**
+     * @dataProvider nonFiniteValueProvider
+     */
+    public function testValuesMustBeFinite(float $value): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Embedding values must be finite numbers.');
+
+        new Embedding([0.1, $value], 2);
+    }
+
+    /**
+     * @return array<string, array{float}>
+     */
+    public static function nonFiniteValueProvider(): array
+    {
+        return [
+            'NAN'  => [NAN],
+            'INF'  => [INF],
+            '-INF' => [-INF],
+        ];
+    }
 }


### PR DESCRIPTION
## Summary

- Reject `NAN`, `INF`, and `-INF` at the `Embedding` constructor boundary.
- Preserve the existing behavior for finite floats and integers.
- Add regression coverage for each non-finite value.

Fixes #262.

## Why

Non-finite values satisfy PHP's `is_float()` check but cannot be represented in JSON. Rejecting them when constructing an `Embedding` prevents an invalid result object from failing later during serialization, logging, caching, persistence, or custom provider handling.

## Testing

A test-only commit first demonstrated the gap: all three new cases failed because no `InvalidArgumentException` was thrown.

After the implementation commit:

- Unit tests pass on PHP 7.4, 8.0, 8.4, and 8.5.
- The PHP 8.4 coverage job passes.
- Composer validation, PHPStan, and PHPCS pass.

## AI assistance

- **AI assistance:** Yes
- **Tool:** OpenAI Codex
- **Used for:** Repository inspection, regression-test design, implementation, and verification. Henry reviewed the scope and remains responsible for the contribution.