### PR TITLE
Return false from isSupported() when the output modality has no matching capability

### DIFF
--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -613,7 +613,12 @@ class PromptBuilder
 
             // If still no capability, infer from output modalities
             if ($capability === null) {
-                $capability = $this->inferCapabilityFromOutputModalities();
+                try {
+                    $capability = $this->inferCapabilityFromOutputModalities();
+                } catch (RuntimeException $e) {
+                    // The output modality maps to no capability, so no model can support it.
+                    return false;
+                }
             }
         }
 

--- a/tests/unit/Builders/PromptBuilderTest.php
+++ b/tests/unit/Builders/PromptBuilderTest.php
@@ -3865,6 +3865,19 @@ class PromptBuilderTest extends TestCase
     }
 
     /**
+     * Tests isSupported returns false for an output modality without a matching capability.
+     *
+     * @return void
+     */
+    public function testIsSupportedReturnsFalseForUnsupportedOutputModality(): void
+    {
+        $builder = new PromptBuilder($this->registry, 'Test prompt');
+        $builder->asOutputModalities(ModalityEnum::document());
+
+        $this->assertFalse($builder->isSupported());
+    }
+
+    /**
      * Tests isSupported method with inferred capability from model interfaces.
      *
      * @return void


### PR DESCRIPTION

Fixes #270

`isSupported()` is declared `: bool`, but the `RuntimeException` from `inferCapabilityFromOutputModalities()` propagates straight out of it when the configured output modality has no matching capability. `ModalityEnum::document()` is the reachable case, since `DOCUMENT` is a first class modality but `CapabilityEnum` has nothing to map it to.

This catches that one call and returns `false`. Asking whether an unsupported modality is supported has a correct answer, and it is no.

Two things kept deliberately narrow:

- `generateResult()` is untouched and still throws for the same modality. That is the right behaviour there, and `testGenerateResultThrowsExceptionForUnsupportedOutputModality()` asserts it.
- Only the inference call sits inside the `try`, so a `RuntimeException` raised anywhere else in `isSupported()` still propagates.

I also considered changing `inferCapabilityFromOutputModalities()` to return `?CapabilityEnum` and letting each caller decide, which reads a little cleaner, but it changes a shared private method used by the generation path as well. Happy to redo it that way if you would rather.

## Testing

`testIsSupportedReturnsFalseForUnsupportedOutputModality()` fails on trunk with:

```
WordPress\AiClient\Common\Exception\RuntimeException: Output modality "document" is not yet supported.

src/Builders/PromptBuilder.php:556
src/Builders/PromptBuilder.php:616
tests/unit/Builders/PromptBuilderTest.php:3877
```

and passes with the patch. Full unit suite green at 1165 tests, 4261 assertions. `phpcs` and `phpstan` both clean.

I did not add an `@since` line to the docblock since I do not know which version this would land in. Say the word and I will add it.

I checked the open PRs that touch nearby code and there is no overlap. #222 adds `isSupportedForSoundGeneration()`, which passes an explicit capability and never reaches the inference branch, and #254 changes `ModelResolver::isSupported()`, which is a different method.
