### PR TITLE
Fix avoid file_exists() on oversized strings in File detection to prevent PHP warnings

### DIFF
--- a/src/Files/DTO/File.php
+++ b/src/Files/DTO/File.php
@@ -100,8 +100,10 @@ class File extends AbstractDataTransferObject
             return;
         }
 
-        // Check if it's a local file path (before base64 check)
-        if (file_exists($file) && is_file($file)) {
+        // Check if it's a local file path (before base64 check).
+        // The length guard avoids calling file_exists() on over-length strings (e.g. base64 data),
+        // which would emit a warning containing the entire string.
+        if (strlen($file) <= PHP_MAXPATHLEN && file_exists($file) && is_file($file)) {
             $this->fileType = FileTypeEnum::inline();
             $this->base64Data = $this->convertFileToBase64($file);
             $this->mimeType = $this->determineMimeType($providedMimeType, null, $file);

--- a/tests/unit/Files/DTO/FileTest.php
+++ b/tests/unit/Files/DTO/FileTest.php
@@ -112,6 +112,43 @@ class FileTest extends TestCase
     }
 
     /**
+     * Tests creating a File from base64 data longer than the maximum path length without a PHP warning.
+     *
+     * @return void
+     */
+    public function testCreateFromLargePlainBase64DoesNotEmitWarning(): void
+    {
+        // Base64-encoded JPEG data, longer than PHP_MAXPATHLEN and starting with the "/9j/" prefix.
+        $rawImage = "\xFF\xD8\xFF" . str_repeat("\x00", PHP_MAXPATHLEN);
+        $base64Data = base64_encode($rawImage);
+        $mimeType = 'image/jpeg';
+
+        $this->assertStringStartsWith('/9j/', $base64Data);
+        $this->assertGreaterThan(PHP_MAXPATHLEN, strlen($base64Data));
+
+        $capturedWarning = null;
+        set_error_handler(
+            static function (int $errno, string $errstr) use (&$capturedWarning): bool {
+                $capturedWarning = $errstr;
+
+                return true;
+            },
+            E_WARNING
+        );
+
+        try {
+            $file = new File($base64Data, $mimeType);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertNull($capturedWarning, 'Constructing a File from large base64 data must not emit a warning.');
+        $this->assertEquals(FileTypeEnum::inline(), $file->getFileType());
+        $this->assertEquals($base64Data, $file->getBase64Data());
+        $this->assertEquals($mimeType, $file->getMimeType());
+    }
+
+    /**
      * Tests that plain base64 without MIME type throws exception.
      *
      * @return void


### PR DESCRIPTION
Closes #258 
## Summary

`File::detectAndProcessFile()` calls `file_exists()` while determining whether an
input string is a local path, before the plain-base64 branch is reached. When the
input is a large base64 payload (e.g. an image returned by a provider via
`bytesBase64Encoded`), the string exceeds the platform's maximum path length and
PHP emits:

> `file_exists(): File name is longer than the maximum allowed path length on this platform (4096): /9j/4AAQSkZJRg...`

The warning message embeds the entire input string, so each occurrence writes
~1 MB to the error log. In practice this produced multi-megabyte error logs from
only a handful of image-generation calls. Base64-encoded JPEG data begins with
`/9j/`, which resembles an absolute path, so the string reaches `file_exists()`
before detection falls through to the base64 handling that processes it correctly.

Functionally the input was always handled correctly — this is a log-noise issue,
not a data-correctness one.

## Change

Guard the filesystem check with a length comparison:

```php
if (strlen($file) <= PHP_MAXPATHLEN && file_exists($file) && is_file($file)) {
```

### AI Disclosure

Claude Opus 4.8 was used for identification and then verification of correctness of the solution.