### PR TITLE
Add function call resolution loop and withMessages() to PromptBuilder

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -375,6 +375,7 @@ direction LR
             +withFunctionResponse(FunctionResponse $functionResponse) self
             +withMessageParts(...MessagePart $parts) self
             +withHistory(...Message $messages) self
+            +withMessages(...Message $messages) self
             +usingModel(ModelInterface $model) self
             +usingModelPreference(...$preferredModels) self
             +usingModelConfig(ModelConfig $config) self
@@ -388,6 +389,8 @@ direction LR
             +usingStopSequences(...string $stopSequences) self
             +usingCandidateCount(int $candidateCount) self
             +usingFunctionDeclarations(...FunctionDeclaration $functionDeclarations) self
+            +usingFunctionCallResolver(FunctionCallResolverInterface $functionCallResolver) self
+            +usingMaxFunctionCallIterations(int $maxIterations) self
             +usingPresencePenalty(float $presencePenalty) self
             +usingFrequencyPenalty(float $frequencyPenalty) self
             +usingWebSearch(WebSearch $webSearch) self
@@ -567,6 +570,7 @@ direction LR
             +withFunctionResponse(FunctionResponse $functionResponse) self
             +withMessageParts(...MessagePart $parts) self
             +withHistory(...Message $messages) self
+            +withMessages(...Message $messages) self
             +usingModel(ModelInterface $model) self
             +usingModelConfig(ModelConfig $config) self
             +usingProvider(string $providerIdOrClassName) self
@@ -578,6 +582,8 @@ direction LR
             +usingStopSequences(...string $stopSequences) self
             +usingCandidateCount(int $candidateCount) self
             +usingFunctionDeclarations(...FunctionDeclaration $functionDeclarations) self
+            +usingFunctionCallResolver(FunctionCallResolverInterface $functionCallResolver) self
+            +usingMaxFunctionCallIterations(int $maxIterations) self
             +usingPresencePenalty(float $presencePenalty) self
             +usingFrequencyPenalty(float $frequencyPenalty) self
             +usingWebSearch(WebSearch $webSearch) self

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -957,6 +957,11 @@ class PromptBuilder
                 break;
             }
 
+            if ($rounds >= $this->maxFunctionCallIterations) {
+                $stopReason = self::STOP_REASON_MAX_ITERATIONS;
+                break;
+            }
+
             /*
              * Check all calls before executing any, so that a round is either
              * fully executed or handed back to the caller untouched.
@@ -966,11 +971,6 @@ class PromptBuilder
                     $stopReason = self::STOP_REASON_UNRESOLVED_FUNCTION_CALLS;
                     break 2;
                 }
-            }
-
-            if ($rounds >= $this->maxFunctionCallIterations) {
-                $stopReason = self::STOP_REASON_MAX_ITERATIONS;
-                break;
             }
 
             $responseParts = [];

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -281,6 +281,11 @@ class PromptBuilder
      * appending a model response message and a follow-up user message when
      * building a manual function call resolution loop.
      *
+     * The last message must be a user message before generating, so a model
+     * message should always be followed by a user message. The last appended
+     * user message becomes the current message. Any parts added afterwards,
+     * for example with {@see self::withText()}, are added to that message.
+     *
      * @since n.e.x.t
      *
      * @param Message ...$messages The messages to append.
@@ -421,11 +426,16 @@ class PromptBuilder
      * the maximum number of rounds is reached.
      *
      * Resolution follows the first response candidate and only applies to text
-     * generation; other capabilities ignore the resolver. Token usage is
+     * generation. Other capabilities ignore the resolver. Token usage is
      * aggregated across all rounds. Details about the loop are exposed under
      * the {@see self::KEY_FUNCTION_CALL_RESOLUTION} key of the additional data
      * of the final result, including the number of rounds, the stop reason,
      * the resolved calls, and the full conversation.
+     *
+     * When the loop stops early, the final response usually contains function
+     * calls and no text. Use {@see self::generateTextResult()} to receive that
+     * response, since {@see self::generateText()} throws when the response has
+     * no text.
      *
      * The maximum number of rounds can be configured with
      * {@see self::usingMaxFunctionCallIterations()}.
@@ -962,7 +972,6 @@ class PromptBuilder
             $functionCalls = $this->getFunctionCalls($message);
 
             if (empty($functionCalls)) {
-                $stopReason = self::STOP_REASON_COMPLETED;
                 break;
             }
 
@@ -1008,8 +1017,7 @@ class PromptBuilder
             $tokenUsage = $this->aggregateTokenUsage($tokenUsage, $result->getTokenUsage());
         }
 
-        $transcript = $messages;
-        $transcript[] = $result->toMessage();
+        $messages[] = $result->toMessage();
 
         $additionalData = $result->getAdditionalData();
         $additionalData[self::KEY_FUNCTION_CALL_RESOLUTION] = [
@@ -1020,7 +1028,7 @@ class PromptBuilder
                 static function (Message $message): array {
                     return $message->toArray();
                 },
-                $transcript
+                $messages
             ),
         ];
 
@@ -1280,10 +1288,15 @@ class PromptBuilder
     /**
      * Generates text from the prompt.
      *
+     * When a function call resolver is set and the resolution loop stops
+     * early, the final response may contain no text. Use
+     * {@see self::generateTextResult()} to handle that case.
+     *
      * @since 0.1.0
      *
      * @return string The generated text.
      * @throws InvalidArgumentException If the prompt or model validation fails.
+     * @throws RuntimeException If the final response contains no text.
      */
     public function generateText(): string
     {
@@ -1292,6 +1305,11 @@ class PromptBuilder
 
     /**
      * Generates multiple text candidates from the prompt.
+     *
+     * When a function call resolver is set and the resolution loop stops
+     * early, the final response may contain no text, and candidates without
+     * text are skipped. Use {@see self::generateTextResult()} to handle that
+     * case.
      *
      * @since 0.1.0
      *

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -426,11 +426,22 @@ class PromptBuilder
      * the maximum number of rounds is reached.
      *
      * Resolution follows the first response candidate and only applies to text
-     * generation. Other capabilities ignore the resolver. Token usage is
-     * aggregated across all rounds. Details about the loop are exposed under
-     * the {@see self::KEY_FUNCTION_CALL_RESOLUTION} key of the additional data
-     * of the final result, including the number of rounds, the stop reason,
-     * the resolved calls, and the full conversation.
+     * generation. Other capabilities ignore the resolver. When more than one
+     * candidate is requested, the other candidates are not followed, and the
+     * final result only contains the candidates of the last round. Token usage
+     * is aggregated across all rounds. Details about the loop are exposed
+     * under the {@see self::KEY_FUNCTION_CALL_RESOLUTION} key of the
+     * additional data of the final result, including the number of rounds,
+     * the stop reason, the resolved calls, and the full conversation.
+     *
+     * Follow-up rounds send the full conversation, so the model must support
+     * chat history. This capability is added to the requirements when a model
+     * is discovered. An explicitly set model is used as is, like for every
+     * other requirement.
+     *
+     * Each round dispatches its own {@see BeforeGenerateResultEvent} and
+     * {@see AfterGenerateResultEvent} with the messages and result of that
+     * round. No event is dispatched for the final aggregated result.
      *
      * When the loop stops early, the final response usually contains function
      * calls and no text. Use {@see self::generateTextResult()} to receive that

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -1103,6 +1103,9 @@ class PromptBuilder
     /**
      * Adds up two token usage objects.
      *
+     * A missing thought token count counts as zero, since providers omit it
+     * when no thinking happened.
+     *
      * @since n.e.x.t
      *
      * @param TokenUsage $total The running total.

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -30,6 +30,9 @@ use WordPress\AiClient\Providers\Models\TextToSpeechConversion\Contracts\TextToS
 use WordPress\AiClient\Providers\Models\VideoGeneration\Contracts\VideoGenerationModelInterface;
 use WordPress\AiClient\Providers\ProviderRegistry;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\AiClient\Results\DTO\TokenUsage;
+use WordPress\AiClient\Tools\Contracts\FunctionCallResolverInterface;
+use WordPress\AiClient\Tools\DTO\FunctionCall;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 use WordPress\AiClient\Tools\DTO\FunctionResponse;
 use WordPress\AiClient\Tools\DTO\WebSearch;
@@ -53,9 +56,55 @@ class PromptBuilder
     use ModelResolutionTrait;
 
     /**
+     * Key in the result's additional data under which function call
+     * resolution details are exposed.
+     *
+     * @since n.e.x.t
+     */
+    public const KEY_FUNCTION_CALL_RESOLUTION = 'functionCallResolution';
+
+    /**
+     * Default maximum number of function call resolution rounds.
+     *
+     * @since n.e.x.t
+     */
+    public const DEFAULT_MAX_FUNCTION_CALL_ITERATIONS = 5;
+
+    /**
+     * Stop reason: the model produced a response without function calls.
+     *
+     * @since n.e.x.t
+     */
+    public const STOP_REASON_COMPLETED = 'completed';
+
+    /**
+     * Stop reason: the model requested a function call the resolver cannot resolve.
+     *
+     * @since n.e.x.t
+     */
+    public const STOP_REASON_UNRESOLVED_FUNCTION_CALLS = 'unresolvedFunctionCalls';
+
+    /**
+     * Stop reason: the maximum number of resolution rounds was reached.
+     *
+     * @since n.e.x.t
+     */
+    public const STOP_REASON_MAX_ITERATIONS = 'maxIterations';
+
+    /**
      * @var list<Message> The messages in the conversation.
      */
     protected array $messages = [];
+
+    /**
+     * @var FunctionCallResolverInterface|null The resolver for automatic function call resolution, if enabled.
+     */
+    private ?FunctionCallResolverInterface $functionCallResolver = null;
+
+    /**
+     * @var int The maximum number of function call resolution rounds.
+     */
+    private int $maxFunctionCallIterations = self::DEFAULT_MAX_FUNCTION_CALL_ITERATIONS;
 
     /**
      * @var EventDispatcherInterface|null The event dispatcher for prompt lifecycle events.
@@ -217,6 +266,27 @@ class PromptBuilder
     }
 
     /**
+     * Appends complete messages to the end of the conversation.
+     *
+     * Unlike {@see self::withHistory()}, which prepends messages before the
+     * current message, this method appends the given messages after all
+     * existing messages. This allows continuing a conversation, for example by
+     * appending a model response message and a follow-up user message when
+     * building a manual function call resolution loop.
+     *
+     * @since n.e.x.t
+     *
+     * @param Message ...$messages The messages to append.
+     * @return self
+     */
+    public function withMessages(Message ...$messages): self
+    {
+        $this->messages = array_merge($this->messages, $messages);
+
+        return $this;
+    }
+
+    /**
      * Sets the system instruction.
      *
      * System instructions are stored in the model configuration and guide
@@ -328,6 +398,63 @@ class PromptBuilder
     public function usingFunctionDeclarations(FunctionDeclaration ...$functionDeclarations): self
     {
         $this->modelConfig->setFunctionDeclarations($functionDeclarations);
+        return $this;
+    }
+
+    /**
+     * Enables automatic resolution of function calls during text generation.
+     *
+     * When a resolver is set, the text generation methods run a resolution
+     * loop instead of a single request. Each round executes the function calls
+     * requested by the model through the resolver, appends the results to the
+     * conversation, and requests a follow-up response. The loop ends when the
+     * model produces a response without function calls, when the resolver
+     * cannot resolve a requested call (the caller gets that response back to
+     * handle it), or when the maximum number of rounds is reached.
+     *
+     * Resolution follows the first response candidate and only applies to text
+     * generation; other capabilities ignore the resolver. Token usage is
+     * aggregated across all rounds. Details about the loop are exposed under
+     * the {@see self::KEY_FUNCTION_CALL_RESOLUTION} key of the additional data
+     * of the final result, including the number of rounds, the stop reason,
+     * the resolved calls, and the full conversation.
+     *
+     * The maximum number of rounds can be configured with
+     * {@see self::usingMaxFunctionCallIterations()}.
+     *
+     * @since n.e.x.t
+     *
+     * @param FunctionCallResolverInterface $functionCallResolver The resolver executing function calls.
+     * @return self
+     */
+    public function usingFunctionCallResolver(FunctionCallResolverInterface $functionCallResolver): self
+    {
+        $this->functionCallResolver = $functionCallResolver;
+        return $this;
+    }
+
+    /**
+     * Sets the maximum number of function call resolution rounds.
+     *
+     * Each round executes the function calls from one model response and
+     * requests a follow-up response. Only relevant when a resolver is set with
+     * {@see self::usingFunctionCallResolver()}. Default 5.
+     *
+     * @since n.e.x.t
+     *
+     * @param int $maxIterations The maximum number of resolution rounds.
+     * @return self
+     * @throws InvalidArgumentException If the maximum number of iterations is less than 1.
+     */
+    public function usingMaxFunctionCallIterations(int $maxIterations): self
+    {
+        if ($maxIterations < 1) {
+            throw new InvalidArgumentException(
+                'The maximum number of function call resolution iterations must be at least 1.'
+            );
+        }
+
+        $this->maxFunctionCallIterations = $maxIterations;
         return $this;
     }
 
@@ -745,20 +872,197 @@ class PromptBuilder
 
         $model = $this->getConfiguredModel($capability);
 
+        $result = $this->executeGenerationRound($model, $capability, $this->messages);
+
+        // Run the function call resolution loop if a resolver is configured.
+        if ($this->functionCallResolver !== null && $capability->isTextGeneration()) {
+            $result = $this->resolveFunctionCalls($model, $capability, $result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Executes a single generation round, dispatching lifecycle events.
+     *
+     * @since n.e.x.t
+     *
+     * @param ModelInterface $model The model to use for generation.
+     * @param CapabilityEnum $capability The capability to use.
+     * @param list<Message> $messages The messages to send.
+     * @return GenerativeAiResult The generated result.
+     * @throws RuntimeException If the model doesn't support the required capability.
+     */
+    private function executeGenerationRound(
+        ModelInterface $model,
+        CapabilityEnum $capability,
+        array $messages
+    ): GenerativeAiResult {
         // Dispatch BeforeGenerateResultEvent
         $this->dispatchEvent(
-            new BeforeGenerateResultEvent($this->messages, $model, $capability)
+            new BeforeGenerateResultEvent($messages, $model, $capability)
         );
 
         // Route to the appropriate generation method based on capability
-        $result = $this->executeModelGeneration($model, $capability, $this->messages);
+        $result = $this->executeModelGeneration($model, $capability, $messages);
 
         // Dispatch AfterGenerateResultEvent
         $this->dispatchEvent(
-            new AfterGenerateResultEvent($this->messages, $model, $capability, $result)
+            new AfterGenerateResultEvent($messages, $model, $capability, $result)
         );
 
         return $result;
+    }
+
+    /**
+     * Runs the function call resolution loop on a generated result.
+     *
+     * Each round executes the function calls requested by the model through
+     * the configured resolver, appends the model response and the function
+     * responses to a copy of the conversation, and requests a follow-up
+     * response. See {@see self::usingFunctionCallResolver()} for the
+     * termination conditions. The builder's own message list is not modified.
+     *
+     * The returned result carries the aggregated token usage of all rounds and
+     * exposes details about the loop under the
+     * {@see self::KEY_FUNCTION_CALL_RESOLUTION} key of its additional data.
+     *
+     * @since n.e.x.t
+     *
+     * @param ModelInterface $model The resolved model to use for follow-up rounds.
+     * @param CapabilityEnum $capability The capability in use.
+     * @param GenerativeAiResult $result The result of the initial request.
+     * @return GenerativeAiResult The final result.
+     */
+    private function resolveFunctionCalls(
+        ModelInterface $model,
+        CapabilityEnum $capability,
+        GenerativeAiResult $result
+    ): GenerativeAiResult {
+        /** @var FunctionCallResolverInterface $resolver */
+        $resolver = $this->functionCallResolver;
+
+        $messages = $this->messages;
+        $rounds = 0;
+        $tokenUsage = $result->getTokenUsage();
+        $resolvedCalls = [];
+        $stopReason = self::STOP_REASON_COMPLETED;
+
+        while (true) {
+            $message = $result->toMessage();
+            $functionCalls = $this->getFunctionCalls($message);
+
+            if (empty($functionCalls)) {
+                $stopReason = self::STOP_REASON_COMPLETED;
+                break;
+            }
+
+            /*
+             * Check all calls before executing any, so that a round is either
+             * fully executed or handed back to the caller untouched.
+             */
+            foreach ($functionCalls as $functionCall) {
+                if (!$resolver->canResolve($functionCall)) {
+                    $stopReason = self::STOP_REASON_UNRESOLVED_FUNCTION_CALLS;
+                    break 2;
+                }
+            }
+
+            if ($rounds >= $this->maxFunctionCallIterations) {
+                $stopReason = self::STOP_REASON_MAX_ITERATIONS;
+                break;
+            }
+
+            $responseParts = [];
+            foreach ($functionCalls as $functionCall) {
+                $functionResponse = $resolver->resolve($functionCall);
+                $responseParts[] = new MessagePart($functionResponse);
+                $resolvedCalls[] = [
+                    'id' => $functionCall->getId(),
+                    'name' => $functionCall->getName(),
+                ];
+            }
+
+            $messages[] = $message;
+            $messages[] = new UserMessage($responseParts);
+            $rounds++;
+
+            $result = $this->executeGenerationRound($model, $capability, $messages);
+            $tokenUsage = $this->aggregateTokenUsage($tokenUsage, $result->getTokenUsage());
+        }
+
+        $transcript = $messages;
+        $transcript[] = $result->toMessage();
+
+        $additionalData = $result->getAdditionalData();
+        $additionalData[self::KEY_FUNCTION_CALL_RESOLUTION] = [
+            'rounds' => $rounds,
+            'stopReason' => $stopReason,
+            'resolvedCalls' => $resolvedCalls,
+            'messages' => array_map(
+                static function (Message $message): array {
+                    return $message->toArray();
+                },
+                $transcript
+            ),
+        ];
+
+        return new GenerativeAiResult(
+            $result->getId(),
+            $result->getCandidates(),
+            $tokenUsage,
+            $result->getProviderMetadata(),
+            $result->getModelMetadata(),
+            $additionalData
+        );
+    }
+
+    /**
+     * Retrieves the function calls contained in a message.
+     *
+     * @since n.e.x.t
+     *
+     * @param Message $message The message to inspect.
+     * @return list<FunctionCall> The function calls in the message.
+     */
+    private function getFunctionCalls(Message $message): array
+    {
+        $functionCalls = [];
+
+        foreach ($message->getParts() as $part) {
+            if ($part->getType()->isFunctionCall()) {
+                $functionCall = $part->getFunctionCall();
+                if ($functionCall instanceof FunctionCall) {
+                    $functionCalls[] = $functionCall;
+                }
+            }
+        }
+
+        return $functionCalls;
+    }
+
+    /**
+     * Adds up two token usage objects.
+     *
+     * @since n.e.x.t
+     *
+     * @param TokenUsage $total The running total.
+     * @param TokenUsage $addition The usage to add.
+     * @return TokenUsage The combined token usage.
+     */
+    private function aggregateTokenUsage(TokenUsage $total, TokenUsage $addition): TokenUsage
+    {
+        $thoughtTokens = null;
+        if ($total->getThoughtTokens() !== null || $addition->getThoughtTokens() !== null) {
+            $thoughtTokens = (int) $total->getThoughtTokens() + (int) $addition->getThoughtTokens();
+        }
+
+        return new TokenUsage(
+            $total->getPromptTokens() + $addition->getPromptTokens(),
+            $total->getCompletionTokens() + $addition->getCompletionTokens(),
+            $total->getTotalTokens() + $addition->getTotalTokens(),
+            $thoughtTokens
+        );
     }
 
     /**

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -85,6 +85,13 @@ class PromptBuilder
     public const STOP_REASON_UNRESOLVED_FUNCTION_CALLS = 'unresolvedFunctionCalls';
 
     /**
+     * Stop reason: the model produced one or more incomplete function calls.
+     *
+     * @since n.e.x.t
+     */
+    public const STOP_REASON_INCOMPLETE_FUNCTION_CALLS = 'incompleteFunctionCalls';
+
+    /**
      * Stop reason: the maximum number of resolution rounds was reached.
      *
      * @since n.e.x.t
@@ -408,9 +415,10 @@ class PromptBuilder
      * loop instead of a single request. Each round executes the function calls
      * requested by the model through the resolver, appends the results to the
      * conversation, and requests a follow-up response. The loop ends when the
-     * model produces a response without function calls, when the resolver
-     * cannot resolve a requested call (the caller gets that response back to
-     * handle it), or when the maximum number of rounds is reached.
+     * model produces a response without function calls, when the model response
+     * contains incomplete function calls, when the resolver cannot resolve a
+     * requested call (the caller gets that response back to handle it), or when
+     * the maximum number of rounds is reached.
      *
      * Resolution follows the first response candidate and only applies to text
      * generation; other capabilities ignore the resolver. Token usage is
@@ -949,7 +957,8 @@ class PromptBuilder
         $stopReason = self::STOP_REASON_COMPLETED;
 
         while (true) {
-            $message = $result->toMessage();
+            $candidate = $result->getCandidates()[0];
+            $message = $candidate->getMessage();
             $functionCalls = $this->getFunctionCalls($message);
 
             if (empty($functionCalls)) {
@@ -959,6 +968,14 @@ class PromptBuilder
 
             if ($rounds >= $this->maxFunctionCallIterations) {
                 $stopReason = self::STOP_REASON_MAX_ITERATIONS;
+                break;
+            }
+
+            if (
+                !$candidate->getFinishReason()->isToolCalls() ||
+                !$this->areFunctionCallsComplete($functionCalls)
+            ) {
+                $stopReason = self::STOP_REASON_INCOMPLETE_FUNCTION_CALLS;
                 break;
             }
 
@@ -1039,6 +1056,29 @@ class PromptBuilder
         }
 
         return $functionCalls;
+    }
+
+    /**
+     * Checks whether all function calls contain the data required for execution.
+     *
+     * Function call IDs are provider-specific and therefore optional, but a
+     * non-empty function name is always required to safely resolve a call.
+     *
+     * @since n.e.x.t
+     *
+     * @param list<FunctionCall> $functionCalls The function calls to check.
+     * @return bool True if every function call is complete, false otherwise.
+     */
+    private function areFunctionCallsComplete(array $functionCalls): bool
+    {
+        foreach ($functionCalls as $functionCall) {
+            $name = $functionCall->getName();
+            if ($name === null || trim($name) === '') {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -745,7 +745,7 @@ class PromptBuilder
         }
 
         // Build requirements with the specified capability
-        $requirements = ModelRequirements::fromPromptData($capability, $this->messages, $this->modelConfig);
+        $requirements = $this->buildModelRequirements($capability);
 
         return $this->modelResolver->isSupported($requirements);
     }
@@ -1441,9 +1441,28 @@ class PromptBuilder
      */
     private function getConfiguredModel(CapabilityEnum $capability): ModelInterface
     {
-        $requirements = ModelRequirements::fromPromptData($capability, $this->messages, $this->modelConfig);
+        $requirements = $this->buildModelRequirements($capability);
 
         return $this->modelResolver->resolve($requirements, $this->modelConfig, 'prompt');
+    }
+
+    /**
+     * Builds the model requirements for the prompt's complete execution flow.
+     *
+     * @since n.e.x.t
+     *
+     * @param CapabilityEnum $capability The capability the model will be using.
+     * @return ModelRequirements The requirements for model selection.
+     */
+    private function buildModelRequirements(CapabilityEnum $capability): ModelRequirements
+    {
+        $requirements = ModelRequirements::fromPromptData($capability, $this->messages, $this->modelConfig);
+
+        if ($this->functionCallResolver !== null && $capability->isTextGeneration()) {
+            $requirements = $requirements->withRequiredCapability(CapabilityEnum::chatHistory());
+        }
+
+        return $requirements;
     }
 
     /**

--- a/src/Providers/Models/DTO/ModelRequirements.php
+++ b/src/Providers/Models/DTO/ModelRequirements.php
@@ -86,6 +86,28 @@ class ModelRequirements extends AbstractDataTransferObject
     }
 
     /**
+     * Returns requirements that also include the given capability.
+     *
+     * @since n.e.x.t
+     *
+     * @param CapabilityEnum $capability The capability to require.
+     * @return self The updated requirements.
+     */
+    public function withRequiredCapability(CapabilityEnum $capability): self
+    {
+        foreach ($this->requiredCapabilities as $requiredCapability) {
+            if ($requiredCapability->value === $capability->value) {
+                return $this;
+            }
+        }
+
+        $requiredCapabilities = $this->requiredCapabilities;
+        $requiredCapabilities[] = $capability;
+
+        return new self($requiredCapabilities, $this->requiredOptions);
+    }
+
+    /**
      * Gets the options that the model must support with specific values.
      *
      * @since 0.1.0

--- a/src/Providers/Models/DTO/ModelRequirements.php
+++ b/src/Providers/Models/DTO/ModelRequirements.php
@@ -96,7 +96,7 @@ class ModelRequirements extends AbstractDataTransferObject
     public function withRequiredCapability(CapabilityEnum $capability): self
     {
         foreach ($this->requiredCapabilities as $requiredCapability) {
-            if ($requiredCapability->value === $capability->value) {
+            if ($requiredCapability->equals($capability)) {
                 return $this;
             }
         }

--- a/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
+++ b/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
@@ -206,45 +206,60 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
      */
     protected function prepareMessagesParam(array $messages, ?string $systemInstruction = null): array
     {
-        $messagesParam = array_map(
-            function (Message $message): array {
-                // Special case: Function response.
-                $messageParts = $message->getParts();
-                if (count($messageParts) === 1 && $messageParts[0]->getType()->isFunctionResponse()) {
-                    $functionResponse = $messageParts[0]->getFunctionResponse();
+        $messagesParam = [];
+        foreach ($messages as $message) {
+            $messageParts = $message->getParts();
+            $functionResponseParts = array_values(array_filter(
+                $messageParts,
+                static function (MessagePart $part): bool {
+                    return $part->getType()->isFunctionResponse();
+                }
+            ));
+
+            if (!empty($functionResponseParts)) {
+                if (count($functionResponseParts) !== count($messageParts)) {
+                    throw new InvalidArgumentException(
+                        'Function responses cannot be combined with other message parts.'
+                    );
+                }
+
+                foreach ($functionResponseParts as $part) {
+                    $functionResponse = $part->getFunctionResponse();
                     if (!$functionResponse) {
                         // This should be impossible due to class internals, but still needs to be checked.
                         throw new RuntimeException(
                             'The function response typed message part must contain a function response.'
                         );
                     }
-                    return [
+
+                    $messagesParam[] = [
                         'role' => 'tool',
                         'content' => json_encode($functionResponse->getResponse()),
                         'tool_call_id' => $functionResponse->getId(),
                     ];
                 }
-                $messageData = [
-                    'role' => $this->getMessageRoleString($message->getRole()),
-                    'content' => array_values(array_filter(array_map(
-                        [$this, 'getMessagePartContentData'],
-                        $messageParts
-                    ))),
-                ];
+                continue;
+            }
 
-                // Only include tool_calls if there are any (OpenAI rejects empty arrays).
-                $toolCalls = array_values(array_filter(array_map(
-                    [$this, 'getMessagePartToolCallData'],
+            $messageData = [
+                'role' => $this->getMessageRoleString($message->getRole()),
+                'content' => array_values(array_filter(array_map(
+                    [$this, 'getMessagePartContentData'],
                     $messageParts
-                )));
-                if (!empty($toolCalls)) {
-                    $messageData['tool_calls'] = $toolCalls;
-                }
+                ))),
+            ];
 
-                return $messageData;
-            },
-            $messages
-        );
+            // Only include tool_calls if there are any (OpenAI rejects empty arrays).
+            $toolCalls = array_values(array_filter(array_map(
+                [$this, 'getMessagePartToolCallData'],
+                $messageParts
+            )));
+            if (!empty($toolCalls)) {
+                $messageData['tool_calls'] = $toolCalls;
+            }
+
+            $messagesParam[] = $messageData;
+        }
 
         if ($systemInstruction) {
             array_unshift(

--- a/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
+++ b/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
@@ -378,9 +378,9 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
             return null;
         }
         if ($type->isFunctionResponse()) {
-            // Special case: Function response.
+            // Special case: Function responses are handled in `prepareMessagesParam()`.
             throw new InvalidArgumentException(
-                'The API only allows a single function response, as the only content of the message.'
+                'Function responses cannot be combined with other message parts.'
             );
         }
         throw new InvalidArgumentException(

--- a/src/Tools/Contracts/FunctionCallResolverInterface.php
+++ b/src/Tools/Contracts/FunctionCallResolverInterface.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Tools\Contracts;
+
+use WordPress\AiClient\Tools\DTO\FunctionCall;
+use WordPress\AiClient\Tools\DTO\FunctionResponse;
+
+/**
+ * Interface for resolving function calls requested by a model.
+ *
+ * A function call resolver executes the function calls that a model requests
+ * during generation and returns the results as function responses. It enables
+ * the automatic function call resolution loop of the
+ * {@see \WordPress\AiClient\Builders\PromptBuilder}: each round the resolver
+ * executes the requested calls, and the responses are appended to the
+ * conversation for a follow-up request.
+ *
+ * Resolution is split into two steps so that a round is only executed when
+ * every requested call can be handled:
+ * - {@see self::canResolve()} checks whether a call can be handled. It must be
+ *   free of side effects, as it is invoked for every call in a round before
+ *   any call is executed.
+ * - {@see self::resolve()} executes a call and returns its response. Execution
+ *   errors should be returned as part of the function response, so the model
+ *   can process them, rather than thrown.
+ *
+ * @since n.e.x.t
+ */
+interface FunctionCallResolverInterface
+{
+    /**
+     * Checks whether the given function call can be resolved.
+     *
+     * This method must not have side effects. It is invoked for every function
+     * call in a model response before any of them is executed. If any call in
+     * a response cannot be resolved, none of them are executed and the
+     * resolution loop stops, handing the response back to the caller.
+     *
+     * @since n.e.x.t
+     *
+     * @param FunctionCall $functionCall The function call to check.
+     * @return bool True if the function call can be resolved.
+     */
+    public function canResolve(FunctionCall $functionCall): bool;
+
+    /**
+     * Resolves the given function call by executing it.
+     *
+     * Only called for function calls that {@see self::canResolve()} reported
+     * as resolvable. Execution errors should be encoded in the returned
+     * function response, so the model can react to them.
+     *
+     * @since n.e.x.t
+     *
+     * @param FunctionCall $functionCall The function call to resolve.
+     * @return FunctionResponse The response for the function call.
+     */
+    public function resolve(FunctionCall $functionCall): FunctionResponse;
+}

--- a/tests/mocks/MockFunctionCallResolver.php
+++ b/tests/mocks/MockFunctionCallResolver.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Tests\mocks;
+
+use WordPress\AiClient\Tools\Contracts\FunctionCallResolverInterface;
+use WordPress\AiClient\Tools\DTO\FunctionCall;
+use WordPress\AiClient\Tools\DTO\FunctionResponse;
+
+/**
+ * Mock function call resolver for testing.
+ *
+ * Records all checked and resolved calls. Behavior can be customized through
+ * optional callbacks; by default every call is resolvable and resolves to a
+ * simple success response.
+ */
+class MockFunctionCallResolver implements FunctionCallResolverInterface
+{
+    /**
+     * @var callable|null Callback deciding whether a call can be resolved.
+     */
+    private $canResolveCallback;
+
+    /**
+     * @var callable|null Callback producing the response for a call.
+     */
+    private $resolveCallback;
+
+    /**
+     * @var list<FunctionCall> The calls passed to canResolve().
+     */
+    public array $checkedCalls = [];
+
+    /**
+     * @var list<FunctionCall> The calls passed to resolve().
+     */
+    public array $resolvedCalls = [];
+
+    /**
+     * @param callable|null $canResolveCallback Optional callback receiving a FunctionCall and returning a bool.
+     * @param callable|null $resolveCallback Optional callback receiving a FunctionCall and returning a
+     *                                       FunctionResponse.
+     */
+    public function __construct(?callable $canResolveCallback = null, ?callable $resolveCallback = null)
+    {
+        $this->canResolveCallback = $canResolveCallback;
+        $this->resolveCallback = $resolveCallback;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function canResolve(FunctionCall $functionCall): bool
+    {
+        $this->checkedCalls[] = $functionCall;
+
+        if ($this->canResolveCallback !== null) {
+            return (bool) ($this->canResolveCallback)($functionCall);
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function resolve(FunctionCall $functionCall): FunctionResponse
+    {
+        $this->resolvedCalls[] = $functionCall;
+
+        if ($this->resolveCallback !== null) {
+            return ($this->resolveCallback)($functionCall);
+        }
+
+        return new FunctionResponse(
+            $functionCall->getId(),
+            $functionCall->getName(),
+            ['status' => 'ok']
+        );
+    }
+}

--- a/tests/traits/MockModelCreationTrait.php
+++ b/tests/traits/MockModelCreationTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace WordPress\AiClient\Tests\traits;
 
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\ModelMessage;
 use WordPress\AiClient\Messages\Enums\ModalityEnum;
@@ -55,11 +56,24 @@ trait MockModelCreationTrait
      */
     protected function createTestResult(string $content = 'Test response'): GenerativeAiResult
     {
-        $candidate = new Candidate(
-            new ModelMessage([new MessagePart($content)]),
-            FinishReasonEnum::stop()
-        );
-        $tokenUsage = new TokenUsage(10, 20, 30);
+        return $this->createTestResultWithMessage(new ModelMessage([new MessagePart($content)]));
+    }
+
+    /**
+     * Creates a test GenerativeAiResult with the given model message.
+     *
+     * @param Message $message The model message.
+     * @param TokenUsage|null $tokenUsage Optional token usage. Defaults to 10/20/30.
+     * @param FinishReasonEnum|null $finishReason Optional finish reason. Defaults to stop.
+     * @return GenerativeAiResult
+     */
+    protected function createTestResultWithMessage(
+        Message $message,
+        ?TokenUsage $tokenUsage = null,
+        ?FinishReasonEnum $finishReason = null
+    ): GenerativeAiResult {
+        $candidate = new Candidate($message, $finishReason ?? FinishReasonEnum::stop());
+        $tokenUsage = $tokenUsage ?? new TokenUsage(10, 20, 30);
 
         $providerMetadata = new ProviderMetadata(
             'mock',
@@ -213,60 +227,7 @@ trait MockModelCreationTrait
         GenerativeAiResult $result,
         ?ModelMetadata $metadata = null
     ): ModelInterface {
-        $metadata = $metadata ?? $this->createTestTextModelMetadata();
-
-        $providerMetadata = new ProviderMetadata(
-            'mock',
-            'Mock Provider',
-            ProviderTypeEnum::cloud()
-        );
-
-        return new class (
-            $metadata,
-            $providerMetadata,
-            $result
-        ) implements ModelInterface, TextGenerationModelInterface {
-            private ModelMetadata $metadata;
-            private ProviderMetadata $providerMetadata;
-            private GenerativeAiResult $result;
-            private ModelConfig $config;
-
-            public function __construct(
-                ModelMetadata $metadata,
-                ProviderMetadata $providerMetadata,
-                GenerativeAiResult $result
-            ) {
-                $this->metadata = $metadata;
-                $this->providerMetadata = $providerMetadata;
-                $this->result = $result;
-                $this->config = new ModelConfig();
-            }
-
-            public function metadata(): ModelMetadata
-            {
-                return $this->metadata;
-            }
-
-            public function providerMetadata(): ProviderMetadata
-            {
-                return $this->providerMetadata;
-            }
-
-            public function setConfig(ModelConfig $config): void
-            {
-                $this->config = $config;
-            }
-
-            public function getConfig(): ModelConfig
-            {
-                return $this->config;
-            }
-
-            public function generateTextResult(array $prompt): GenerativeAiResult
-            {
-                return $this->result;
-            }
-        };
+        return $this->createScriptedTextGenerationModel([$result], $metadata);
     }
 
     /**

--- a/tests/traits/MockModelCreationTrait.php
+++ b/tests/traits/MockModelCreationTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WordPress\AiClient\Tests\traits;
 
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\ModelMessage;
 use WordPress\AiClient\Messages\Enums\ModalityEnum;
@@ -264,6 +265,87 @@ trait MockModelCreationTrait
             public function generateTextResult(array $prompt): GenerativeAiResult
             {
                 return $this->result;
+            }
+        };
+    }
+
+    /**
+     * Creates a mock text generation model that returns scripted results in order.
+     *
+     * Each call to generateTextResult() returns the next result from the given
+     * list. Once the list is exhausted, the last result is returned again.
+     *
+     * @param list<GenerativeAiResult> $results The results to return, in order. Must not be empty.
+     * @param ModelMetadata|null $metadata Optional metadata (uses default if not provided).
+     * @return ModelInterface&TextGenerationModelInterface The mock model.
+     */
+    protected function createScriptedTextGenerationModel(
+        array $results,
+        ?ModelMetadata $metadata = null
+    ): ModelInterface {
+        if (empty($results)) {
+            throw new InvalidArgumentException('At least one scripted result must be provided.');
+        }
+
+        $metadata = $metadata ?? $this->createTestTextModelMetadata();
+
+        $providerMetadata = new ProviderMetadata(
+            'mock',
+            'Mock Provider',
+            ProviderTypeEnum::cloud()
+        );
+
+        return new class (
+            $metadata,
+            $providerMetadata,
+            $results
+        ) implements ModelInterface, TextGenerationModelInterface {
+            private ModelMetadata $metadata;
+            private ProviderMetadata $providerMetadata;
+            /** @var list<GenerativeAiResult> */
+            private array $results;
+            private int $callCount = 0;
+            private ModelConfig $config;
+
+            /**
+             * @param list<GenerativeAiResult> $results
+             */
+            public function __construct(
+                ModelMetadata $metadata,
+                ProviderMetadata $providerMetadata,
+                array $results
+            ) {
+                $this->metadata = $metadata;
+                $this->providerMetadata = $providerMetadata;
+                $this->results = $results;
+                $this->config = new ModelConfig();
+            }
+
+            public function metadata(): ModelMetadata
+            {
+                return $this->metadata;
+            }
+
+            public function providerMetadata(): ProviderMetadata
+            {
+                return $this->providerMetadata;
+            }
+
+            public function setConfig(ModelConfig $config): void
+            {
+                $this->config = $config;
+            }
+
+            public function getConfig(): ModelConfig
+            {
+                return $this->config;
+            }
+
+            public function generateTextResult(array $prompt): GenerativeAiResult
+            {
+                $index = min($this->callCount, count($this->results) - 1);
+                $this->callCount++;
+                return $this->results[$index];
             }
         };
     }

--- a/tests/unit/Builders/PromptBuilderFunctionCallResolutionTest.php
+++ b/tests/unit/Builders/PromptBuilderFunctionCallResolutionTest.php
@@ -8,24 +8,19 @@ use PHPUnit\Framework\TestCase;
 use WordPress\AiClient\Builders\PromptBuilder;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Events\BeforeGenerateResultEvent;
-use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\ModelMessage;
 use WordPress\AiClient\Messages\DTO\UserMessage;
-use WordPress\AiClient\Providers\DTO\ProviderMetadata;
-use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 use WordPress\AiClient\Providers\Models\DTO\SupportedOption;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 use WordPress\AiClient\Providers\Models\Enums\OptionEnum;
 use WordPress\AiClient\Providers\ProviderRegistry;
-use WordPress\AiClient\Results\DTO\Candidate;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
 use WordPress\AiClient\Results\DTO\TokenUsage;
 use WordPress\AiClient\Results\Enums\FinishReasonEnum;
 use WordPress\AiClient\Tests\mocks\MockEventDispatcher;
 use WordPress\AiClient\Tests\mocks\MockFunctionCallResolver;
-use WordPress\AiClient\Tests\mocks\MockProvider;
 use WordPress\AiClient\Tests\traits\MockModelCreationTrait;
 use WordPress\AiClient\Tools\DTO\FunctionCall;
 
@@ -55,8 +50,7 @@ class PromptBuilderFunctionCallResolutionTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->registry = new ProviderRegistry();
-        $this->registry->registerProvider(MockProvider::class);
+        $this->registry = $this->createRegistryWithMockProvider();
         $this->dispatcher = new MockEventDispatcher();
     }
 
@@ -73,32 +67,10 @@ class PromptBuilderFunctionCallResolutionTest extends TestCase
             $parts[] = new MessagePart($functionCall);
         }
 
-        return $this->createResultWithMessage(
+        return $this->createTestResultWithMessage(
             new ModelMessage($parts),
             null,
             FinishReasonEnum::toolCalls()
-        );
-    }
-
-    /**
-     * Creates a result with the given model message and token usage.
-     *
-     * @param Message $message The model message.
-     * @param TokenUsage|null $tokenUsage Optional token usage. Defaults to 10/20/30.
-     * @param FinishReasonEnum|null $finishReason Optional finish reason. Defaults to stop.
-     * @return GenerativeAiResult The result.
-     */
-    private function createResultWithMessage(
-        Message $message,
-        ?TokenUsage $tokenUsage = null,
-        ?FinishReasonEnum $finishReason = null
-    ): GenerativeAiResult {
-        return new GenerativeAiResult(
-            'test-result-id',
-            [new Candidate($message, $finishReason ?? FinishReasonEnum::stop())],
-            $tokenUsage ?? new TokenUsage(10, 20, 30),
-            new ProviderMetadata('mock', 'Mock Provider', ProviderTypeEnum::cloud()),
-            new ModelMetadata('mock-model', 'Mock Model', [], [])
         );
     }
 
@@ -255,7 +227,7 @@ class PromptBuilderFunctionCallResolutionTest extends TestCase
      */
     public function testDoesNotResolveFunctionCallsFromTruncatedResponse(): void
     {
-        $truncatedResult = $this->createResultWithMessage(
+        $truncatedResult = $this->createTestResultWithMessage(
             new ModelMessage([
                 new MessagePart(new FunctionCall('call-1', 'get_weather', ['city' => 'Ber']))
             ]),
@@ -379,12 +351,12 @@ class PromptBuilderFunctionCallResolutionTest extends TestCase
     public function testAggregatesTokenUsageAcrossRounds(): void
     {
         $model = $this->createScriptedTextGenerationModel([
-            $this->createResultWithMessage(
+            $this->createTestResultWithMessage(
                 new ModelMessage([new MessagePart(new FunctionCall('call-1', 'get_weather', []))]),
                 new TokenUsage(1, 2, 3),
                 FinishReasonEnum::toolCalls()
             ),
-            $this->createResultWithMessage(
+            $this->createTestResultWithMessage(
                 new ModelMessage([new MessagePart('Final answer')]),
                 new TokenUsage(10, 20, 30)
             ),

--- a/tests/unit/Builders/PromptBuilderFunctionCallResolutionTest.php
+++ b/tests/unit/Builders/PromptBuilderFunctionCallResolutionTest.php
@@ -259,6 +259,8 @@ class PromptBuilderFunctionCallResolutionTest extends TestCase
         $resolution = $result->getAdditionalData()[PromptBuilder::KEY_FUNCTION_CALL_RESOLUTION];
         $this->assertSame(2, $resolution['rounds']);
         $this->assertSame(PromptBuilder::STOP_REASON_MAX_ITERATIONS, $resolution['stopReason']);
+        // Calls from a response beyond the iteration limit must not be inspected or resolved.
+        $this->assertCount(2, $resolver->checkedCalls);
         $this->assertCount(2, $resolver->resolvedCalls);
         // Initial request plus one follow-up per round.
         $this->assertCount(3, $this->dispatcher->getDispatchedEventsOfType(BeforeGenerateResultEvent::class));

--- a/tests/unit/Builders/PromptBuilderFunctionCallResolutionTest.php
+++ b/tests/unit/Builders/PromptBuilderFunctionCallResolutionTest.php
@@ -73,7 +73,11 @@ class PromptBuilderFunctionCallResolutionTest extends TestCase
             $parts[] = new MessagePart($functionCall);
         }
 
-        return $this->createResultWithMessage(new ModelMessage($parts));
+        return $this->createResultWithMessage(
+            new ModelMessage($parts),
+            null,
+            FinishReasonEnum::toolCalls()
+        );
     }
 
     /**
@@ -81,13 +85,17 @@ class PromptBuilderFunctionCallResolutionTest extends TestCase
      *
      * @param Message $message The model message.
      * @param TokenUsage|null $tokenUsage Optional token usage. Defaults to 10/20/30.
+     * @param FinishReasonEnum|null $finishReason Optional finish reason. Defaults to stop.
      * @return GenerativeAiResult The result.
      */
-    private function createResultWithMessage(Message $message, ?TokenUsage $tokenUsage = null): GenerativeAiResult
-    {
+    private function createResultWithMessage(
+        Message $message,
+        ?TokenUsage $tokenUsage = null,
+        ?FinishReasonEnum $finishReason = null
+    ): GenerativeAiResult {
         return new GenerativeAiResult(
             'test-result-id',
-            [new Candidate($message, FinishReasonEnum::stop())],
+            [new Candidate($message, $finishReason ?? FinishReasonEnum::stop())],
             $tokenUsage ?? new TokenUsage(10, 20, 30),
             new ProviderMetadata('mock', 'Mock Provider', ProviderTypeEnum::cloud()),
             new ModelMetadata('mock-model', 'Mock Model', [], [])
@@ -241,6 +249,100 @@ class PromptBuilderFunctionCallResolutionTest extends TestCase
     }
 
     /**
+     * Tests that a truncated function call response is not executed.
+     *
+     * @return void
+     */
+    public function testDoesNotResolveFunctionCallsFromTruncatedResponse(): void
+    {
+        $truncatedResult = $this->createResultWithMessage(
+            new ModelMessage([
+                new MessagePart(new FunctionCall('call-1', 'get_weather', ['city' => 'Ber']))
+            ]),
+            null,
+            FinishReasonEnum::length()
+        );
+        $model = $this->createScriptedTextGenerationModel([
+            $truncatedResult,
+            $this->createTestResult('Never reached'),
+        ]);
+        $resolver = new MockFunctionCallResolver();
+
+        $result = $this->createBuilder()
+            ->usingModel($model)
+            ->usingFunctionCallResolver($resolver)
+            ->generateTextResult();
+
+        $this->assertSame([], $resolver->checkedCalls);
+        $this->assertSame([], $resolver->resolvedCalls);
+        $this->assertTrue($result->toMessage()->getParts()[0]->getType()->isFunctionCall());
+        $this->assertCount(1, $this->dispatcher->getDispatchedEventsOfType(BeforeGenerateResultEvent::class));
+
+        $resolution = $result->getAdditionalData()[PromptBuilder::KEY_FUNCTION_CALL_RESOLUTION];
+        $this->assertSame(0, $resolution['rounds']);
+        $this->assertSame(PromptBuilder::STOP_REASON_INCOMPLETE_FUNCTION_CALLS, $resolution['stopReason']);
+        $this->assertSame([], $resolution['resolvedCalls']);
+    }
+
+    /**
+     * Tests that one incomplete call prevents a parallel batch from executing.
+     *
+     * @return void
+     */
+    public function testDoesNotResolveParallelCallsWhenOneHasNoName(): void
+    {
+        $model = $this->createScriptedTextGenerationModel([
+            $this->createFunctionCallResult(
+                new FunctionCall('call-1', 'get_weather', []),
+                new FunctionCall('call-2', null, [])
+            ),
+            $this->createTestResult('Never reached'),
+        ]);
+        $resolver = new MockFunctionCallResolver();
+
+        $result = $this->createBuilder()
+            ->usingModel($model)
+            ->usingFunctionCallResolver($resolver)
+            ->generateTextResult();
+
+        $this->assertSame([], $resolver->checkedCalls);
+        $this->assertSame([], $resolver->resolvedCalls);
+
+        $resolution = $result->getAdditionalData()[PromptBuilder::KEY_FUNCTION_CALL_RESOLUTION];
+        $this->assertSame(0, $resolution['rounds']);
+        $this->assertSame(PromptBuilder::STOP_REASON_INCOMPLETE_FUNCTION_CALLS, $resolution['stopReason']);
+        $this->assertSame([], $resolution['resolvedCalls']);
+    }
+
+    /**
+     * Tests that a completed name-only function call remains resolvable.
+     *
+     * @return void
+     */
+    public function testResolvesCompletedFunctionCallWithoutId(): void
+    {
+        $model = $this->createScriptedTextGenerationModel([
+            $this->createFunctionCallResult(new FunctionCall(null, 'get_weather', [])),
+            $this->createTestResult('Final answer'),
+        ]);
+        $resolver = new MockFunctionCallResolver();
+
+        $result = $this->createBuilder()
+            ->usingModel($model)
+            ->usingFunctionCallResolver($resolver)
+            ->generateTextResult();
+
+        $this->assertSame('Final answer', $result->toText());
+        $this->assertCount(1, $resolver->checkedCalls);
+        $this->assertCount(1, $resolver->resolvedCalls);
+        $this->assertSame('get_weather', $resolver->resolvedCalls[0]->getName());
+
+        $resolution = $result->getAdditionalData()[PromptBuilder::KEY_FUNCTION_CALL_RESOLUTION];
+        $this->assertSame(1, $resolution['rounds']);
+        $this->assertSame(PromptBuilder::STOP_REASON_COMPLETED, $resolution['stopReason']);
+    }
+
+    /**
      * Tests that the loop stops after the maximum number of iterations.
      *
      * @return void
@@ -279,7 +381,8 @@ class PromptBuilderFunctionCallResolutionTest extends TestCase
         $model = $this->createScriptedTextGenerationModel([
             $this->createResultWithMessage(
                 new ModelMessage([new MessagePart(new FunctionCall('call-1', 'get_weather', []))]),
-                new TokenUsage(1, 2, 3)
+                new TokenUsage(1, 2, 3),
+                FinishReasonEnum::toolCalls()
             ),
             $this->createResultWithMessage(
                 new ModelMessage([new MessagePart('Final answer')]),

--- a/tests/unit/Builders/PromptBuilderFunctionCallResolutionTest.php
+++ b/tests/unit/Builders/PromptBuilderFunctionCallResolutionTest.php
@@ -1,0 +1,422 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Tests\unit\Builders;
+
+use PHPUnit\Framework\TestCase;
+use WordPress\AiClient\Builders\PromptBuilder;
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+use WordPress\AiClient\Events\BeforeGenerateResultEvent;
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\ModelMessage;
+use WordPress\AiClient\Messages\DTO\UserMessage;
+use WordPress\AiClient\Providers\DTO\ProviderMetadata;
+use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\ProviderRegistry;
+use WordPress\AiClient\Results\DTO\Candidate;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\AiClient\Results\DTO\TokenUsage;
+use WordPress\AiClient\Results\Enums\FinishReasonEnum;
+use WordPress\AiClient\Tests\mocks\MockEventDispatcher;
+use WordPress\AiClient\Tests\mocks\MockFunctionCallResolver;
+use WordPress\AiClient\Tests\mocks\MockProvider;
+use WordPress\AiClient\Tests\traits\MockModelCreationTrait;
+use WordPress\AiClient\Tools\DTO\FunctionCall;
+
+/**
+ * Tests for the automatic function call resolution loop in PromptBuilder.
+ *
+ * @covers \WordPress\AiClient\Builders\PromptBuilder
+ */
+class PromptBuilderFunctionCallResolutionTest extends TestCase
+{
+    use MockModelCreationTrait;
+
+    /**
+     * @var ProviderRegistry
+     */
+    private ProviderRegistry $registry;
+
+    /**
+     * @var MockEventDispatcher
+     */
+    private MockEventDispatcher $dispatcher;
+
+    /**
+     * Sets up the test environment.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->registry = new ProviderRegistry();
+        $this->registry->registerProvider(MockProvider::class);
+        $this->dispatcher = new MockEventDispatcher();
+    }
+
+    /**
+     * Creates a result whose message requests the given function calls.
+     *
+     * @param FunctionCall ...$functionCalls The function calls to include.
+     * @return GenerativeAiResult The result.
+     */
+    private function createFunctionCallResult(FunctionCall ...$functionCalls): GenerativeAiResult
+    {
+        $parts = [];
+        foreach ($functionCalls as $functionCall) {
+            $parts[] = new MessagePart($functionCall);
+        }
+
+        return $this->createResultWithMessage(new ModelMessage($parts));
+    }
+
+    /**
+     * Creates a result with the given model message and token usage.
+     *
+     * @param Message $message The model message.
+     * @param TokenUsage|null $tokenUsage Optional token usage. Defaults to 10/20/30.
+     * @return GenerativeAiResult The result.
+     */
+    private function createResultWithMessage(Message $message, ?TokenUsage $tokenUsage = null): GenerativeAiResult
+    {
+        return new GenerativeAiResult(
+            'test-result-id',
+            [new Candidate($message, FinishReasonEnum::stop())],
+            $tokenUsage ?? new TokenUsage(10, 20, 30),
+            new ProviderMetadata('mock', 'Mock Provider', ProviderTypeEnum::cloud()),
+            new ModelMetadata('mock-model', 'Mock Model', [], [])
+        );
+    }
+
+    /**
+     * Creates a prompt builder with the event dispatcher wired.
+     *
+     * @param string $prompt The prompt text.
+     * @return PromptBuilder The builder.
+     */
+    private function createBuilder(string $prompt = 'Hello, world!'): PromptBuilder
+    {
+        return new PromptBuilder($this->registry, $prompt, $this->dispatcher);
+    }
+
+    /**
+     * Tests that a function call is resolved and the final answer returned.
+     *
+     * @return void
+     */
+    public function testResolvesFunctionCallsAndReturnsFinalResult(): void
+    {
+        $model = $this->createScriptedTextGenerationModel([
+            $this->createFunctionCallResult(new FunctionCall('call-1', 'get_weather', ['city' => 'Berlin'])),
+            $this->createTestResult('Final answer'),
+        ]);
+        $resolver = new MockFunctionCallResolver();
+
+        $result = $this->createBuilder()
+            ->usingModel($model)
+            ->usingFunctionCallResolver($resolver)
+            ->generateTextResult();
+
+        $this->assertSame('Final answer', $result->toText());
+        $this->assertCount(1, $resolver->resolvedCalls);
+        $this->assertSame('get_weather', $resolver->resolvedCalls[0]->getName());
+
+        $resolution = $result->getAdditionalData()[PromptBuilder::KEY_FUNCTION_CALL_RESOLUTION];
+        $this->assertSame(1, $resolution['rounds']);
+        $this->assertSame(PromptBuilder::STOP_REASON_COMPLETED, $resolution['stopReason']);
+        $this->assertSame([['id' => 'call-1', 'name' => 'get_weather']], $resolution['resolvedCalls']);
+    }
+
+    /**
+     * Tests the ordering and roles of the transcript sent in follow-up rounds.
+     *
+     * @return void
+     */
+    public function testFollowUpRequestContainsFullTranscript(): void
+    {
+        $model = $this->createScriptedTextGenerationModel([
+            $this->createFunctionCallResult(new FunctionCall('call-1', 'get_weather', ['city' => 'Berlin'])),
+            $this->createTestResult('Final answer'),
+        ]);
+        $resolver = new MockFunctionCallResolver();
+
+        $result = $this->createBuilder()
+            ->usingModel($model)
+            ->usingFunctionCallResolver($resolver)
+            ->generateTextResult();
+
+        $beforeEvents = $this->dispatcher->getDispatchedEventsOfType(BeforeGenerateResultEvent::class);
+        $this->assertCount(2, $beforeEvents);
+
+        $followUpMessages = $beforeEvents[1]->getMessages();
+        $this->assertCount(3, $followUpMessages);
+        $this->assertTrue($followUpMessages[0]->getRole()->isUser());
+        $this->assertTrue($followUpMessages[1]->getRole()->isModel());
+        $this->assertTrue($followUpMessages[2]->getRole()->isUser());
+
+        // The model message carries the function call, the user message the response.
+        $this->assertTrue($followUpMessages[1]->getParts()[0]->getType()->isFunctionCall());
+        $responsePart = $followUpMessages[2]->getParts()[0];
+        $this->assertTrue($responsePart->getType()->isFunctionResponse());
+        $functionResponse = $responsePart->getFunctionResponse();
+        $this->assertNotNull($functionResponse);
+        $this->assertSame('call-1', $functionResponse->getId());
+        $this->assertSame(['status' => 'ok'], $functionResponse->getResponse());
+
+        // The exposed transcript also contains the final model response.
+        $resolution = $result->getAdditionalData()[PromptBuilder::KEY_FUNCTION_CALL_RESOLUTION];
+        $this->assertCount(4, $resolution['messages']);
+    }
+
+    /**
+     * Tests that multiple function calls in one response are resolved into one message.
+     *
+     * @return void
+     */
+    public function testResolvesMultipleFunctionCallsInOneResponse(): void
+    {
+        $model = $this->createScriptedTextGenerationModel([
+            $this->createFunctionCallResult(
+                new FunctionCall('call-1', 'get_weather', ['city' => 'Berlin']),
+                new FunctionCall('call-2', 'get_time', ['city' => 'Berlin'])
+            ),
+            $this->createTestResult('Final answer'),
+        ]);
+        $resolver = new MockFunctionCallResolver();
+
+        $this->createBuilder()
+            ->usingModel($model)
+            ->usingFunctionCallResolver($resolver)
+            ->generateTextResult();
+
+        $this->assertCount(2, $resolver->resolvedCalls);
+
+        $beforeEvents = $this->dispatcher->getDispatchedEventsOfType(BeforeGenerateResultEvent::class);
+        $responseMessage = $beforeEvents[1]->getMessages()[2];
+        $this->assertCount(2, $responseMessage->getParts());
+        $this->assertTrue($responseMessage->getParts()[0]->getType()->isFunctionResponse());
+        $this->assertTrue($responseMessage->getParts()[1]->getType()->isFunctionResponse());
+    }
+
+    /**
+     * Tests that the loop stops without executing any call when one call cannot be resolved.
+     *
+     * @return void
+     */
+    public function testStopsWithoutExecutingWhenACallCannotBeResolved(): void
+    {
+        $model = $this->createScriptedTextGenerationModel([
+            $this->createFunctionCallResult(
+                new FunctionCall('call-1', 'known_function', []),
+                new FunctionCall('call-2', 'unknown_function', [])
+            ),
+            $this->createTestResult('Never reached'),
+        ]);
+        $resolver = new MockFunctionCallResolver(
+            static function (FunctionCall $functionCall): bool {
+                return $functionCall->getName() === 'known_function';
+            }
+        );
+
+        $result = $this->createBuilder()
+            ->usingModel($model)
+            ->usingFunctionCallResolver($resolver)
+            ->generateTextResult();
+
+        // No call was executed, and the function call response is handed back.
+        $this->assertSame([], $resolver->resolvedCalls);
+        $this->assertTrue($result->toMessage()->getParts()[0]->getType()->isFunctionCall());
+        $this->assertCount(1, $this->dispatcher->getDispatchedEventsOfType(BeforeGenerateResultEvent::class));
+
+        $resolution = $result->getAdditionalData()[PromptBuilder::KEY_FUNCTION_CALL_RESOLUTION];
+        $this->assertSame(0, $resolution['rounds']);
+        $this->assertSame(PromptBuilder::STOP_REASON_UNRESOLVED_FUNCTION_CALLS, $resolution['stopReason']);
+        $this->assertSame([], $resolution['resolvedCalls']);
+    }
+
+    /**
+     * Tests that the loop stops after the maximum number of iterations.
+     *
+     * @return void
+     */
+    public function testStopsAtMaxIterations(): void
+    {
+        // The model requests a function call on every round.
+        $model = $this->createScriptedTextGenerationModel([
+            $this->createFunctionCallResult(new FunctionCall('call-1', 'get_weather', [])),
+        ]);
+        $resolver = new MockFunctionCallResolver();
+
+        $result = $this->createBuilder()
+            ->usingModel($model)
+            ->usingFunctionCallResolver($resolver)
+            ->usingMaxFunctionCallIterations(2)
+            ->generateTextResult();
+
+        $resolution = $result->getAdditionalData()[PromptBuilder::KEY_FUNCTION_CALL_RESOLUTION];
+        $this->assertSame(2, $resolution['rounds']);
+        $this->assertSame(PromptBuilder::STOP_REASON_MAX_ITERATIONS, $resolution['stopReason']);
+        $this->assertCount(2, $resolver->resolvedCalls);
+        // Initial request plus one follow-up per round.
+        $this->assertCount(3, $this->dispatcher->getDispatchedEventsOfType(BeforeGenerateResultEvent::class));
+    }
+
+    /**
+     * Tests that token usage is aggregated across all rounds.
+     *
+     * @return void
+     */
+    public function testAggregatesTokenUsageAcrossRounds(): void
+    {
+        $model = $this->createScriptedTextGenerationModel([
+            $this->createResultWithMessage(
+                new ModelMessage([new MessagePart(new FunctionCall('call-1', 'get_weather', []))]),
+                new TokenUsage(1, 2, 3)
+            ),
+            $this->createResultWithMessage(
+                new ModelMessage([new MessagePart('Final answer')]),
+                new TokenUsage(10, 20, 30)
+            ),
+        ]);
+        $resolver = new MockFunctionCallResolver();
+
+        $result = $this->createBuilder()
+            ->usingModel($model)
+            ->usingFunctionCallResolver($resolver)
+            ->generateTextResult();
+
+        $tokenUsage = $result->getTokenUsage();
+        $this->assertSame(11, $tokenUsage->getPromptTokens());
+        $this->assertSame(22, $tokenUsage->getCompletionTokens());
+        $this->assertSame(33, $tokenUsage->getTotalTokens());
+        $this->assertNull($tokenUsage->getThoughtTokens());
+    }
+
+    /**
+     * Tests that a response without function calls completes with zero rounds.
+     *
+     * @return void
+     */
+    public function testCompletesWithZeroRoundsWithoutFunctionCalls(): void
+    {
+        $model = $this->createScriptedTextGenerationModel([
+            $this->createTestResult('Immediate answer'),
+        ]);
+        $resolver = new MockFunctionCallResolver();
+
+        $result = $this->createBuilder()
+            ->usingModel($model)
+            ->usingFunctionCallResolver($resolver)
+            ->generateTextResult();
+
+        $this->assertSame('Immediate answer', $result->toText());
+
+        $resolution = $result->getAdditionalData()[PromptBuilder::KEY_FUNCTION_CALL_RESOLUTION];
+        $this->assertSame(0, $resolution['rounds']);
+        $this->assertSame(PromptBuilder::STOP_REASON_COMPLETED, $resolution['stopReason']);
+        $this->assertSame([], $resolution['resolvedCalls']);
+        $this->assertCount(2, $resolution['messages']);
+    }
+
+    /**
+     * Tests that an invalid maximum number of iterations is rejected.
+     *
+     * @return void
+     */
+    public function testRejectsInvalidMaxIterations(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->createBuilder()->usingMaxFunctionCallIterations(0);
+    }
+
+    /**
+     * Tests that the resolver is ignored for non-text generation.
+     *
+     * @return void
+     */
+    public function testResolverIsIgnoredForImageGeneration(): void
+    {
+        $model = $this->createMockImageGenerationModel($this->createTestResult('image'));
+        $resolver = new MockFunctionCallResolver();
+
+        $result = $this->createBuilder()
+            ->usingModel($model)
+            ->usingFunctionCallResolver($resolver)
+            ->generateImageResult();
+
+        $this->assertArrayNotHasKey(
+            PromptBuilder::KEY_FUNCTION_CALL_RESOLUTION,
+            $result->getAdditionalData()
+        );
+        $this->assertSame([], $resolver->checkedCalls);
+    }
+
+    /**
+     * Tests that withMessages() appends full messages to the conversation.
+     *
+     * @return void
+     */
+    public function testWithMessagesAppendsToConversation(): void
+    {
+        $model = $this->createScriptedTextGenerationModel([
+            $this->createTestResult('Answer'),
+        ]);
+
+        $this->createBuilder('First question')
+            ->withMessages(
+                new ModelMessage([new MessagePart('First answer')]),
+                new UserMessage([new MessagePart('Follow-up question')])
+            )
+            ->usingModel($model)
+            ->generateTextResult();
+
+        $beforeEvents = $this->dispatcher->getDispatchedEventsOfType(BeforeGenerateResultEvent::class);
+        $sentMessages = $beforeEvents[0]->getMessages();
+
+        $this->assertCount(3, $sentMessages);
+        $this->assertTrue($sentMessages[0]->getRole()->isUser());
+        $this->assertSame('First question', $sentMessages[0]->getParts()[0]->getText());
+        $this->assertTrue($sentMessages[1]->getRole()->isModel());
+        $this->assertSame('First answer', $sentMessages[1]->getParts()[0]->getText());
+        $this->assertTrue($sentMessages[2]->getRole()->isUser());
+        $this->assertSame('Follow-up question', $sentMessages[2]->getParts()[0]->getText());
+    }
+
+    /**
+     * Tests that withMessages() appends after the current message while withHistory() prepends.
+     *
+     * @return void
+     */
+    public function testWithMessagesAndWithHistoryOrdering(): void
+    {
+        $model = $this->createScriptedTextGenerationModel([
+            $this->createTestResult('Answer'),
+        ]);
+
+        $this->createBuilder('Current question')
+            ->withHistory(
+                new UserMessage([new MessagePart('Historical question')]),
+                new ModelMessage([new MessagePart('Historical answer')])
+            )
+            ->withMessages(
+                new ModelMessage([new MessagePart('Appended answer')]),
+                new UserMessage([new MessagePart('Appended question')])
+            )
+            ->usingModel($model)
+            ->generateTextResult();
+
+        $beforeEvents = $this->dispatcher->getDispatchedEventsOfType(BeforeGenerateResultEvent::class);
+        $sentMessages = $beforeEvents[0]->getMessages();
+
+        $this->assertCount(5, $sentMessages);
+        $this->assertSame('Historical question', $sentMessages[0]->getParts()[0]->getText());
+        $this->assertSame('Historical answer', $sentMessages[1]->getParts()[0]->getText());
+        $this->assertSame('Current question', $sentMessages[2]->getParts()[0]->getText());
+        $this->assertSame('Appended answer', $sentMessages[3]->getParts()[0]->getText());
+        $this->assertSame('Appended question', $sentMessages[4]->getParts()[0]->getText());
+    }
+}

--- a/tests/unit/Builders/PromptBuilderFunctionCallResolutionTest.php
+++ b/tests/unit/Builders/PromptBuilderFunctionCallResolutionTest.php
@@ -376,6 +376,33 @@ class PromptBuilderFunctionCallResolutionTest extends TestCase
     }
 
     /**
+     * Tests that a missing thought token count in one round counts as zero.
+     *
+     * @return void
+     */
+    public function testAggregatesThoughtTokensWhenOnlySomeRoundsReportThem(): void
+    {
+        $model = $this->createScriptedTextGenerationModel([
+            $this->createTestResultWithMessage(
+                new ModelMessage([new MessagePart(new FunctionCall('call-1', 'get_weather', []))]),
+                new TokenUsage(1, 2, 3),
+                FinishReasonEnum::toolCalls()
+            ),
+            $this->createTestResultWithMessage(
+                new ModelMessage([new MessagePart('Final answer')]),
+                new TokenUsage(10, 20, 30, 5)
+            ),
+        ]);
+
+        $result = $this->createBuilder()
+            ->usingModel($model)
+            ->usingFunctionCallResolver(new MockFunctionCallResolver())
+            ->generateTextResult();
+
+        $this->assertSame(5, $result->getTokenUsage()->getThoughtTokens());
+    }
+
+    /**
      * Tests that a response without function calls completes with zero rounds.
      *
      * @return void

--- a/tests/unit/Builders/PromptBuilderFunctionCallResolutionTest.php
+++ b/tests/unit/Builders/PromptBuilderFunctionCallResolutionTest.php
@@ -15,6 +15,9 @@ use WordPress\AiClient\Messages\DTO\UserMessage;
 use WordPress\AiClient\Providers\DTO\ProviderMetadata;
 use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\DTO\SupportedOption;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+use WordPress\AiClient\Providers\Models\Enums\OptionEnum;
 use WordPress\AiClient\Providers\ProviderRegistry;
 use WordPress\AiClient\Results\DTO\Candidate;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
@@ -321,6 +324,51 @@ class PromptBuilderFunctionCallResolutionTest extends TestCase
         $this->assertSame(PromptBuilder::STOP_REASON_COMPLETED, $resolution['stopReason']);
         $this->assertSame([], $resolution['resolvedCalls']);
         $this->assertCount(2, $resolution['messages']);
+    }
+
+    /**
+     * Tests that automatic resolution requires chat history support.
+     *
+     * @return void
+     */
+    public function testResolverRequiresChatHistorySupport(): void
+    {
+        $metadata = new ModelMetadata(
+            'text-only-model',
+            'Text-only Model',
+            [CapabilityEnum::textGeneration()],
+            [new SupportedOption(OptionEnum::inputModalities())]
+        );
+        $model = $this->createMockTextGenerationModel($this->createTestResult('Answer'), $metadata);
+        $builder = $this->createBuilder()->usingModel($model);
+
+        $this->assertTrue($builder->isSupportedForTextGeneration());
+
+        $builder->usingFunctionCallResolver(new MockFunctionCallResolver());
+
+        $this->assertFalse($builder->isSupportedForTextGeneration());
+    }
+
+    /**
+     * Tests that automatic resolution accepts a model with chat history support.
+     *
+     * @return void
+     */
+    public function testResolverSupportsModelWithChatHistory(): void
+    {
+        $metadata = new ModelMetadata(
+            'chat-model',
+            'Chat Model',
+            [CapabilityEnum::textGeneration(), CapabilityEnum::chatHistory()],
+            [new SupportedOption(OptionEnum::inputModalities())]
+        );
+        $model = $this->createMockTextGenerationModel($this->createTestResult('Answer'), $metadata);
+
+        $builder = $this->createBuilder()
+            ->usingModel($model)
+            ->usingFunctionCallResolver(new MockFunctionCallResolver());
+
+        $this->assertTrue($builder->isSupportedForTextGeneration());
     }
 
     /**

--- a/tests/unit/Builders/PromptBuilderTest.php
+++ b/tests/unit/Builders/PromptBuilderTest.php
@@ -36,6 +36,7 @@ use WordPress\AiClient\Results\DTO\Candidate;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
 use WordPress\AiClient\Results\DTO\TokenUsage;
 use WordPress\AiClient\Results\Enums\FinishReasonEnum;
+use WordPress\AiClient\Tests\mocks\MockFunctionCallResolver;
 use WordPress\AiClient\Tests\traits\MockModelCreationTrait;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 use WordPress\AiClient\Tools\DTO\FunctionResponse;
@@ -3305,6 +3306,45 @@ class PromptBuilderTest extends TestCase
         $builder->usingModel($model);
 
         $this->assertTrue($builder->isSupportedForTextGeneration());
+    }
+
+    /**
+     * Tests model discovery requires chat history for automatic function call resolution.
+     *
+     * @return void
+     */
+    public function testModelDiscoveryRequiresChatHistoryForFunctionCallResolution(): void
+    {
+        $result = $this->createTestResult('Answer');
+        $metadata = new ModelMetadata(
+            'chat-model',
+            'Chat Model',
+            [CapabilityEnum::textGeneration(), CapabilityEnum::chatHistory()],
+            [new SupportedOption(OptionEnum::inputModalities())]
+        );
+        $model = $this->createMockTextGenerationModel($result, $metadata);
+        $providerMetadata = $model->providerMetadata();
+
+        $this->registry->expects($this->once())
+            ->method('findModelsMetadataForSupport')
+            ->with($this->callback(static function (ModelRequirements $requirements): bool {
+                return $requirements->getRequiredCapabilities() === [
+                    CapabilityEnum::textGeneration(),
+                    CapabilityEnum::chatHistory(),
+                ];
+            }))
+            ->willReturn([new ProviderModelsMetadata($providerMetadata, [$metadata])]);
+
+        $this->registry->expects($this->once())
+            ->method('getProviderModel')
+            ->with($providerMetadata->getId(), 'chat-model', $this->isInstanceOf(ModelConfig::class))
+            ->willReturn($model);
+
+        $actualResult = (new PromptBuilder($this->registry, 'Test prompt'))
+            ->usingFunctionCallResolver(new MockFunctionCallResolver())
+            ->generateTextResult();
+
+        $this->assertSame('Answer', $actualResult->toText());
     }
 
     /**

--- a/tests/unit/Providers/Models/DTO/ModelRequirementsTest.php
+++ b/tests/unit/Providers/Models/DTO/ModelRequirementsTest.php
@@ -63,6 +63,31 @@ class ModelRequirementsTest extends TestCase
     }
 
     /**
+     * Tests adding a required capability without mutating the original requirements.
+     *
+     * @return void
+     */
+    public function testWithRequiredCapability(): void
+    {
+        $options = [new RequiredOption(OptionEnum::temperature(), 0.7)];
+        $requirements = new ModelRequirements([CapabilityEnum::textGeneration()], $options);
+
+        $updatedRequirements = $requirements->withRequiredCapability(CapabilityEnum::chatHistory());
+
+        $this->assertNotSame($requirements, $updatedRequirements);
+        $this->assertSame(
+            [CapabilityEnum::textGeneration(), CapabilityEnum::chatHistory()],
+            $updatedRequirements->getRequiredCapabilities()
+        );
+        $this->assertSame($options, $updatedRequirements->getRequiredOptions());
+        $this->assertSame([CapabilityEnum::textGeneration()], $requirements->getRequiredCapabilities());
+        $this->assertSame(
+            $updatedRequirements,
+            $updatedRequirements->withRequiredCapability(CapabilityEnum::chatHistory())
+        );
+    }
+
+    /**
      * Tests JSON schema generation.
      *
      * @return void

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
@@ -549,6 +549,41 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
     }
 
     /**
+     * Tests prepareMessagesParam() with multiple function responses from one model turn.
+     *
+     * @return void
+     */
+    public function testPrepareMessagesParamMultipleFunctionResponses(): void
+    {
+        $message = new Message(
+            MessageRoleEnum::user(),
+            [
+                new MessagePart(new FunctionResponse('call_1', 'get_weather', ['temperature' => 18])),
+                new MessagePart(new FunctionResponse('call_2', 'get_time', ['time' => '10:30'])),
+            ]
+        );
+        $model = $this->createModel();
+
+        $prepared = $model->exposePrepareMessagesParam([$message]);
+
+        $this->assertSame(
+            [
+                [
+                    'role' => 'tool',
+                    'content' => json_encode(['temperature' => 18]),
+                    'tool_call_id' => 'call_1',
+                ],
+                [
+                    'role' => 'tool',
+                    'content' => json_encode(['time' => '10:30']),
+                    'tool_call_id' => 'call_2',
+                ],
+            ],
+            $prepared
+        );
+    }
+
+    /**
      * Tests getMessageRoleString() method.
      *
      * @dataProvider messageRoleProvider

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
@@ -584,6 +584,28 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
     }
 
     /**
+     * Tests prepareMessagesParam() with a function response mixed with other parts (should throw exception).
+     *
+     * @return void
+     */
+    public function testPrepareMessagesParamFunctionResponseMixedWithOtherParts(): void
+    {
+        $message = new Message(
+            MessageRoleEnum::user(),
+            [
+                new MessagePart(new FunctionResponse('call_1', 'get_weather', ['temperature' => 18])),
+                new MessagePart('Some extra text'),
+            ]
+        );
+        $model = $this->createModel();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Function responses cannot be combined with other message parts.');
+
+        $model->exposePrepareMessagesParam([$message]);
+    }
+
+    /**
      * Tests getMessageRoleString() method.
      *
      * @dataProvider messageRoleProvider
@@ -748,9 +770,7 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
         $model = $this->createModel();
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            'The API only allows a single function response, as the only content of the message.'
-        );
+        $this->expectExceptionMessage('Function responses cannot be combined with other message parts.');
 
         $model->exposeGetMessagePartContentData($part);
     }


### PR DESCRIPTION
Fixes #272

## What

This PR adds two things to `PromptBuilder`, as proposed in #272:

1. `withMessages(Message ...$messages)` to append full messages to the conversation. It is the counterpart to `withHistory()`, which prepends. This gives developers a public way to continue a conversation, for example to build a manual function call loop.

2. An automatic function call resolution loop, enabled with a resolver:

```php
$result = AiClient::prompt('What is this site about?')
    ->usingFunctionDeclarations(...$declarations)
    ->usingFunctionCallResolver($resolver)
    ->usingMaxFunctionCallIterations(3) // default 5
    ->generateTextResult();
```

The example uses `generateTextResult()` on purpose. When the loop stops early, the final response usually contains function calls and no text, and `generateText()` throws in that case. `generateTextResult()` hands the response back so the caller can handle it.

## The resolver interface

The extension point is a small interface with two methods:

```php
interface FunctionCallResolverInterface
{
    public function canResolve(FunctionCall $functionCall): bool;
    public function resolve(FunctionCall $functionCall): FunctionResponse;
}
```

The two steps are separate on purpose. `canResolve()` must be free of side effects. It is called for every function call in a model response before any call is executed. This way, a round is either executed completely or handed back to the caller untouched. `resolve()` executes one call. Execution errors should be encoded in the returned `FunctionResponse`, so the model can react to them.

## How the loop works

- Each round executes the function calls requested by the model through the resolver, appends the model message and a user message with the function responses to a copy of the conversation, and requests a follow-up response. The builder's own message list is not changed.
- The loop stops when the model answers without function calls (`completed`), when the round limit is reached (`maxIterations`), when the response looks incomplete (`incompleteFunctionCalls`, see below), or when the resolver cannot resolve a requested call (`unresolvedFunctionCalls`, so the caller can handle custom functions).
- A response is treated as incomplete when its finish reason is not `toolCalls` (for example a truncated response that hit the token limit) or when a function call has no name. Such calls are never executed. Provider adapters must map their finish reasons correctly for this check; the official OpenAI provider still needs the follow-up described below.
- When a resolver is set, model discovery also requires the chat history capability, because follow-up rounds send multi-message conversations.
- `BeforeGenerateResultEvent` and `AfterGenerateResultEvent` fire for every round, so consumers can observe the loop or abort it.
- Token usage is summed across all rounds.
- The number of rounds, the stop reason, the resolved calls, and the full conversation are exposed under the `functionCallResolution` key of the additional data of the final result.
- The loop follows the first response candidate and only applies to text generation. Other capabilities ignore the resolver.

## Why in the SDK

WordPress core is adding an ability resolution loop to the WP AI Client ([Trac ticket 64865](https://core.trac.wordpress.org/ticket/64865), [wordpress-develop PR #12658](https://github.com/WordPress/wordpress-develop/pull/12658)). Because the SDK had no way to append messages or run the loop, that PR captures the messages and the resolved model from `BeforeGenerateResultEvent` and calls the model directly for later rounds. With this PR, the WordPress side shrinks to a thin resolver: `canResolve()` checks that the function name maps to a registered ability, and `resolve()` executes it. The workaround disappears. Any other consumer of the SDK gets the same loop for free.

## Note on scope

`docs/REQUIREMENTS.md` says the client must not include agents. My reading is that this loop is not an agent framework. It is a small, bounded loop on top of the existing function calling feature, and it stays fully under the control of the caller. Happy to adjust the docs wording as part of this PR if you agree, or to change the approach if you read the scope differently.

## OpenAI provider follow-up

This PR also updates the SDK's OpenAI-compatible Chat Completions implementation. A user message with several function responses, which is what the loop sends after parallel function calls, is now expanded into one `tool` message per response. Mixing function responses with other parts in one message is rejected with a clear error. The official [OpenAI provider](https://github.com/WordPress/ai-provider-for-openai), which uses the Responses API, still needs a separate follow-up to normalize parallel top-level function-call items into one candidate, preserve an incomplete response's finish reason, and expand parallel calls and responses into top-level input items. No official-provider code is changed here.

## Testing

```
composer test
```

The new tests in `tests/unit/Builders/PromptBuilderFunctionCallResolutionTest.php` cover the happy path, transcript ordering and roles, multiple calls in one response, the no-execution guarantee when a call cannot be resolved, the iteration limit, token usage aggregation, zero-round completion, invalid options, non-text capabilities, and `withMessages()` ordering. `composer lint` (PHPCS and PHPStan) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

