### PR TITLE
GH#265: Preserve Guzzle HTTP error responses

### DIFF
--- a/src/Providers/Http/HttpTransporter.php
+++ b/src/Providers/Http/HttpTransporter.php
@@ -244,7 +244,9 @@ class HttpTransporter implements HttpTransporterInterface
      */
     private function buildGuzzleOptions(RequestOptions $options): array
     {
-        $guzzleOptions = [];
+        $guzzleOptions = [
+            'http_errors' => false,
+        ];
 
         $timeout = $options->getTimeout();
         if ($timeout !== null) {

--- a/tests/unit/Providers/Http/HttpTransporterTest.php
+++ b/tests/unit/Providers/Http/HttpTransporterTest.php
@@ -12,7 +12,10 @@ use WordPress\AiClient\Providers\Http\DTO\Request;
 use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
 use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
+use WordPress\AiClient\Providers\Http\Exception\ClientException;
+use WordPress\AiClient\Providers\Http\Exception\ServerException;
 use WordPress\AiClient\Providers\Http\HttpTransporter;
+use WordPress\AiClient\Providers\Http\Util\ResponseUtil;
 use WordPress\AiClient\Tests\mocks\GuzzleLikeClient;
 
 /**
@@ -251,9 +254,70 @@ class HttpTransporterTest extends TestCase
 
         $lastOptions = $guzzleClient->getLastOptions();
         $this->assertIsArray($lastOptions);
+        $this->assertFalse($lastOptions['http_errors']);
         $this->assertSame(5.0, $lastOptions['timeout']);
         $this->assertSame(1.0, $lastOptions['connect_timeout']);
         $this->assertSame(['max' => 3], $lastOptions['allow_redirects']);
+    }
+
+    /**
+     * Tests that Guzzle server error responses remain available for typed handling.
+     *
+     * @return void
+     */
+    public function testSendReturnsGuzzleServerErrorResponseForTypedHandling(): void
+    {
+        $guzzleClient = new GuzzleLikeClient(new Psr7Response(529));
+        $transporter = new HttpTransporter(
+            $guzzleClient,
+            $this->httpFactory,
+            $this->httpFactory
+        );
+
+        $response = $transporter->send(
+            new Request(HttpMethodEnum::GET(), 'https://api.example.com/overloaded'),
+            new RequestOptions()
+        );
+
+        $this->assertSame(529, $response->getStatusCode());
+
+        $lastOptions = $guzzleClient->getLastOptions();
+        $this->assertIsArray($lastOptions);
+        $this->assertFalse($lastOptions['http_errors']);
+
+        $this->expectException(ServerException::class);
+        $this->expectExceptionCode(529);
+        $this->expectExceptionMessage('Overloaded (529)');
+
+        ResponseUtil::throwIfNotSuccessful($response);
+    }
+
+    /**
+     * Tests that Guzzle client error responses avoid the generic transport exception path.
+     *
+     * @return void
+     */
+    public function testSendReturnsGuzzleClientErrorResponseForTypedHandling(): void
+    {
+        $guzzleClient = new GuzzleLikeClient(new Psr7Response(400));
+        $transporter = new HttpTransporter(
+            $guzzleClient,
+            $this->httpFactory,
+            $this->httpFactory
+        );
+
+        $response = $transporter->send(
+            new Request(HttpMethodEnum::GET(), 'https://api.example.com/bad-request'),
+            new RequestOptions()
+        );
+
+        $this->assertSame(400, $response->getStatusCode());
+
+        $this->expectException(ClientException::class);
+        $this->expectExceptionCode(400);
+        $this->expectExceptionMessage('Bad Request (400)');
+
+        ResponseUtil::throwIfNotSuccessful($response);
     }
 
     /**


### PR DESCRIPTION
## Summary

- preserve PSR-18-style response semantics when request options select the Guzzle-compatible `send()` path
- disable Guzzle status-code exceptions while retaining timeout and redirect option translation
- cover 529 and representative 4xx responses through the SDK's typed response handling

Resolves #265

## Testing

- `vendor/bin/phpunit tests/unit/Providers/Http/HttpTransporterTest.php` — 12 tests, 56 assertions
- `vendor/bin/phpunit tests/unit/Providers/Http/Util/ResponseUtilTest.php` — 9 tests, 18 assertions
- `composer test:unit` — 1,166 tests, 4,271 assertions
- `composer lint` — PHPCS 207 files; PHPStan 111 files, no errors
- `composer validate --strict`
- `composer check-platform-reqs`

## Runtime Testing

Self-assessed against the repository's Guzzle-shaped test client: the focused tests execute the options path and verify both 529-to-`ServerException` and 400-to-`ClientException` translation. The repository does not install `guzzlehttp/guzzle`; live provider integration tests were not run because they make billable API calls and do not exercise this option bridge.

## Decisions

The new option is scoped to `buildGuzzleOptions()`, so ordinary PSR-18 clients and `ClientWithOptionsInterface` implementations remain unchanged. No retries or dependency changes are introduced.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.191 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 33m and 118,309 tokens on this with the user in an interactive session. Overall, 4h 36m since this issue was created.
