### PR TITLE
Add model context window metadata and proactive token-limit check

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -365,6 +365,7 @@ direction LR
             +usingRequestOptions(RequestOptions $requestOptions) self
             +usingSystemInstruction(string $systemInstruction) self
             +usingMaxTokens(int $maxTokens) self
+            +usingTokenCounter(TokenCounterInterface $tokenCounter) self
             +usingTemperature(float $temperature) self
             +usingTopP(float $topP) self
             +usingTopK(int $topK) self
@@ -556,6 +557,7 @@ direction LR
             +usingProvider(string $providerIdOrClassName) self
             +usingSystemInstruction(string $systemInstruction) self
             +usingMaxTokens(int $maxTokens) self
+            +usingTokenCounter(TokenCounterInterface $tokenCounter) self
             +usingTemperature(float $temperature) self
             +usingTopP(float $topP) self
             +usingTopK(int $topK) self
@@ -1103,6 +1105,7 @@ direction LR
             +getName() string
             +getSupportedCapabilities() CapabilityEnum[]
             +getSupportedOptions() SupportedOption[]
+            +getContextWindow() ?int
             +getJsonSchema() array< string, mixed >$
         }
         class ModelRequirements {

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -5,6 +5,7 @@ This glossary defines common terms relevant for the PHP AI Client and related pr
 * **Agent**: An autonomous system that can perceive its environment, make decisions, and take actions to achieve specific goals, often leveraging AI models.
 * **Candidate Count**: The number of different response options an LLM generates internally.
 * **Capability**: A specific skill, function, or type of task that an AI model can perform, e.g. text generation or image generation.
+* **Context Window**: The total number of tokens (input plus output) a _Model_ can process in a single request. Exposed as model metadata (`ModelMetadata::getContextWindow()`) and used for an advisory pre-flight check. Distinct from the _Max Tokens_ option, which caps only the generated output.
 * **Extender API**: The API used by developers that want to enable the use of additional _Providers_ or _Models_.
 * **Generative AI**: Overarching term describing AI models that generate content as requested in a prompt.
 * **Implementer API**: The API used by people that want to _implement_ AI features in their own software/products.

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -8,6 +8,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use WordPress\AiClient\Builders\Traits\ModelResolutionTrait;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Common\Exception\RuntimeException;
+use WordPress\AiClient\Common\Exception\TokenLimitReachedException;
 use WordPress\AiClient\Events\AfterGenerateResultEvent;
 use WordPress\AiClient\Events\BeforeGenerateResultEvent;
 use WordPress\AiClient\Files\DTO\File;
@@ -27,6 +28,8 @@ use WordPress\AiClient\Providers\Models\ImageGeneration\Contracts\ImageGeneratio
 use WordPress\AiClient\Providers\Models\SpeechGeneration\Contracts\SpeechGenerationModelInterface;
 use WordPress\AiClient\Providers\Models\TextGeneration\Contracts\TextGenerationModelInterface;
 use WordPress\AiClient\Providers\Models\TextToSpeechConversion\Contracts\TextToSpeechConversionModelInterface;
+use WordPress\AiClient\Providers\Models\Tokenization\Contracts\TokenCounterInterface;
+use WordPress\AiClient\Providers\Models\Tokenization\HeuristicTokenCounter;
 use WordPress\AiClient\Providers\Models\VideoGeneration\Contracts\VideoGenerationModelInterface;
 use WordPress\AiClient\Providers\ProviderRegistry;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
@@ -61,6 +64,11 @@ class PromptBuilder
      * @var EventDispatcherInterface|null The event dispatcher for prompt lifecycle events.
      */
     private ?EventDispatcherInterface $eventDispatcher = null;
+
+    /**
+     * @var TokenCounterInterface|null Optional token counter used for the pre-flight context-window check.
+     */
+    private ?TokenCounterInterface $tokenCounter = null;
 
     // phpcs:disable Generic.Files.LineLength.TooLong
     /**
@@ -244,6 +252,27 @@ class PromptBuilder
     public function usingMaxTokens(int $maxTokens): self
     {
         $this->modelConfig->setMaxTokens($maxTokens);
+        return $this;
+    }
+
+    /**
+     * Sets the token counter used for the pre-flight context-window check.
+     *
+     * By default the builder uses a rough, provider-agnostic estimate
+     * ({@see HeuristicTokenCounter}). Provide a custom counter here to supply accurate,
+     * model-specific counts (for example one backed by a real tokenizer or a server-side
+     * tokenize endpoint). This only affects the proactive check performed before a request is
+     * sent, which runs when the resolved model exposes a context window via
+     * {@see \WordPress\AiClient\Providers\Models\DTO\ModelMetadata::getContextWindow()}.
+     *
+     * @since n.e.x.t
+     *
+     * @param TokenCounterInterface $tokenCounter The token counter to use.
+     * @return self The builder instance, for method chaining.
+     */
+    public function usingTokenCounter(TokenCounterInterface $tokenCounter): self
+    {
+        $this->tokenCounter = $tokenCounter;
         return $this;
     }
 
@@ -745,6 +774,9 @@ class PromptBuilder
 
         $model = $this->getConfiguredModel($capability);
 
+        // Fail fast if the assembled prompt is estimated to exceed the model's context window.
+        $this->assertPromptFitsContextWindow($model);
+
         // Dispatch BeforeGenerateResultEvent
         $this->dispatchEvent(
             new BeforeGenerateResultEvent($this->messages, $model, $capability)
@@ -759,6 +791,62 @@ class PromptBuilder
         );
 
         return $result;
+    }
+
+    /**
+     * Asserts that the assembled prompt is estimated to fit within the model's context window.
+     *
+     * The check runs only when the resolved model exposes a context window via
+     * {@see \WordPress\AiClient\Providers\Models\DTO\ModelMetadata::getContextWindow()}. When it
+     * does, the builder estimates the input token count (message text plus any system instruction)
+     * using the configured token counter, adds the configured output cap
+     * ({@see ModelConfig::getMaxTokens()}) when one is set, and throws when the total exceeds the
+     * context window. The estimate is advisory: a passing check does not guarantee the provider
+     * will accept the request, and models that do not publish a context window are never checked.
+     *
+     * @since n.e.x.t
+     *
+     * @param ModelInterface $model The resolved model to check the prompt against.
+     * @throws TokenLimitReachedException If the estimated prompt size exceeds the context window.
+     */
+    private function assertPromptFitsContextWindow(ModelInterface $model): void
+    {
+        $contextWindow = $model->metadata()->getContextWindow();
+        if ($contextWindow === null) {
+            return;
+        }
+
+        $messages = $this->messages;
+
+        $systemInstruction = $this->modelConfig->getSystemInstruction();
+        if ($systemInstruction !== null && $systemInstruction !== '') {
+            array_unshift($messages, new UserMessage([new MessagePart($systemInstruction)]));
+        }
+
+        $tokenCounter = $this->tokenCounter ?? new HeuristicTokenCounter();
+        $estimatedInputTokens = $tokenCounter->countTokens($messages, $model->metadata());
+
+        $reservedOutputTokens = $this->modelConfig->getMaxTokens() ?? 0;
+        $estimatedTotalTokens = $estimatedInputTokens + $reservedOutputTokens;
+
+        if ($estimatedTotalTokens <= $contextWindow) {
+            return;
+        }
+
+        throw new TokenLimitReachedException(
+            sprintf(
+                'The prompt is estimated at %d tokens%s, which exceeds the context window of %d '
+                . 'tokens for model "%s". Reduce the prompt size, or provide an accurate token '
+                . 'counter via usingTokenCounter() if this estimate is inaccurate.',
+                $estimatedInputTokens,
+                $reservedOutputTokens > 0
+                    ? sprintf(' plus %d reserved for output', $reservedOutputTokens)
+                    : '',
+                $contextWindow,
+                $model->metadata()->getId()
+            ),
+            $contextWindow
+        );
     }
 
     /**

--- a/src/Common/Exception/TokenLimitReachedException.php
+++ b/src/Common/Exception/TokenLimitReachedException.php
@@ -7,9 +7,18 @@ namespace WordPress\AiClient\Common\Exception;
 /**
  * Exception thrown when a token limit is reached during prompt fulfillment.
  *
- * Providers should throw this exception when the token usage for a request
- * exceeds the allowed limit, whether that is the model's context window
- * or a configured maximum.
+ * This exception is thrown when the token usage for a request exceeds the allowed limit, whether
+ * that is the model's context window or a configured maximum. It covers two cases:
+ *
+ * - Proactively (input side): {@see \WordPress\AiClient\Builders\PromptBuilder} throws it before a
+ *   request is sent when the estimated prompt size exceeds the resolved model's context window
+ *   (see {@see \WordPress\AiClient\Providers\Models\DTO\ModelMetadata::getContextWindow()}). This is
+ *   distinct from the per-request output cap configured via
+ *   {@see \WordPress\AiClient\Providers\Models\DTO\ModelConfig::setMaxTokens()}.
+ * - Reactively (output side): providers may throw it when a response indicates generation was
+ *   truncated because the token limit was reached.
+ *
+ * The associated limit, when known, is available via {@see self::getMaxTokens()}.
  *
  * @since 1.0.0
  */

--- a/src/Providers/Models/DTO/ModelMetadata.php
+++ b/src/Providers/Models/DTO/ModelMetadata.php
@@ -22,7 +22,8 @@ use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
  *     id: string,
  *     name: string,
  *     supportedCapabilities: list<string>,
- *     supportedOptions: list<SupportedOptionArrayShape>
+ *     supportedOptions: list<SupportedOptionArrayShape>,
+ *     contextWindow?: int
  * }
  *
  * @extends AbstractDataTransferObject<ModelMetadataArrayShape>
@@ -33,6 +34,7 @@ class ModelMetadata extends AbstractDataTransferObject
     public const KEY_NAME = 'name';
     public const KEY_SUPPORTED_CAPABILITIES = 'supportedCapabilities';
     public const KEY_SUPPORTED_OPTIONS = 'supportedOptions';
+    public const KEY_CONTEXT_WINDOW = 'contextWindow';
 
     /**
      * @var string The model's unique identifier.
@@ -54,6 +56,11 @@ class ModelMetadata extends AbstractDataTransferObject
      */
     protected array $supportedOptions;
 
+    /**
+     * @var int|null The model's context window, in tokens, or null if unknown.
+     */
+    protected ?int $contextWindow;
+
 
     /**
      * Constructor.
@@ -64,11 +71,20 @@ class ModelMetadata extends AbstractDataTransferObject
      * @param string $name The model's display name.
      * @param list<CapabilityEnum> $supportedCapabilities The model's supported capabilities.
      * @param list<SupportedOption> $supportedOptions The model's supported configuration options.
+     * @param int|null $contextWindow The model's context window, in tokens, or null if unknown. This is the
+     *                                total number of tokens (input plus output) the model can process for a
+     *                                single request, distinct from the per-request output cap configured via
+     *                                {@see \WordPress\AiClient\Providers\Models\DTO\ModelConfig::setMaxTokens()}.
      *
-     * @throws InvalidArgumentException If arrays are not lists.
+     * @throws InvalidArgumentException If arrays are not lists, or if the context window is not positive.
      */
-    public function __construct(string $id, string $name, array $supportedCapabilities, array $supportedOptions)
-    {
+    public function __construct(
+        string $id,
+        string $name,
+        array $supportedCapabilities,
+        array $supportedOptions,
+        ?int $contextWindow = null
+    ) {
         if (!array_is_list($supportedCapabilities)) {
             throw new InvalidArgumentException('Supported capabilities must be a list array.');
         }
@@ -77,10 +93,15 @@ class ModelMetadata extends AbstractDataTransferObject
             throw new InvalidArgumentException('Supported options must be a list array.');
         }
 
+        if ($contextWindow !== null && $contextWindow < 1) {
+            throw new InvalidArgumentException('Context window must be a positive integer.');
+        }
+
         $this->id = $id;
         $this->name = $name;
         $this->supportedCapabilities = $supportedCapabilities;
         $this->supportedOptions = $supportedOptions;
+        $this->contextWindow = $contextWindow;
     }
 
     /**
@@ -132,6 +153,24 @@ class ModelMetadata extends AbstractDataTransferObject
     }
 
     /**
+     * Gets the model's context window, in tokens.
+     *
+     * The context window is the total number of tokens (input plus output) the model can process
+     * for a single request. It is distinct from the per-request output cap configured via
+     * {@see \WordPress\AiClient\Providers\Models\DTO\ModelConfig::setMaxTokens()}, which limits only
+     * the number of tokens the model may generate. Providers that do not publish a fixed context
+     * window (for example self-hosted, user-configurable servers) return null.
+     *
+     * @since n.e.x.t
+     *
+     * @return int|null The context window in tokens, or null if unknown.
+     */
+    public function getContextWindow(): ?int
+    {
+        return $this->contextWindow;
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @since 0.1.0
@@ -162,6 +201,11 @@ class ModelMetadata extends AbstractDataTransferObject
                     'items' => SupportedOption::getJsonSchema(),
                     'description' => 'The model\'s supported configuration options.',
                 ],
+                self::KEY_CONTEXT_WINDOW => [
+                    'type' => 'integer',
+                    'minimum' => 1,
+                    'description' => 'The model\'s context window, in tokens (total input plus output).',
+                ],
             ],
             'required' => [self::KEY_ID, self::KEY_NAME, self::KEY_SUPPORTED_CAPABILITIES, self::KEY_SUPPORTED_OPTIONS],
         ];
@@ -176,7 +220,7 @@ class ModelMetadata extends AbstractDataTransferObject
      */
     public function toArray(): array
     {
-        return [
+        $data = [
             self::KEY_ID => $this->id,
             self::KEY_NAME => $this->name,
             self::KEY_SUPPORTED_CAPABILITIES => array_map(
@@ -188,6 +232,12 @@ class ModelMetadata extends AbstractDataTransferObject
                 $this->supportedOptions
             ),
         ];
+
+        if ($this->contextWindow !== null) {
+            $data[self::KEY_CONTEXT_WINDOW] = $this->contextWindow;
+        }
+
+        return $data;
     }
 
     /**
@@ -214,7 +264,8 @@ class ModelMetadata extends AbstractDataTransferObject
             array_map(
                 static fn(array $optionData): SupportedOption => SupportedOption::fromArray($optionData),
                 $array[self::KEY_SUPPORTED_OPTIONS]
-            )
+            ),
+            $array[self::KEY_CONTEXT_WINDOW] ?? null
         );
     }
 

--- a/src/Providers/Models/Tokenization/Contracts/TokenCounterInterface.php
+++ b/src/Providers/Models/Tokenization/Contracts/TokenCounterInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Providers\Models\Tokenization\Contracts;
+
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+
+/**
+ * Contract for estimating the number of tokens a set of messages will consume.
+ *
+ * Token counting is model specific: every provider tokenizes text differently, and an accurate
+ * count generally requires that provider's own tokenizer. The SDK ships a rough, dependency-free
+ * default (see {@see \WordPress\AiClient\Providers\Models\Tokenization\HeuristicTokenCounter}); a
+ * consumer that has access to an accurate tokenizer (for example a self-hosted server's tokenize
+ * endpoint, or a bundled tokenizer library) may implement this interface and supply it via
+ * {@see \WordPress\AiClient\Builders\PromptBuilder::usingTokenCounter()}.
+ *
+ * @since n.e.x.t
+ */
+interface TokenCounterInterface
+{
+    /**
+     * Estimates the number of tokens the given messages will consume for the given model.
+     *
+     * @since n.e.x.t
+     *
+     * @param list<Message> $messages The messages to estimate a token count for.
+     * @param ModelMetadata $modelMetadata The metadata of the model the messages are intended for.
+     * @return int The estimated number of tokens. Never negative.
+     */
+    public function countTokens(array $messages, ModelMetadata $modelMetadata): int;
+}

--- a/src/Providers/Models/Tokenization/HeuristicTokenCounter.php
+++ b/src/Providers/Models/Tokenization/HeuristicTokenCounter.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Providers\Models\Tokenization;
+
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\Tokenization\Contracts\TokenCounterInterface;
+
+/**
+ * Rough, provider-agnostic token counter used as the SDK default.
+ *
+ * This counter approximates token usage by dividing the total number of characters in the text
+ * parts of the messages by a fixed characters-per-token ratio. It is intentionally simple and
+ * dependency free, and it is NOT accurate: real tokenizers vary by model, language, and content
+ * (code, non-English text, and markup all tokenize differently). It is meant only to catch grossly
+ * oversized prompts as a best-effort safeguard. For accurate counts, provide a custom
+ * {@see TokenCounterInterface} implementation via
+ * {@see \WordPress\AiClient\Builders\PromptBuilder::usingTokenCounter()}.
+ *
+ * Non-text parts (files, function calls, and function responses) are not counted.
+ *
+ * @since n.e.x.t
+ */
+final class HeuristicTokenCounter implements TokenCounterInterface
+{
+    /**
+     * Approximate number of characters per token for English-like text.
+     *
+     * @since n.e.x.t
+     *
+     * @var int
+     */
+    private const CHARACTERS_PER_TOKEN = 4;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     *
+     * @param list<Message> $messages The messages to estimate a token count for.
+     * @param ModelMetadata $modelMetadata The metadata of the model the messages are intended for.
+     * @return int The estimated number of tokens. Never negative.
+     */
+    public function countTokens(array $messages, ModelMetadata $modelMetadata): int
+    {
+        $characters = 0;
+
+        foreach ($messages as $message) {
+            foreach ($message->getParts() as $part) {
+                if (!$part->getType()->isText()) {
+                    continue;
+                }
+
+                $text = $part->getText();
+                if ($text === null) {
+                    continue;
+                }
+
+                $characters += strlen($text);
+            }
+        }
+
+        if ($characters === 0) {
+            return 0;
+        }
+
+        return (int) ceil($characters / self::CHARACTERS_PER_TOKEN);
+    }
+}

--- a/tests/unit/Builders/PromptBuilderTest.php
+++ b/tests/unit/Builders/PromptBuilderTest.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use WordPress\AiClient\Builders\PromptBuilder;
+use WordPress\AiClient\Common\Exception\TokenLimitReachedException;
 use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Files\Enums\FileTypeEnum;
 use WordPress\AiClient\Files\Enums\MediaOrientationEnum;
@@ -30,6 +31,7 @@ use WordPress\AiClient\Providers\Models\Enums\OptionEnum;
 use WordPress\AiClient\Providers\Models\SpeechGeneration\Contracts\SpeechGenerationModelInterface;
 use WordPress\AiClient\Providers\Models\TextGeneration\Contracts\TextGenerationModelInterface;
 use WordPress\AiClient\Providers\Models\TextToSpeechConversion\Contracts\TextToSpeechConversionModelInterface;
+use WordPress\AiClient\Providers\Models\Tokenization\Contracts\TokenCounterInterface;
 use WordPress\AiClient\Providers\Models\VideoGeneration\Contracts\VideoGenerationModelInterface;
 use WordPress\AiClient\Providers\ProviderRegistry;
 use WordPress\AiClient\Results\DTO\Candidate;
@@ -4158,5 +4160,135 @@ class PromptBuilderTest extends TestCase
         $config = $configProperty->getValue($builder);
 
         $this->assertEquals(['STOP', 'END'], $config->getStopSequences());
+    }
+
+    /**
+     * Tests that usingTokenCounter is fluent.
+     *
+     * @return void
+     */
+    public function testUsingTokenCounterIsFluent(): void
+    {
+        $builder = new PromptBuilder($this->registry);
+
+        $result = $builder->usingTokenCounter($this->createFixedTokenCounter(1));
+
+        $this->assertSame($builder, $result);
+    }
+
+    /**
+     * Tests that generation throws when the estimated prompt exceeds the context window.
+     *
+     * @return void
+     */
+    public function testGenerateThrowsWhenPromptExceedsContextWindow(): void
+    {
+        $metadata = new ModelMetadata('tiny', 'Tiny', [CapabilityEnum::textGeneration()], [], 1);
+        $model = $this->createMockTextGenerationModel($this->createTestResult(), $metadata);
+
+        $builder = new PromptBuilder($this->registry, str_repeat('word ', 200));
+        $builder->usingModel($model);
+
+        try {
+            $builder->generateTextResult();
+            $this->fail('Expected TokenLimitReachedException was not thrown.');
+        } catch (TokenLimitReachedException $exception) {
+            $this->assertSame(1, $exception->getMaxTokens());
+        }
+    }
+
+    /**
+     * Tests that generation proceeds when the estimated prompt fits the context window.
+     *
+     * @return void
+     */
+    public function testGenerateDoesNotThrowWhenPromptFitsContextWindow(): void
+    {
+        $result = $this->createTestResult('Fits');
+        $metadata = new ModelMetadata('roomy', 'Roomy', [CapabilityEnum::textGeneration()], [], 100000);
+        $model = $this->createMockTextGenerationModel($result, $metadata);
+
+        $builder = new PromptBuilder($this->registry, 'Short prompt');
+        $builder->usingModel($model);
+
+        $this->assertSame($result, $builder->generateTextResult());
+    }
+
+    /**
+     * Tests that no check is performed when the model does not expose a context window.
+     *
+     * @return void
+     */
+    public function testGenerateDoesNotCheckWhenContextWindowUnknown(): void
+    {
+        $result = $this->createTestResult('Unknown window');
+        $metadata = new ModelMetadata('unknown', 'Unknown', [CapabilityEnum::textGeneration()], []);
+        $model = $this->createMockTextGenerationModel($result, $metadata);
+
+        $builder = new PromptBuilder($this->registry, str_repeat('word ', 5000));
+        $builder->usingModel($model);
+
+        $this->assertSame($result, $builder->generateTextResult());
+    }
+
+    /**
+     * Tests that reserved output tokens are counted against the context window.
+     *
+     * @return void
+     */
+    public function testGenerateCountsReservedOutputTokens(): void
+    {
+        $metadata = new ModelMetadata('cap', 'Cap', [CapabilityEnum::textGeneration()], [], 100);
+        $model = $this->createMockTextGenerationModel($this->createTestResult(), $metadata);
+
+        // Small input on its own fits, but the reserved output cap pushes the total over the window.
+        $builder = new PromptBuilder($this->registry, 'Short prompt');
+        $builder->usingModel($model)->usingMaxTokens(500);
+
+        $this->expectException(TokenLimitReachedException::class);
+
+        $builder->generateTextResult();
+    }
+
+    /**
+     * Tests that an injected token counter overrides the default estimate.
+     *
+     * @return void
+     */
+    public function testUsingTokenCounterOverridesDefaultEstimate(): void
+    {
+        $metadata = new ModelMetadata('roomy', 'Roomy', [CapabilityEnum::textGeneration()], [], 50);
+        $model = $this->createMockTextGenerationModel($this->createTestResult(), $metadata);
+
+        // A tiny prompt that the default heuristic would pass, but the injected counter reports as huge.
+        $builder = new PromptBuilder($this->registry, 'Hi');
+        $builder->usingModel($model)->usingTokenCounter($this->createFixedTokenCounter(1000));
+
+        $this->expectException(TokenLimitReachedException::class);
+
+        $builder->generateTextResult();
+    }
+
+    /**
+     * Creates a token counter that always reports a fixed count.
+     *
+     * @param int $count The token count to report.
+     * @return TokenCounterInterface The fixed token counter.
+     */
+    private function createFixedTokenCounter(int $count): TokenCounterInterface
+    {
+        return new class ($count) implements TokenCounterInterface {
+            private int $count;
+
+            public function __construct(int $count)
+            {
+                $this->count = $count;
+            }
+
+            public function countTokens(array $messages, ModelMetadata $modelMetadata): int
+            {
+                return $this->count;
+            }
+        };
     }
 }

--- a/tests/unit/Providers/Models/DTO/ModelMetadataTest.php
+++ b/tests/unit/Providers/Models/DTO/ModelMetadataTest.php
@@ -484,4 +484,131 @@ class ModelMetadataTest extends TestCase
             $this->assertSame($cap, $clonedCaps[$index]);
         }
     }
+
+    /**
+     * Tests that the context window is stored when provided.
+     *
+     * @return void
+     */
+    public function testConstructorWithContextWindow(): void
+    {
+        $metadata = new ModelMetadata('m', 'M', [], [], 128000);
+
+        $this->assertSame(128000, $metadata->getContextWindow());
+    }
+
+    /**
+     * Tests that the context window defaults to null.
+     *
+     * @return void
+     */
+    public function testConstructorWithoutContextWindow(): void
+    {
+        $metadata = new ModelMetadata('m', 'M', [], []);
+
+        $this->assertNull($metadata->getContextWindow());
+    }
+
+    /**
+     * Tests that a non-positive context window is rejected.
+     *
+     * @return void
+     */
+    public function testConstructorThrowsOnNonPositiveContextWindow(): void
+    {
+        $this->expectException(\WordPress\AiClient\Common\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Context window must be a positive integer.');
+
+        new ModelMetadata('m', 'M', [], [], 0);
+    }
+
+    /**
+     * Tests that toArray includes the context window when set.
+     *
+     * @return void
+     */
+    public function testToArrayIncludesContextWindow(): void
+    {
+        $metadata = new ModelMetadata('m', 'M', [], [], 32000);
+
+        $array = $metadata->toArray();
+
+        $this->assertArrayHasKey(ModelMetadata::KEY_CONTEXT_WINDOW, $array);
+        $this->assertSame(32000, $array[ModelMetadata::KEY_CONTEXT_WINDOW]);
+    }
+
+    /**
+     * Tests that toArray omits the context window when not set.
+     *
+     * @return void
+     */
+    public function testToArrayExcludesContextWindow(): void
+    {
+        $metadata = new ModelMetadata('m', 'M', [], []);
+
+        $this->assertArrayNotHasKey(ModelMetadata::KEY_CONTEXT_WINDOW, $metadata->toArray());
+    }
+
+    /**
+     * Tests that fromArray reads the context window when present.
+     *
+     * @return void
+     */
+    public function testFromArrayWithContextWindow(): void
+    {
+        $metadata = ModelMetadata::fromArray([
+            ModelMetadata::KEY_ID => 'm',
+            ModelMetadata::KEY_NAME => 'M',
+            ModelMetadata::KEY_SUPPORTED_CAPABILITIES => [],
+            ModelMetadata::KEY_SUPPORTED_OPTIONS => [],
+            ModelMetadata::KEY_CONTEXT_WINDOW => 8192,
+        ]);
+
+        $this->assertSame(8192, $metadata->getContextWindow());
+    }
+
+    /**
+     * Tests that fromArray defaults the context window to null when absent.
+     *
+     * @return void
+     */
+    public function testFromArrayWithoutContextWindow(): void
+    {
+        $metadata = ModelMetadata::fromArray([
+            ModelMetadata::KEY_ID => 'm',
+            ModelMetadata::KEY_NAME => 'M',
+            ModelMetadata::KEY_SUPPORTED_CAPABILITIES => [],
+            ModelMetadata::KEY_SUPPORTED_OPTIONS => [],
+        ]);
+
+        $this->assertNull($metadata->getContextWindow());
+    }
+
+    /**
+     * Tests round-trip array transformation preserves the context window.
+     *
+     * @return void
+     */
+    public function testArrayRoundTripWithContextWindow(): void
+    {
+        $original = new ModelMetadata('m', 'M', [], [], 200000);
+
+        $restored = ModelMetadata::fromArray($original->toArray());
+
+        $this->assertSame(200000, $restored->getContextWindow());
+    }
+
+    /**
+     * Tests that the JSON schema exposes the context window as an optional property.
+     *
+     * @return void
+     */
+    public function testJsonSchemaIncludesContextWindow(): void
+    {
+        $schema = ModelMetadata::getJsonSchema();
+
+        $this->assertArrayHasKey(ModelMetadata::KEY_CONTEXT_WINDOW, $schema['properties']);
+        $this->assertSame('integer', $schema['properties'][ModelMetadata::KEY_CONTEXT_WINDOW]['type']);
+        $this->assertNotContains(ModelMetadata::KEY_CONTEXT_WINDOW, $schema['required']);
+    }
 }

--- a/tests/unit/Providers/Models/Tokenization/HeuristicTokenCounterTest.php
+++ b/tests/unit/Providers/Models/Tokenization/HeuristicTokenCounterTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Tests\unit\Providers\Models\Tokenization;
+
+use PHPUnit\Framework\TestCase;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\UserMessage;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\Tokenization\Contracts\TokenCounterInterface;
+use WordPress\AiClient\Providers\Models\Tokenization\HeuristicTokenCounter;
+
+/**
+ * @covers \WordPress\AiClient\Providers\Models\Tokenization\HeuristicTokenCounter
+ */
+class HeuristicTokenCounterTest extends TestCase
+{
+    /**
+     * @var HeuristicTokenCounter
+     */
+    private HeuristicTokenCounter $counter;
+
+    /**
+     * @var ModelMetadata
+     */
+    private ModelMetadata $metadata;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->counter = new HeuristicTokenCounter();
+        $this->metadata = new ModelMetadata('m', 'M', [], []);
+    }
+
+    /**
+     * Tests that the counter implements the shared contract.
+     *
+     * @return void
+     */
+    public function testImplementsTokenCounterInterface(): void
+    {
+        $this->assertInstanceOf(TokenCounterInterface::class, $this->counter);
+    }
+
+    /**
+     * Tests that an empty message list yields zero tokens.
+     *
+     * @return void
+     */
+    public function testCountTokensReturnsZeroForNoMessages(): void
+    {
+        $this->assertSame(0, $this->counter->countTokens([], $this->metadata));
+    }
+
+    /**
+     * Tests that text is estimated at roughly four characters per token, rounded up.
+     *
+     * @return void
+     */
+    public function testCountTokensRoundsUp(): void
+    {
+        // 4 characters -> 1 token.
+        $exact = new UserMessage([new MessagePart('abcd')]);
+        $this->assertSame(1, $this->counter->countTokens([$exact], $this->metadata));
+
+        // 5 characters -> ceil(5 / 4) = 2 tokens.
+        $overflow = new UserMessage([new MessagePart('abcde')]);
+        $this->assertSame(2, $this->counter->countTokens([$overflow], $this->metadata));
+    }
+
+    /**
+     * Tests that text across multiple parts and messages is summed.
+     *
+     * @return void
+     */
+    public function testCountTokensSumsAcrossPartsAndMessages(): void
+    {
+        $messages = [
+            new UserMessage([
+                new MessagePart('abcd'),
+                new MessagePart('efgh'),
+            ]),
+            new UserMessage([new MessagePart('ijkl')]),
+        ];
+
+        // 12 characters total -> 12 / 4 = 3 tokens.
+        $this->assertSame(3, $this->counter->countTokens($messages, $this->metadata));
+    }
+}


### PR DESCRIPTION
Closes - #260 
## Summary

Adds an **input-side** counterpart to the existing output-side `maxTokens` cap. Today the SDK has no concept of a model's context window, and `TokenLimitReachedException` is declared but never thrown. This PR lets callers (chat UIs, agents, plugins) discover a model's context window and be told — with a typed, catchable exception, *before* a request is sent — when an assembled prompt is estimated to be too large, instead of relying on an opaque provider-side HTTP error.

Implements the input-side of #260 (context-window metadata + proactive budgeting). The reactive/output-side (#193) is intentionally left as a follow-up; both can share the same `TokenLimitReachedException`.

## What changed

**Metadata**
- `ModelMetadata` gains an optional `contextWindow` (`?int`, total input + output tokens). Nullable, defaults to `null`, backward compatible: constructor param is trailing/optional, included in `toArray()`/schema only when set, read in `fromArray()` without becoming required. Rejected if `< 1`.

**Token counting (BYOB)**
- New `TokenCounterInterface` (`countTokens(list<Message>, ModelMetadata): int`).
- New default `HeuristicTokenCounter`: a rough, dependency-free `strlen / 4` estimate over text parts, documented as advisory. Non-text parts (files, tool calls/responses) are not counted.
- New `PromptBuilder::usingTokenCounter()` to inject an accurate, model-specific counter per request.

**Proactive check**
- `PromptBuilder::generateResult()` now estimates the prompt (message text + system instruction, plus the configured output `maxTokens` when set) and throws `TokenLimitReachedException` when the total exceeds the resolved model's `contextWindow`. **No-op when the context window is unknown**, so existing behavior is preserved until providers populate the field.

**Docs**
- Clarified `contextWindow` (input budget) vs `ModelConfig::maxTokens` (output cap) in docblocks, `docs/ARCHITECTURE.md`, and `docs/GLOSSARY.md`.

## Design notes / assumptions

- `contextWindow` is the **total** window (input + output), matching published specs — not input-only.
- The check is **always-on when a window is known, but advisory**: a heuristic can be wrong, so it can false-positive; `usingTokenCounter()` is the escape hatch, and the docblock states a passing check is not a guarantee.
- Override is **per-call only**; registry-level/provider propagation (the `HttpTransporter`-style parity) is deliberately out of scope here.
- No real per-model context-window numbers are shipped — those belong in the provider packages; core stays `null`.
- The check is not capability-gated (runs for any model exposing a window; only text is counted). Easy to restrict to text generation if preferred.

## Relationship to #193

#193 covers the reactive/output side (truncation via `finish_reason == length`). This PR is the proactive/input side. The exception and its docblock cover both cases so #193 can build on this; the `length` finish reason already flows through to `Candidate::getFinishReason()->isLength()`.

## Testing

- `composer lint` (PHPCS PSR-12/PER + Slevomat, and PHPStan level `max`): clean.
- `composer test:unit`: full suite passes, including new tests for the `contextWindow` field, `HeuristicTokenCounter`, and the `PromptBuilder` check (throws when over, no-op when the window is unknown, honors reserved output, honors an injected counter).

## AI usage disclosure

This PR was developed collaboratively with Claude, in a Claude Code session, under human direction and review.

- **Model used:** Claude Opus 4.8 (`claude-opus-4-8`), via Claude Code.
- **How it was used:**
  - Investigated the SDK to confirm the gap (`ModelMetadata`, `ModelConfig`, `TokenLimitReachedException`, `PromptBuilder`) and reviewed related issue #193.
  - Studied the repo's conventions (DTO patterns, the `HttpTransporter`-style override mechanism, exception/`finish_reason` handling, test structure, PHP 7.4 / PHPStan-max / PSR-12 constraints) before writing code.
  - Drafted the implementation, unit tests, and the doc updates (`ARCHITECTURE.md`, `GLOSSARY.md`), and wrote this PR description and the issue comment.
  - Ran `composer lint` (PHPCS + PHPStan level `max`) and `composer test:unit`, plus an offline demo script, to verify behavior.
- **Human involvement:** A human maintainer directed the scope, clarified the approach with the issue author, reviewed every change.
- **Caveats:**
  - Verification was done via unit tests and an offline demo; no live provider API calls were made.
  - No real per-model context-window values are included — those are left to the provider packages.
