### PR TITLE
Qualify global function and constant references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,44 @@ Key constraints include:
 *   PER Coding Style (extending PSR-12).
 *   Strict type hinting for all parameters, return values, and properties.
 
+### Global function and constant references
+
+Inside a namespace, PHP resolves an unqualified function or constant name by first looking in the current namespace and only then falling back to the global namespace. That fallback is a runtime lookup on every call, and it prevents opcache from substituting the optimized handlers for common built-ins. Both `src/` and `tests/` are fully normalized to avoid it, and new code must stay that way.
+
+The rule is per file, based on how many times the name is referenced in that file:
+
+*   **Referenced once:** prefix it with a leading backslash, e.g. `\gettype($value)` or `\PATHINFO_EXTENSION`.
+*   **Referenced two or more times:** import it at the top with `use function` or `use const`, and leave the call sites unqualified.
+
+```php
+namespace WordPress\AiClient\Files\ValueObjects;
+
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+
+use function sprintf;
+use function strtolower;
+
+// ...
+
+if (!\is_string($other)) {                                  // used once: leading backslash
+    throw new InvalidArgumentException(
+        sprintf('Invalid MIME type: %s', \gettype($other))  // sprintf imported, gettype used once
+    );
+}
+
+return $this->value === strtolower($other);
+```
+
+Notes:
+
+*   `composer phpcs` enforces the first half of this automatically. The `SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly` rule in `phpcs.xml.dist` fails the build on any global function or constant referenced via the namespace fallback, so a bare `sprintf(...)` is a hard error. It accepts both approved forms equally, so the choice between a leading backslash and an import is a convention that reviewers need to check by eye.
+*   `composer phpcbf` can fix a fallback reference, but it always fixes by adding an import. For a name used only once, prefer prefixing with `\` by hand instead.
+*   PSR-12 treats class imports, `use function` imports, and `use const` imports as separate header blocks, each separated by a blank line and each sorted alphabetically. `composer phpcbf` fixes the spacing automatically.
+*   This applies to global **functions and constants** only. Classes need no equivalent treatment: PHP has no global fallback for class names, so a global class such as `Throwable` or `ReflectionClass` must already be imported or fully qualified for the code to run at all. Keep importing those with a plain `use` statement as usual.
+*   `true`, `false`, and `null` are language constructs, not constants, and must not be prefixed.
+*   Files with no namespace declaration, such as `cli.php` and `src/polyfills.php`, are already in the global namespace and need no qualification.
+*   Do not qualify calls to functions defined by this project or by a dependency inside a namespace; the rule covers global built-ins (including the `src/polyfills.php` shims, which are defined globally).
+
 ## Core Principles
 
 *   **Provider Agnostic:** The client is designed to work with any AI provider, avoiding vendor lock-in.
@@ -79,6 +117,7 @@ For a more detailed overview, refer to the `docs/ARCHITECTURE.md` file.
 *   **Write Tests:** All new features or bug fixes must be accompanied by corresponding unit tests.
 *   **Use the Fluent API:** When writing examples or tests for the implementer API, prefer the fluent API for readability.
 *   **Use `{@inheritDoc}`:** When implementing an interface method, use `{@inheritDoc}` in the PHPDoc block to avoid duplicating documentation, as specified in `CONTRIBUTING.md`.
+*   **Qualify Global Functions and Constants:** Within a namespace, prefix a global function or constant with `\` when it is referenced once in the file, or import it with `use function` / `use const` when it is referenced more than once. See "Global function and constant references" above.
 
 ### DON'T:
 
@@ -101,3 +140,4 @@ All exceptions must use the project's custom exception classes rather than PHP b
 *   **Direct HTTP Client Usage:** A common mistake is to instantiate a PSR-18 client directly in a model. This is incorrect. Instead, the model should receive an `HttpTransporter` instance and use it to send requests.
 *   **Ignoring the Fluent API:** While the traditional API is available, the fluent API is the preferred way for implementers to use the client. Avoid writing complex, nested method calls when the fluent API provides a cleaner alternative.
 *   **Duplicating Interface Documentation:** Manually writing PHPDoc descriptions for methods that implement an interface is a common pitfall. The `{@inheritDoc}` tag should be used instead to inherit the documentation from the interface.
+*   **Unqualified Global Functions:** Writing `sprintf(...)` or `is_array(...)` bare inside a namespace is easy to do by habit, but it forces a runtime namespace fallback lookup on every call. Either prefix with `\` or add a `use function` import, depending on how many times the name appears in the file.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -40,4 +40,31 @@
 			<property name="searchAnnotations" value="true" />
 		</properties>
 	</rule>
+
+	<!--
+		Forbid referencing global functions and constants via the namespace fallback.
+		A bare `sprintf()` inside a namespace makes PHP look in the current namespace
+		first and only then fall back to the global one, which costs a runtime lookup
+		on every call and blocks opcache from using its optimized handlers.
+
+		Both accepted forms pass: a leading backslash (`\sprintf()`) for a name used
+		once in a file, and a `use function` / `use const` import for a name used more
+		than once. The count-based split between those two is a convention documented
+		in AGENTS.md and is not machine-enforceable.
+
+		ReferenceViaFullyQualifiedName is excluded so this rule stays scoped to the
+		fallback problem and does not also start policing how classes are referenced.
+	-->
+	<rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
+		<properties>
+			<property name="allowFallbackGlobalFunctions" value="false" />
+			<property name="allowFallbackGlobalConstants" value="false" />
+			<property name="allowFullyQualifiedGlobalFunctions" value="true" />
+			<property name="allowFullyQualifiedGlobalConstants" value="true" />
+			<property name="allowFullyQualifiedGlobalClasses" value="true" />
+			<property name="searchAnnotations" value="false" />
+		</properties>
+		<exclude name="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName" />
+		<exclude name="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.PartialUse" />
+	</rule>
 </ruleset>

--- a/src/AiClient.php
+++ b/src/AiClient.php
@@ -19,6 +19,11 @@ use WordPress\AiClient\Results\DTO\Embedding;
 use WordPress\AiClient\Results\DTO\EmbeddingResult;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
 
+use function get_class;
+use function gettype;
+use function is_object;
+use function sprintf;
+
 /**
  * Main AI Client class providing both fluent and traditional APIs for AI operations.
  *
@@ -206,7 +211,7 @@ class AiClient
         }
 
         // Handle string input (provider ID or class name) via registry
-        if (is_string($availabilityOrIdOrClassName)) {
+        if (\is_string($availabilityOrIdOrClassName)) {
             return self::defaultRegistry()->isProviderConfigured($availabilityOrIdOrClassName);
         }
 

--- a/src/Builders/EmbeddingBuilder.php
+++ b/src/Builders/EmbeddingBuilder.php
@@ -21,6 +21,10 @@ use WordPress\AiClient\Providers\ProviderRegistry;
 use WordPress\AiClient\Results\DTO\Embedding;
 use WordPress\AiClient\Results\DTO\EmbeddingResult;
 
+use function count;
+use function is_array;
+use function sprintf;
+
 /**
  * Fluent builder for generating embeddings.
  *
@@ -71,7 +75,7 @@ class EmbeddingBuilder
             return;
         }
 
-        if (is_array($input) && array_is_list($input)) {
+        if (is_array($input) && \array_is_list($input)) {
             /** @var list<EmbeddingInput> $input */
             $this->withInput(...$input);
             return;
@@ -256,8 +260,8 @@ class EmbeddingBuilder
             return $this->validatePart($input);
         }
 
-        if (is_string($input)) {
-            if (trim($input) === '') {
+        if (\is_string($input)) {
+            if (\trim($input) === '') {
                 throw new InvalidArgumentException('Cannot create an embedding input from an empty string.');
             }
             return new MessagePart($input);

--- a/src/Builders/MessageBuilder.php
+++ b/src/Builders/MessageBuilder.php
@@ -55,7 +55,7 @@ class MessageBuilder
         // Handle different input types
         if ($input instanceof MessagePart) {
             $this->parts[] = $input;
-        } elseif (is_string($input)) {
+        } elseif (\is_string($input)) {
             $this->withText($input);
         } elseif ($input instanceof File) {
             $this->withFile($input);
@@ -63,7 +63,7 @@ class MessageBuilder
             $this->withFunctionCall($input);
         } elseif ($input instanceof FunctionResponse) {
             $this->withFunctionResponse($input);
-        } elseif (is_array($input) && MessagePart::isArrayShape($input)) {
+        } elseif (\is_array($input) && MessagePart::isArrayShape($input)) {
             $this->parts[] = MessagePart::fromArray($input);
         } else {
             throw new InvalidArgumentException(
@@ -141,7 +141,7 @@ class MessageBuilder
      */
     public function withText(string $text): self
     {
-        if (trim($text) === '') {
+        if (\trim($text) === '') {
             throw new InvalidArgumentException('Text content cannot be empty.');
         }
 

--- a/src/Builders/PromptBuilder.php
+++ b/src/Builders/PromptBuilder.php
@@ -34,6 +34,13 @@ use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 use WordPress\AiClient\Tools\DTO\FunctionResponse;
 use WordPress\AiClient\Tools\DTO\WebSearch;
 
+use function array_is_list;
+use function array_merge;
+use function end;
+use function is_array;
+use function is_string;
+use function sprintf;
+
 /**
  * Fluent builder for constructing AI prompts.
  *
@@ -536,7 +543,7 @@ class PromptBuilder
 
         // Multi-modal output (multiple modalities) defaults to text generation. This is temporary
         // as a multi-modal interface will be implemented in the future.
-        if (count($outputModalities) > 1) {
+        if (\count($outputModalities) > 1) {
             return CapabilityEnum::textGeneration();
         }
 
@@ -1114,7 +1121,7 @@ class PromptBuilder
 
         if ($lastMessage instanceof Message && $lastMessage->getRole()->isUser()) {
             // Replace the last message with a new one containing the appended part
-            array_pop($this->messages);
+            \array_pop($this->messages);
             $this->messages[] = $lastMessage->withPart($part);
             return;
         }
@@ -1166,7 +1173,7 @@ class PromptBuilder
 
         // Handle string input
         if (is_string($input)) {
-            if (trim($input) === '') {
+            if (\trim($input) === '') {
                 throw new InvalidArgumentException('Cannot create a message from an empty string.');
             }
             return new Message($defaultRole, [new MessagePart($input)]);
@@ -1242,7 +1249,7 @@ class PromptBuilder
             );
         }
 
-        $firstMessage = reset($messages);
+        $firstMessage = \reset($messages);
         if (!$firstMessage->getRole()->isUser()) {
             throw new InvalidArgumentException(
                 'The first message must be from a user role, not from ' . $firstMessage->getRole()->value

--- a/src/Builders/Traits/ModelResolutionTrait.php
+++ b/src/Builders/Traits/ModelResolutionTrait.php
@@ -10,6 +10,8 @@ use WordPress\AiClient\Providers\ModelResolver;
 use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 
+use function array_merge;
+
 /**
  * Provides shared model selection and configuration methods for builders.
  *

--- a/src/Common/AbstractDataTransferObject.php
+++ b/src/Common/AbstractDataTransferObject.php
@@ -10,6 +10,8 @@ use WordPress\AiClient\Common\Contracts\WithArrayTransformationInterface;
 use WordPress\AiClient\Common\Contracts\WithJsonSchemaInterface;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 
+use function is_array;
+
 /**
  * Abstract base class for all Data Value Objects in the AI Client.
  *
@@ -46,17 +48,17 @@ abstract class AbstractDataTransferObject implements
         $missingKeys = [];
 
         foreach ($requiredKeys as $key) {
-            if (!array_key_exists($key, $data)) {
+            if (!\array_key_exists($key, $data)) {
                 $missingKeys[] = $key;
             }
         }
 
         if (!empty($missingKeys)) {
             throw new InvalidArgumentException(
-                sprintf(
+                \sprintf(
                     '%s::fromArray() missing required keys: %s',
                     static::class,
-                    implode(', ', $missingKeys)
+                    \implode(', ', $missingKeys)
                 )
             );
         }

--- a/src/Common/AbstractEnum.php
+++ b/src/Common/AbstractEnum.php
@@ -10,6 +10,9 @@ use ReflectionClass;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Common\Exception\RuntimeException;
 
+use function sprintf;
+use function strtoupper;
+
 /**
  * Abstract base class for enum-like behavior in PHP 7.4.
  *
@@ -204,7 +207,7 @@ abstract class AbstractEnum implements JsonSerializable
      */
     final public static function getValues(): array
     {
-        return array_values(static::getConstants());
+        return \array_values(static::getConstants());
     }
 
     /**
@@ -217,7 +220,7 @@ abstract class AbstractEnum implements JsonSerializable
      */
     final public static function isValidValue(string $value): bool
     {
-        return in_array($value, self::getValues(), true);
+        return \in_array($value, self::getValues(), true);
     }
 
     /**
@@ -286,7 +289,7 @@ abstract class AbstractEnum implements JsonSerializable
         $enumConstants = [];
         foreach ($constants as $name => $value) {
             // Check if constant name follows uppercase snake_case pattern
-            if (!preg_match('/^[A-Z][A-Z0-9_]*$/', $name)) {
+            if (!\preg_match('/^[A-Z][A-Z0-9_]*$/', $name)) {
                 throw new RuntimeException(
                     sprintf(
                         'Invalid enum constant name "%s" in %s. Constants must be UPPER_SNAKE_CASE.',
@@ -297,14 +300,14 @@ abstract class AbstractEnum implements JsonSerializable
             }
 
             // Check if value is valid type
-            if (!is_string($value)) {
+            if (!\is_string($value)) {
                 throw new RuntimeException(
                     sprintf(
                         'Invalid enum value type for constant %s::%s. ' .
                         'Only string values are allowed, %s given.',
                         $className,
                         $name,
-                        gettype($value)
+                        \gettype($value)
                     )
                 );
             }
@@ -328,8 +331,8 @@ abstract class AbstractEnum implements JsonSerializable
     final public function __call(string $name, array $arguments): bool
     {
         // Handle is* methods
-        if (str_starts_with($name, 'is')) {
-            $constantName = self::camelCaseToConstant(substr($name, 2));
+        if (\str_starts_with($name, 'is')) {
+            $constantName = self::camelCaseToConstant(\substr($name, 2));
             $constants = static::getConstants();
 
             if (isset($constants[$constantName])) {
@@ -376,7 +379,7 @@ abstract class AbstractEnum implements JsonSerializable
      */
     private static function camelCaseToConstant(string $camelCase): string
     {
-        $snakeCase = preg_replace('/([a-z])([A-Z])/', '$1_$2', $camelCase);
+        $snakeCase = \preg_replace('/([a-z])([A-Z])/', '$1_$2', $camelCase);
         if ($snakeCase === null) {
             return strtoupper($camelCase);
         }

--- a/src/Common/Traits/WithDataCachingTrait.php
+++ b/src/Common/Traits/WithDataCachingTrait.php
@@ -63,7 +63,7 @@ trait WithDataCachingTrait
             return $cache->has($fullKey);
         }
 
-        return array_key_exists($fullKey, $this->localCache);
+        return \array_key_exists($fullKey, $this->localCache);
     }
 
     /**

--- a/src/Files/DTO/File.php
+++ b/src/Files/DTO/File.php
@@ -10,6 +10,9 @@ use WordPress\AiClient\Common\Exception\RuntimeException;
 use WordPress\AiClient\Files\Enums\FileTypeEnum;
 use WordPress\AiClient\Files\ValueObjects\MimeType;
 
+use function preg_match;
+use function sprintf;
+
 /**
  * Represents a file in the AI client.
  *
@@ -101,7 +104,7 @@ class File extends AbstractDataTransferObject
         }
 
         // Check if it's a local file path (before base64 check)
-        if (file_exists($file) && is_file($file)) {
+        if (\file_exists($file) && \is_file($file)) {
             $this->fileType = FileTypeEnum::inline();
             $this->base64Data = $this->convertFileToBase64($file);
             $this->mimeType = $this->determineMimeType($providedMimeType, null, $file);
@@ -136,7 +139,7 @@ class File extends AbstractDataTransferObject
      */
     private function isUrl(string $string): bool
     {
-        return filter_var($string, FILTER_VALIDATE_URL) !== false
+        return \filter_var($string, \FILTER_VALIDATE_URL) !== false
             && preg_match('/^https?:\/\//i', $string);
     }
 
@@ -151,7 +154,7 @@ class File extends AbstractDataTransferObject
      */
     private function convertFileToBase64(string $filePath): string
     {
-        $fileContent = @file_get_contents($filePath);
+        $fileContent = @\file_get_contents($filePath);
 
         if ($fileContent === false) {
             throw new RuntimeException(
@@ -159,7 +162,7 @@ class File extends AbstractDataTransferObject
             );
         }
 
-        return base64_encode($fileContent);
+        return \base64_encode($fileContent);
     }
 
     /**
@@ -364,16 +367,16 @@ class File extends AbstractDataTransferObject
 
         // Try to determine from file extension
         if ($pathOrUrl !== null) {
-            $parsedUrl = parse_url($pathOrUrl);
+            $parsedUrl = \parse_url($pathOrUrl);
             $path = $parsedUrl['path'] ?? $pathOrUrl;
 
             // Remove query string and fragment if present
-            $cleanPath = strtok($path, '?#');
+            $cleanPath = \strtok($path, '?#');
             if ($cleanPath === false) {
                 $cleanPath = $path;
             }
 
-            $extension = pathinfo($cleanPath, PATHINFO_EXTENSION);
+            $extension = \pathinfo($cleanPath, \PATHINFO_EXTENSION);
             if (!empty($extension)) {
                 try {
                     return MimeType::fromExtension($extension);

--- a/src/Files/ValueObjects/MimeType.php
+++ b/src/Files/ValueObjects/MimeType.php
@@ -6,6 +6,9 @@ namespace WordPress\AiClient\Files\ValueObjects;
 
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 
+use function sprintf;
+use function strtolower;
+
 /**
  * Value object representing a MIME type.
  *
@@ -142,7 +145,7 @@ final class MimeType
     public function toExtension(): string
     {
         // Reverse lookup for the MIME type to find the extension.
-        $extension = array_search($this->value, self::$extensionMap, true);
+        $extension = \array_search($this->value, self::$extensionMap, true);
         if ($extension === false) {
             throw new InvalidArgumentException(
                 sprintf('No known extension for MIME type: %s', $this->value)
@@ -185,7 +188,7 @@ final class MimeType
     public static function isValid(string $mimeType): bool
     {
         // Basic MIME type validation: type/subtype
-        return (bool) preg_match(
+        return (bool) \preg_match(
             '/^[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+.]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-\^_+.]*$/',
             $mimeType
         );
@@ -204,7 +207,7 @@ final class MimeType
      */
     public function isType(string $mimeType): bool
     {
-        return str_starts_with($this->value, strtolower($mimeType) . '/');
+        return \str_starts_with($this->value, strtolower($mimeType) . '/');
     }
 
     /**
@@ -264,7 +267,7 @@ final class MimeType
      */
     public function isDocument(): bool
     {
-        return in_array($this->value, self::$documentTypes, true);
+        return \in_array($this->value, self::$documentTypes, true);
     }
 
     /**
@@ -282,12 +285,12 @@ final class MimeType
             return $this->value === $other->value;
         }
 
-        if (is_string($other)) {
+        if (\is_string($other)) {
             return $this->value === strtolower($other);
         }
 
         throw new InvalidArgumentException(
-            sprintf('Invalid MIME type comparison: %s', gettype($other))
+            sprintf('Invalid MIME type comparison: %s', \gettype($other))
         );
     }
 

--- a/src/Messages/DTO/Message.php
+++ b/src/Messages/DTO/Message.php
@@ -8,6 +8,8 @@ use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 
+use function array_map;
+
 /**
  * Represents a message in an AI conversation.
  *

--- a/src/Messages/DTO/MessagePart.php
+++ b/src/Messages/DTO/MessagePart.php
@@ -97,7 +97,7 @@ class MessagePart extends AbstractDataTransferObject
         $this->channel = $channel ?? MessagePartChannelEnum::content();
         $this->thoughtSignature = $thoughtSignature;
 
-        if (is_string($content)) {
+        if (\is_string($content)) {
             $this->type = MessagePartTypeEnum::text();
             $this->text = $content;
         } elseif ($content instanceof File) {
@@ -110,9 +110,9 @@ class MessagePart extends AbstractDataTransferObject
             $this->type = MessagePartTypeEnum::functionResponse();
             $this->functionResponse = $content;
         } else {
-            $type = is_object($content) ? get_class($content) : gettype($content);
+            $type = \is_object($content) ? \get_class($content) : \gettype($content);
             throw new InvalidArgumentException(
-                sprintf(
+                \sprintf(
                     'Unsupported content type %s. Expected string, File, '
                     . 'FunctionCall, or FunctionResponse.',
                     $type

--- a/src/Messages/Util/ModalityCombinationsUtil.php
+++ b/src/Messages/Util/ModalityCombinationsUtil.php
@@ -33,7 +33,7 @@ class ModalityCombinationsUtil
     public static function buildCombinations(array $required, array $optional): array
     {
         $combinations = [];
-        $count        = count($optional);
+        $count        = \count($optional);
         $subsetCount  = 1 << $count; // 2^count.
 
         for ($i = 0; $i < $subsetCount; $i++) {

--- a/src/Providers/ApiBasedImplementation/AbstractApiBasedModelMetadataDirectory.php
+++ b/src/Providers/ApiBasedImplementation/AbstractApiBasedModelMetadataDirectory.php
@@ -47,7 +47,7 @@ abstract class AbstractApiBasedModelMetadataDirectory implements
     final public function listModelMetadata(): array
     {
         $modelsMetadata = $this->getModelMetadataMap();
-        return array_values($modelsMetadata);
+        return \array_values($modelsMetadata);
     }
 
     /**
@@ -71,7 +71,7 @@ abstract class AbstractApiBasedModelMetadataDirectory implements
         $modelsMetadata = $this->getModelMetadataMap();
         if (!isset($modelsMetadata[$modelId])) {
             throw new InvalidArgumentException(
-                sprintf('No model with ID %s was found in the provider', $modelId)
+                \sprintf('No model with ID %s was found in the provider', $modelId)
             );
         }
         return $modelsMetadata[$modelId];
@@ -111,7 +111,7 @@ abstract class AbstractApiBasedModelMetadataDirectory implements
      */
     protected function getBaseCacheKey(): string
     {
-        return 'ai_client_' . AiClient::VERSION . '_' . md5(static::class);
+        return 'ai_client_' . AiClient::VERSION . '_' . \md5(static::class);
     }
 
     /**

--- a/src/Providers/ApiBasedImplementation/AbstractApiProvider.php
+++ b/src/Providers/ApiBasedImplementation/AbstractApiProvider.php
@@ -48,6 +48,6 @@ abstract class AbstractApiProvider extends AbstractProvider
             return static::baseUrl();
         }
 
-        return static::baseUrl() . '/' . ltrim($path, '/');
+        return static::baseUrl() . '/' . \ltrim($path, '/');
     }
 }

--- a/src/Providers/DTO/ProviderMetadata.php
+++ b/src/Providers/DTO/ProviderMetadata.php
@@ -101,9 +101,9 @@ class ProviderMetadata extends AbstractDataTransferObject
         ?string $description = null,
         ?string $logoPath = null
     ) {
-        if (!preg_match('/^[a-z0-9\-_]+$/', $id)) {
+        if (!\preg_match('/^[a-z0-9\-_]+$/', $id)) {
             throw new InvalidArgumentException(
-                sprintf(
+                \sprintf(
                     // phpcs:ignore Generic.Files.LineLength.TooLong
                     'Invalid provider ID "%s". Only lowercase alphanumeric characters, hyphens, and underscores are allowed.',
                     $id
@@ -239,7 +239,7 @@ class ProviderMetadata extends AbstractDataTransferObject
                 ],
                 self::KEY_AUTHENTICATION_METHOD => [
                     'type' => ['string', 'null'],
-                    'enum' => array_merge(RequestAuthenticationMethod::getValues(), [null]),
+                    'enum' => \array_merge(RequestAuthenticationMethod::getValues(), [null]),
                     'description' => 'The authentication method.',
                 ],
                 self::KEY_LOGO_PATH => [

--- a/src/Providers/DTO/ProviderModelsMetadata.php
+++ b/src/Providers/DTO/ProviderModelsMetadata.php
@@ -8,6 +8,8 @@ use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 
+use function array_map;
+
 /**
  * Represents metadata about a provider and its available models.
  *
@@ -53,7 +55,7 @@ class ProviderModelsMetadata extends AbstractDataTransferObject
      */
     public function __construct(ProviderMetadata $provider, array $models)
     {
-        if (!array_is_list($models)) {
+        if (!\array_is_list($models)) {
             throw new InvalidArgumentException('Models must be a list array.');
         }
 

--- a/src/Providers/Http/Abstracts/AbstractClientDiscoveryStrategy.php
+++ b/src/Providers/Http/Abstracts/AbstractClientDiscoveryStrategy.php
@@ -30,7 +30,7 @@ abstract class AbstractClientDiscoveryStrategy implements DiscoveryStrategy
      */
     public static function init(): void
     {
-        if (!class_exists('\Http\Discovery\Psr18ClientDiscovery')) {
+        if (!\class_exists('\Http\Discovery\Psr18ClientDiscovery')) {
             return;
         }
 
@@ -67,7 +67,7 @@ abstract class AbstractClientDiscoveryStrategy implements DiscoveryStrategy
             'Psr\Http\Message\UriFactoryInterface',
         ];
 
-        if (in_array($type, $psr17Factories, true)) {
+        if (\in_array($type, $psr17Factories, true)) {
             return [
                 [
                     'class' => Psr17Factory::class,

--- a/src/Providers/Http/Collections/HeadersCollection.php
+++ b/src/Providers/Http/Collections/HeadersCollection.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace WordPress\AiClient\Providers\Http\Collections;
 
+use function strtolower;
+
 /**
  * Simple collection for managing HTTP headers with case-insensitive access.
  *
@@ -80,7 +82,7 @@ class HeadersCollection
     public function getAsString(string $name): ?string
     {
         $values = $this->get($name);
-        return $values !== null ? implode(', ', $values) : null;
+        return $values !== null ? \implode(', ', $values) : null;
     }
 
     /**
@@ -107,11 +109,11 @@ class HeadersCollection
      */
     private function set(string $name, $value): void
     {
-        if (is_array($value)) {
-            $normalizedValues = array_values($value);
+        if (\is_array($value)) {
+            $normalizedValues = \array_values($value);
         } else {
             // Split comma-separated string into array
-            $normalizedValues = array_map('trim', explode(',', $value));
+            $normalizedValues = \array_map('trim', \explode(',', $value));
         }
         $lowerName = strtolower($name);
 

--- a/src/Providers/Http/DTO/Request.php
+++ b/src/Providers/Http/DTO/Request.php
@@ -11,6 +11,10 @@ use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Providers\Http\Collections\HeadersCollection;
 use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
 
+use function http_build_query;
+use function is_array;
+use function is_string;
+
 /**
  * Represents an HTTP request.
  *
@@ -153,7 +157,7 @@ class Request extends AbstractDataTransferObject
     {
         // If GET request with data, append as query parameters
         if ($this->method === HttpMethodEnum::GET() && $this->data !== null && !empty($this->data)) {
-            $separator = str_contains($this->uri, '?') ? '&' : '?';
+            $separator = \str_contains($this->uri, '?') ? '&' : '?';
             return $this->uri . $separator . http_build_query($this->data);
         }
 
@@ -242,8 +246,8 @@ class Request extends AbstractDataTransferObject
             $contentType = $this->getContentType();
 
             // JSON encoding
-            if ($contentType !== null && stripos($contentType, 'application/json') !== false) {
-                return json_encode($this->data, JSON_THROW_ON_ERROR);
+            if ($contentType !== null && \stripos($contentType, 'application/json') !== false) {
+                return \json_encode($this->data, \JSON_THROW_ON_ERROR);
             }
 
             // Default to URL encoding for forms

--- a/src/Providers/Http/DTO/RequestOptions.php
+++ b/src/Providers/Http/DTO/RequestOptions.php
@@ -247,7 +247,7 @@ class RequestOptions extends AbstractDataTransferObject
     {
         if ($value !== null && $value < 0) {
             throw new InvalidArgumentException(
-                sprintf('Request option "%s" must be greater than or equal to 0.', $fieldName)
+                \sprintf('Request option "%s" must be greater than or equal to 0.', $fieldName)
             );
         }
     }

--- a/src/Providers/Http/DTO/Response.php
+++ b/src/Providers/Http/DTO/Response.php
@@ -185,14 +185,14 @@ class Response extends AbstractDataTransferObject
             return null;
         }
 
-        $data = json_decode($this->body, true);
+        $data = \json_decode($this->body, true);
 
-        if (json_last_error() !== JSON_ERROR_NONE) {
+        if (\json_last_error() !== \JSON_ERROR_NONE) {
             return null;
         }
 
         /** @var array<string, mixed>|null $data */
-        return is_array($data) ? $data : null;
+        return \is_array($data) ? $data : null;
     }
 
     /**

--- a/src/Providers/Http/Enums/HttpMethodEnum.php
+++ b/src/Providers/Http/Enums/HttpMethodEnum.php
@@ -6,6 +6,8 @@ namespace WordPress\AiClient\Providers\Http\Enums;
 
 use WordPress\AiClient\Common\AbstractEnum;
 
+use function in_array;
+
 /**
  * Represents HTTP request methods.
  *

--- a/src/Providers/Http/Exception/ClientException.php
+++ b/src/Providers/Http/Exception/ClientException.php
@@ -9,6 +9,8 @@ use WordPress\AiClient\Providers\Http\DTO\Request;
 use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Http\Util\ErrorMessageExtractor;
 
+use function sprintf;
+
 /**
  * Exception thrown for 4xx HTTP client errors.
  *

--- a/src/Providers/Http/Exception/NetworkException.php
+++ b/src/Providers/Http/Exception/NetworkException.php
@@ -57,7 +57,7 @@ class NetworkException extends RuntimeException
     public static function fromPsr18NetworkException(RequestInterface $psrRequest, \Throwable $networkException): self
     {
         $request = Request::fromPsrRequest($psrRequest);
-        $message = sprintf(
+        $message = \sprintf(
             'Network error occurred while sending request to %s: %s',
             $request->getUri(),
             $networkException->getMessage()

--- a/src/Providers/Http/Exception/RedirectException.php
+++ b/src/Providers/Http/Exception/RedirectException.php
@@ -7,6 +7,8 @@ namespace WordPress\AiClient\Providers\Http\Exception;
 use WordPress\AiClient\Common\Exception\RuntimeException;
 use WordPress\AiClient\Providers\Http\DTO\Response;
 
+use function sprintf;
+
 /**
  * Exception thrown for 3xx HTTP redirect responses.
  *

--- a/src/Providers/Http/Exception/ResponseException.php
+++ b/src/Providers/Http/Exception/ResponseException.php
@@ -6,6 +6,8 @@ namespace WordPress\AiClient\Providers\Http\Exception;
 
 use WordPress\AiClient\Common\Exception\RuntimeException;
 
+use function sprintf;
+
 /**
  * Exception class for HTTP response errors.
  *

--- a/src/Providers/Http/Exception/ServerException.php
+++ b/src/Providers/Http/Exception/ServerException.php
@@ -8,6 +8,8 @@ use WordPress\AiClient\Common\Exception\RuntimeException;
 use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Http\Util\ErrorMessageExtractor;
 
+use function sprintf;
+
 /**
  * Exception thrown for 5xx HTTP server errors.
  *

--- a/src/Providers/Http/HttpTransporter.php
+++ b/src/Providers/Http/HttpTransporter.php
@@ -91,7 +91,7 @@ class HttpTransporter implements HttpTransporterInterface
         } catch (\Psr\Http\Client\ClientExceptionInterface $e) {
             // Handle other PSR-18 client exceptions that are not network-related
             throw new RuntimeException(
-                sprintf(
+                \sprintf(
                     'HTTP client error occurred while sending request to %s: %s',
                     $request->getUri(),
                     $e->getMessage()
@@ -173,7 +173,7 @@ class HttpTransporter implements HttpTransporterInterface
     {
         $reflection = new \ReflectionObject($client);
 
-        if (!is_callable([$client, 'send'])) {
+        if (!\is_callable([$client, 'send'])) {
             return false;
         }
 
@@ -189,7 +189,7 @@ class HttpTransporter implements HttpTransporterInterface
 
         $parameters = $method->getParameters();
 
-        if (count($parameters) < 2) {
+        if (\count($parameters) < 2) {
             return false;
         }
 
@@ -198,7 +198,7 @@ class HttpTransporter implements HttpTransporterInterface
             return false;
         }
 
-        if (!is_a($firstParameter->getName(), RequestInterface::class, true)) {
+        if (!\is_a($firstParameter->getName(), RequestInterface::class, true)) {
             return false;
         }
 

--- a/src/Providers/Http/Util/ErrorMessageExtractor.php
+++ b/src/Providers/Http/Util/ErrorMessageExtractor.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace WordPress\AiClient\Providers\Http\Util;
 
+use function is_array;
+use function is_string;
+
 /**
  * Utility for extracting error messages from API response data.
  *

--- a/src/Providers/Http/Util/ResponseUtil.php
+++ b/src/Providers/Http/Util/ResponseUtil.php
@@ -58,7 +58,7 @@ class ResponseUtil
         }
 
         throw new \RuntimeException(
-            sprintf('Response returned invalid status code: %s', $response->getStatusCode())
+            \sprintf('Response returned invalid status code: %s', $response->getStatusCode())
         );
     }
 }

--- a/src/Providers/ModelResolver.php
+++ b/src/Providers/ModelResolver.php
@@ -12,6 +12,10 @@ use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 use WordPress\AiClient\Providers\Models\DTO\ModelRequirements;
 
+use function is_string;
+use function reset;
+use function sprintf;
+
 /**
  * Resolves the concrete AI model to use based on selection preferences.
  *
@@ -124,9 +128,9 @@ class ModelResolver
         $preferenceKeys = [];
 
         foreach ($preferredModels as $preferredModel) {
-            if (is_array($preferredModel)) {
+            if (\is_array($preferredModel)) {
                 // [model identifier, provider ID] tuple
-                if (!array_is_list($preferredModel) || count($preferredModel) !== 2) {
+                if (!\array_is_list($preferredModel) || \count($preferredModel) !== 2) {
                     throw new InvalidArgumentException(
                         'Model preference tuple must contain model identifier and provider ID.'
                     );
@@ -277,14 +281,14 @@ class ModelResolver
         // Check if any preferred models match the candidates, in priority order.
         if (!empty($this->modelPreferenceKeys)) {
             // Find preferences that match available candidates, preserving preference order.
-            $matchingPreferences = array_intersect_key(
-                array_flip($this->modelPreferenceKeys),
+            $matchingPreferences = \array_intersect_key(
+                \array_flip($this->modelPreferenceKeys),
                 $candidateMap
             );
 
             if (!empty($matchingPreferences)) {
                 // Get the first matching preference key
-                $firstMatchKey = key($matchingPreferences);
+                $firstMatchKey = \key($matchingPreferences);
                 [$providerId, $modelId] = $candidateMap[$firstMatchKey];
 
                 $model = $this->registry->getProviderModel($providerId, $modelId, $modelConfig);
@@ -428,7 +432,7 @@ class ModelResolver
             throw new InvalidArgumentException($emptyMessage);
         }
 
-        $trimmed = trim($value);
+        $trimmed = \trim($value);
         if ($trimmed === '') {
             throw new InvalidArgumentException($emptyMessage);
         }

--- a/src/Providers/Models/DTO/ModelConfig.php
+++ b/src/Providers/Models/DTO/ModelConfig.php
@@ -12,6 +12,9 @@ use WordPress\AiClient\Messages\Enums\ModalityEnum;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 use WordPress\AiClient\Tools\DTO\WebSearch;
 
+use function array_is_list;
+use function array_map;
+
 /**
  * Represents configuration for an AI model.
  *
@@ -698,7 +701,7 @@ class ModelConfig extends AbstractDataTransferObject
      */
     public function setOutputMediaAspectRatio(string $outputMediaAspectRatio): void
     {
-        if (!preg_match('/^\d+:\d+$/', $outputMediaAspectRatio)) {
+        if (!\preg_match('/^\d+:\d+$/', $outputMediaAspectRatio)) {
             throw new InvalidArgumentException(
                 'Output media aspect ratio must be in the format "width:height" (e.g. 3:2, 16:9).'
             );
@@ -736,7 +739,7 @@ class ModelConfig extends AbstractDataTransferObject
         MediaOrientationEnum $orientation,
         string $aspectRatio
     ): void {
-        $aspectRatioParts = explode(':', $aspectRatio);
+        $aspectRatioParts = \explode(':', $aspectRatio);
         if ($orientation->isSquare() && $aspectRatioParts[0] !== $aspectRatioParts[1]) {
             throw new InvalidArgumentException(
                 'The aspect ratio "' . $aspectRatio . '" is not compatible with the square orientation.'

--- a/src/Providers/Models/DTO/ModelMetadata.php
+++ b/src/Providers/Models/DTO/ModelMetadata.php
@@ -8,6 +8,9 @@ use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 
+use function array_is_list;
+use function array_map;
+
 /**
  * Represents metadata about an AI model.
  *

--- a/src/Providers/Models/DTO/ModelRequirements.php
+++ b/src/Providers/Models/DTO/ModelRequirements.php
@@ -12,6 +12,13 @@ use WordPress\AiClient\Messages\Enums\ModalityEnum;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 use WordPress\AiClient\Providers\Models\Enums\OptionEnum;
 
+use function array_is_list;
+use function array_map;
+use function array_unique;
+use function array_values;
+
+use const SORT_REGULAR;
+
 /**
  * Represents requirements that implementing code has for AI model selection.
  *
@@ -155,7 +162,7 @@ class ModelRequirements extends AbstractDataTransferObject
         $inputModalities = [];
 
         // Check if we have chat history (multiple messages)
-        if (count($messages) > 1) {
+        if (\count($messages) > 1) {
             $capabilities[] = CapabilityEnum::chatHistory();
         }
 

--- a/src/Providers/Models/DTO/SupportedOption.php
+++ b/src/Providers/Models/DTO/SupportedOption.php
@@ -9,6 +9,8 @@ use WordPress\AiClient\Common\AbstractEnum;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Providers\Models\Enums\OptionEnum;
 
+use function is_array;
+
 /**
  * Represents a supported configuration option for an AI model.
  *
@@ -51,7 +53,7 @@ class SupportedOption extends AbstractDataTransferObject
      */
     public function __construct(OptionEnum $name, ?array $supportedValues = null)
     {
-        if ($supportedValues !== null && !array_is_list($supportedValues)) {
+        if ($supportedValues !== null && !\array_is_list($supportedValues)) {
             throw new InvalidArgumentException('Supported values must be a list array.');
         }
 
@@ -144,8 +146,8 @@ class SupportedOption extends AbstractDataTransferObject
      */
     private static function normalizeArrayForComparison(array $items): array
     {
-        $normalized = array_map([self::class, 'normalizeValue'], $items);
-        sort($normalized);
+        $normalized = \array_map([self::class, 'normalizeValue'], $items);
+        \sort($normalized);
         return $normalized;
     }
 

--- a/src/Providers/Models/Enums/OptionEnum.php
+++ b/src/Providers/Models/Enums/OptionEnum.php
@@ -99,13 +99,13 @@ class OptionEnum extends AbstractEnum
 
         // Add ModelConfig constants that start with KEY_
         foreach ($modelConfigConstants as $constantName => $constantValue) {
-            if (str_starts_with($constantName, 'KEY_')) {
+            if (\str_starts_with($constantName, 'KEY_')) {
                 // Remove KEY_ prefix to get the enum constant name
-                $enumConstantName = substr($constantName, 4);
+                $enumConstantName = \substr($constantName, 4);
 
                 // The value is the snake_case version stored in ModelConfig
                 // ModelConfig already stores these as snake_case strings
-                if (is_string($constantValue)) {
+                if (\is_string($constantValue)) {
                     $constants[$enumConstantName] = $constantValue;
                 }
             }

--- a/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleImageGenerationModel.php
+++ b/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleImageGenerationModel.php
@@ -23,6 +23,9 @@ use WordPress\AiClient\Results\DTO\GenerativeAiResult;
 use WordPress\AiClient\Results\DTO\TokenUsage;
 use WordPress\AiClient\Results\Enums\FinishReasonEnum;
 
+use function is_array;
+use function is_string;
+
 /**
  * Base class for an image generation model for providers that implement OpenAI's API format.
  *
@@ -125,7 +128,7 @@ abstract class AbstractOpenAiCompatibleImageGenerationModel extends AbstractApiB
 
         $outputMimeType = $config->getOutputMimeType();
         if ($outputMimeType !== null) {
-            $params['output_format'] = preg_replace('/^image\//', '', $outputMimeType);
+            $params['output_format'] = \preg_replace('/^image\//', '', $outputMimeType);
         }
 
         $outputMediaOrientation = $config->getOutputMediaOrientation();
@@ -142,7 +145,7 @@ abstract class AbstractOpenAiCompatibleImageGenerationModel extends AbstractApiB
         foreach ($customOptions as $key => $value) {
             if (isset($params[$key])) {
                 throw new InvalidArgumentException(
-                    sprintf(
+                    \sprintf(
                         'The custom option "%s" conflicts with an existing parameter.',
                         $key
                     )
@@ -166,7 +169,7 @@ abstract class AbstractOpenAiCompatibleImageGenerationModel extends AbstractApiB
      */
     protected function preparePromptParam(array $messages): string
     {
-        if (count($messages) !== 1) {
+        if (\count($messages) !== 1) {
             throw new InvalidArgumentException(
                 'The API requires a single user message as prompt.'
             );
@@ -304,7 +307,7 @@ abstract class AbstractOpenAiCompatibleImageGenerationModel extends AbstractApiB
 
         $candidates = [];
         foreach ($responseData['data'] as $index => $choiceData) {
-            if (!is_array($choiceData) || array_is_list($choiceData)) {
+            if (!is_array($choiceData) || \array_is_list($choiceData)) {
                 throw ResponseException::fromInvalidData(
                     $this->providerMetadata()->getName(),
                     "data[{$index}]",

--- a/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
+++ b/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
@@ -25,6 +25,16 @@ use WordPress\AiClient\Results\Enums\FinishReasonEnum;
 use WordPress\AiClient\Tools\DTO\FunctionCall;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 
+use function array_filter;
+use function array_is_list;
+use function array_map;
+use function array_values;
+use function count;
+use function is_array;
+use function is_string;
+use function json_encode;
+use function sprintf;
+
 /**
  * Base class for a text generation model for providers that implement OpenAI's API format.
  *
@@ -247,7 +257,7 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
         );
 
         if ($systemInstruction) {
-            array_unshift(
+            \array_unshift(
                 $messagesParam,
                 [
                     /*
@@ -766,7 +776,7 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
         }
 
         $functionArguments = is_string($toolCallData['function']['arguments'])
-            ? json_decode($toolCallData['function']['arguments'], true)
+            ? \json_decode($toolCallData['function']['arguments'], true)
             : $toolCallData['function']['arguments'];
 
         $functionCall = new FunctionCall(

--- a/src/Providers/ProviderRegistry.php
+++ b/src/Providers/ProviderRegistry.php
@@ -22,6 +22,14 @@ use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 use WordPress\AiClient\Providers\Models\DTO\ModelRequirements;
 
+use function get_class;
+use function is_array;
+use function is_subclass_of;
+use function preg_replace;
+use function sprintf;
+use function str_replace;
+use function strtoupper;
+
 /**
  * Registry for managing AI providers and their models.
  *
@@ -63,7 +71,7 @@ class ProviderRegistry implements WithHttpTransporterInterface
      */
     public function registerProvider(string $className): void
     {
-        if (!class_exists($className)) {
+        if (!\class_exists($className)) {
             throw new InvalidArgumentException(
                 sprintf('Provider class does not exist: %s', $className)
             );
@@ -136,7 +144,7 @@ class ProviderRegistry implements WithHttpTransporterInterface
      */
     public function getRegisteredProviderIds(): array
     {
-        return array_keys($this->registeredIdsToClassNames);
+        return \array_keys($this->registeredIdsToClassNames);
     }
 
     /**
@@ -540,13 +548,13 @@ class ProviderRegistry implements WithHttpTransporterInterface
                 $envVarName = $this->getEnvVarName($providerId, $property);
 
                 // Try to get the value from environment variable or constant.
-                $envValue = getenv($envVarName);
+                $envValue = \getenv($envVarName);
                 if ($envValue === false) {
-                    if (!defined($envVarName)) {
+                    if (!\defined($envVarName)) {
                         continue; // Skip if neither environment variable nor constant is defined.
                     }
-                    $envValue = constant($envVarName);
-                    if (!is_scalar($envValue)) {
+                    $envValue = \constant($envVarName);
+                    if (!\is_scalar($envValue)) {
                         continue;
                     }
                 }
@@ -554,7 +562,7 @@ class ProviderRegistry implements WithHttpTransporterInterface
                 if (isset($details['type'])) {
                     switch ($details['type']) {
                         case 'boolean':
-                            $authenticationData[$property] = filter_var($envValue, FILTER_VALIDATE_BOOLEAN);
+                            $authenticationData[$property] = \filter_var($envValue, \FILTER_VALIDATE_BOOLEAN);
                             break;
                         case 'number':
                             $authenticationData[$property] = (int) $envValue;
@@ -573,7 +581,7 @@ class ProviderRegistry implements WithHttpTransporterInterface
             if (isset($authenticationSchema['required']) && is_array($authenticationSchema['required'])) {
                 /** @var list<string> $requiredProperties */
                 $requiredProperties = $authenticationSchema['required'];
-                if (array_diff_key(array_flip($requiredProperties), $authenticationData)) {
+                if (\array_diff_key(\array_flip($requiredProperties), $authenticationData)) {
                     return null;
                 }
             }

--- a/src/Results/DTO/Embedding.php
+++ b/src/Results/DTO/Embedding.php
@@ -11,6 +11,8 @@ use JsonSerializable;
 use Traversable;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 
+use function array_is_list;
+
 /**
  * Represents a single generated embedding vector.
  *
@@ -54,7 +56,7 @@ final class Embedding implements Countable, IteratorAggregate, JsonSerializable
             throw new InvalidArgumentException('Embedding values must be integers or floats.');
         }
 
-        if (count($values) !== $dimensions) {
+        if (\count($values) !== $dimensions) {
             throw new InvalidArgumentException('Embedding vector length must match dimensions.');
         }
 
@@ -74,12 +76,12 @@ final class Embedding implements Countable, IteratorAggregate, JsonSerializable
      */
     private static function isEmbeddingList($values): bool
     {
-        if (!is_array($values) || !array_is_list($values)) {
+        if (!\is_array($values) || !array_is_list($values)) {
             return false;
         }
 
         foreach ($values as $value) {
-            if (!is_int($value) && !is_float($value)) {
+            if (!\is_int($value) && !\is_float($value)) {
                 return false;
             }
         }

--- a/src/Results/DTO/EmbeddingResult.php
+++ b/src/Results/DTO/EmbeddingResult.php
@@ -270,7 +270,7 @@ class EmbeddingResult extends AbstractDataTransferObject implements ResultInterf
     {
         $data = [
             self::KEY_ID => $this->id,
-            self::KEY_EMBEDDINGS => array_map(
+            self::KEY_EMBEDDINGS => \array_map(
                 static fn (Embedding $embedding): array => $embedding->toArray(),
                 $this->embeddings
             ),

--- a/src/Results/DTO/GenerativeAiResult.php
+++ b/src/Results/DTO/GenerativeAiResult.php
@@ -13,6 +13,11 @@ use WordPress\AiClient\Providers\DTO\ProviderMetadata;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 use WordPress\AiClient\Results\Contracts\ResultInterface;
 
+use function array_filter;
+use function array_map;
+use function array_values;
+use function sprintf;
+
 /**
  * Represents the result of a generative AI operation.
  *
@@ -183,7 +188,7 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
      */
     public function getCandidateCount(): int
     {
-        return count($this->candidates);
+        return \count($this->candidates);
     }
 
     /**

--- a/tests/integration/Anthropic/FunctionCallingIntegrationTest.php
+++ b/tests/integration/Anthropic/FunctionCallingIntegrationTest.php
@@ -14,6 +14,8 @@ use WordPress\AiClient\Tools\DTO\FunctionCall;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 use WordPress\AiClient\Tools\DTO\FunctionResponse;
 
+use function stripos;
+
 /**
  * Integration tests for Anthropic function calling.
  *

--- a/tests/integration/Google/FunctionCallingIntegrationTest.php
+++ b/tests/integration/Google/FunctionCallingIntegrationTest.php
@@ -14,6 +14,8 @@ use WordPress\AiClient\Tools\DTO\FunctionCall;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 use WordPress\AiClient\Tools\DTO\FunctionResponse;
 
+use function stripos;
+
 /**
  * Integration tests for Google function calling.
  *

--- a/tests/integration/OpenAi/EmbeddingGenerationIntegrationTest.php
+++ b/tests/integration/OpenAi/EmbeddingGenerationIntegrationTest.php
@@ -10,6 +10,8 @@ use WordPress\AiClient\Results\DTO\Embedding;
 use WordPress\AiClient\Results\DTO\EmbeddingResult;
 use WordPress\AiClient\Tests\integration\traits\IntegrationTestTrait;
 
+use function count;
+
 /**
  * Integration tests for OpenAI embedding generation.
  *

--- a/tests/integration/OpenAi/FunctionCallingIntegrationTest.php
+++ b/tests/integration/OpenAi/FunctionCallingIntegrationTest.php
@@ -14,6 +14,8 @@ use WordPress\AiClient\Tools\DTO\FunctionCall;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 use WordPress\AiClient\Tools\DTO\FunctionResponse;
 
+use function stripos;
+
 /**
  * Integration tests for OpenAI function calling.
  *

--- a/tests/integration/traits/IntegrationTestTrait.php
+++ b/tests/integration/traits/IntegrationTestTrait.php
@@ -20,7 +20,7 @@ trait IntegrationTestTrait
     protected function requireApiKey(string $envVar): void
     {
         // Check both $_ENV (populated by symfony/dotenv) and getenv() (shell environment)
-        $value = $_ENV[$envVar] ?? getenv($envVar);
+        $value = $_ENV[$envVar] ?? \getenv($envVar);
         if ($value === false || $value === '' || $value === null) {
             $this->markTestSkipped("Skipping: {$envVar} environment variable is not set.");
         }

--- a/tests/mocks/MockCache.php
+++ b/tests/mocks/MockCache.php
@@ -132,7 +132,7 @@ class MockCache implements CacheInterface
     public function has($key): bool
     {
         $this->operations[] = ['operation' => 'has', 'key' => $key];
-        return array_key_exists($key, $this->cache);
+        return \array_key_exists($key, $this->cache);
     }
 
     /**
@@ -153,7 +153,7 @@ class MockCache implements CacheInterface
      */
     public function getOperationsOfType(string $operation): array
     {
-        return array_values(array_filter(
+        return \array_values(\array_filter(
             $this->operations,
             static function (array $op) use ($operation): bool {
                 return $op['operation'] === $operation;

--- a/tests/mocks/MockEventDispatcher.php
+++ b/tests/mocks/MockEventDispatcher.php
@@ -34,7 +34,7 @@ class MockEventDispatcher implements EventDispatcherInterface
     {
         $this->dispatchedEvents[] = $event;
 
-        $eventClass = get_class($event);
+        $eventClass = \get_class($event);
         if (isset($this->listeners[$eventClass])) {
             foreach ($this->listeners[$eventClass] as $listener) {
                 $listener($event);
@@ -78,7 +78,7 @@ class MockEventDispatcher implements EventDispatcherInterface
      */
     public function getDispatchedEventsOfType(string $eventClass): array
     {
-        return array_values(array_filter(
+        return \array_values(\array_filter(
             $this->dispatchedEvents,
             static function (object $event) use ($eventClass): bool {
                 return $event instanceof $eventClass;

--- a/tests/mocks/MockModelMetadataDirectory.php
+++ b/tests/mocks/MockModelMetadataDirectory.php
@@ -43,7 +43,7 @@ class MockModelMetadataDirectory implements
      */
     public function listModelMetadata(): array
     {
-        return array_values($this->models);
+        return \array_values($this->models);
     }
 
     /**
@@ -61,7 +61,7 @@ class MockModelMetadataDirectory implements
     {
         if (!isset($this->models[$modelId])) {
             throw new InvalidArgumentException(
-                sprintf('Model not found: %s', $modelId)
+                \sprintf('Model not found: %s', $modelId)
             );
         }
 

--- a/tests/traits/ArrayTransformationTestTrait.php
+++ b/tests/traits/ArrayTransformationTestTrait.php
@@ -51,7 +51,7 @@ trait ArrayTransformationTestTrait
     protected function assertArrayRoundTrip($original, callable $assertCallback): void
     {
         $array = $original->toArray();
-        $className = get_class($original);
+        $className = \get_class($original);
         $restored = $className::fromArray($array);
 
         $this->assertInstanceOf($className, $restored, 'fromArray() should return instance of ' . $className);

--- a/tests/traits/EnumTestTrait.php
+++ b/tests/traits/EnumTestTrait.php
@@ -7,6 +7,8 @@ namespace WordPress\AiClient\Tests\traits;
 use BadMethodCallException;
 use WordPress\AiClient\Common\AbstractEnum;
 
+use function reset;
+
 /**
  * Trait for testing enum classes.
  */
@@ -37,7 +39,7 @@ trait EnumTestTrait
         $actualValues = $enumClass::getValues();
 
         // Since getValues() now returns just the values, we need to extract values from expected
-        $expectedValuesList = array_values($expectedValues);
+        $expectedValuesList = \array_values($expectedValues);
 
         $this->assertEquals($expectedValuesList, $actualValues);
     }
@@ -52,7 +54,7 @@ trait EnumTestTrait
 
         $cases = $enumClass::cases();
 
-        $this->assertCount(count($expectedValues), $cases);
+        $this->assertCount(\count($expectedValues), $cases);
 
         foreach ($cases as $case) {
             $this->assertInstanceOf($enumClass, $case);

--- a/tests/traits/MockModelCreationTrait.php
+++ b/tests/traits/MockModelCreationTrait.php
@@ -103,7 +103,7 @@ trait MockModelCreationTrait
         return new EmbeddingResult(
             'test-embedding-result-id',
             $embeddings,
-            count($embeddings[0]),
+            \count($embeddings[0]),
             new TokenUsage(10, 0, 10),
             $providerMetadata,
             $modelMetadata

--- a/tests/unit/AiClientTest.php
+++ b/tests/unit/AiClientTest.php
@@ -208,7 +208,7 @@ class AiClientTest extends TestCase
 
         $embeddings = AiClient::generateEmbeddings(['First prompt', 'Second prompt'], $mockModel, $registry);
 
-        $this->assertSame($expectedEmbeddings, array_map(
+        $this->assertSame($expectedEmbeddings, \array_map(
             static fn ($embedding): array => $embedding->getValues(),
             $embeddings
         ));

--- a/tests/unit/Builders/EmbeddingBuilderTest.php
+++ b/tests/unit/Builders/EmbeddingBuilderTest.php
@@ -126,7 +126,7 @@ class EmbeddingBuilderTest extends TestCase
         $builder = new EmbeddingBuilder($this->registry, ['First input', 'Second input']);
         $builder->usingModel($model);
 
-        $this->assertSame($embeddings, array_map(
+        $this->assertSame($embeddings, \array_map(
             static fn ($embedding): array => $embedding->getValues(),
             $builder->generateEmbeddings()
         ));

--- a/tests/unit/Common/AbstractDataTransferObjectTest.php
+++ b/tests/unit/Common/AbstractDataTransferObjectTest.php
@@ -11,6 +11,8 @@ use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Common\Contracts\WithArrayTransformationInterface;
 use WordPress\AiClient\Common\Contracts\WithJsonSchemaInterface;
 
+use function json_encode;
+
 /**
  * Tests for the AbstractDataTransferObject class.
  *
@@ -97,7 +99,7 @@ class AbstractDataTransferObjectTest extends TestCase
         // Verify JSON encoding produces correct output
         $json = json_encode($result);
         $this->assertIsString($json);
-        $decoded = json_decode($json, true);
+        $decoded = \json_decode($json, true);
 
         // In JSON, empty object should be {} not []
         $this->assertStringContainsString('"emptyObject":{}', $json);

--- a/tests/unit/Common/AbstractEnumTest.php
+++ b/tests/unit/Common/AbstractEnumTest.php
@@ -12,6 +12,8 @@ use WordPress\AiClient\Tests\mocks\Enums\InvalidNameTestEnum;
 use WordPress\AiClient\Tests\mocks\Enums\InvalidTypeTestEnum;
 use WordPress\AiClient\Tests\mocks\Enums\ValidTestEnum;
 
+use function array_map;
+
 /**
  * @covers \WordPress\AiClient\Common\AbstractEnum
  */

--- a/tests/unit/Exceptions/ExceptionsTest.php
+++ b/tests/unit/Exceptions/ExceptionsTest.php
@@ -14,6 +14,8 @@ use WordPress\AiClient\Providers\Http\Exception\ClientException;
 use WordPress\AiClient\Providers\Http\Exception\NetworkException;
 use WordPress\AiClient\Providers\Http\Exception\ServerException;
 
+use function json_encode;
+
 /**
  * Tests for AI Client exceptions.
  *

--- a/tests/unit/Files/DTO/FileTest.php
+++ b/tests/unit/Files/DTO/FileTest.php
@@ -11,6 +11,11 @@ use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Files\Enums\FileTypeEnum;
 use WordPress\AiClient\Files\ValueObjects\MimeType;
 
+use function file_put_contents;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
 /**
  * @covers \WordPress\AiClient\Files\DTO\File
  */
@@ -142,7 +147,7 @@ class FileTest extends TestCase
 
             $this->assertEquals(FileTypeEnum::inline(), $file->getFileType());
             $this->assertNull($file->getUrl());
-            $this->assertEquals(base64_encode('Hello World'), $file->getBase64Data());
+            $this->assertEquals(\base64_encode('Hello World'), $file->getBase64Data());
             $this->assertEquals('text/plain', $file->getMimeType());
         } finally {
             unlink($tempFile);
@@ -183,8 +188,8 @@ class FileTest extends TestCase
     public function testDirectoryThrowsException(): void
     {
         // Create a directory instead of a file
-        $tempDir = sys_get_temp_dir() . '/test_dir_' . uniqid();
-        mkdir($tempDir);
+        $tempDir = sys_get_temp_dir() . '/test_dir_' . \uniqid();
+        \mkdir($tempDir);
 
         try {
             $this->expectException(InvalidArgumentException::class);
@@ -194,7 +199,7 @@ class FileTest extends TestCase
 
             new File($tempDir, 'text/plain');
         } finally {
-            rmdir($tempDir);
+            \rmdir($tempDir);
         }
     }
 

--- a/tests/unit/Messages/DTO/MessagePartTest.php
+++ b/tests/unit/Messages/DTO/MessagePartTest.php
@@ -118,7 +118,7 @@ class MessagePartTest extends TestCase
     public function testUnsupportedContentThrowsException($content, string $expectedType): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf(
+        $this->expectExceptionMessage(\sprintf(
             'Unsupported content type %s. Expected string, File, FunctionCall, or FunctionResponse.',
             $expectedType
         ));

--- a/tests/unit/Messages/DTO/MessageTest.php
+++ b/tests/unit/Messages/DTO/MessageTest.php
@@ -351,7 +351,7 @@ class MessageTest extends TestCase
         $restored = Message::fromArray($json);
 
         $this->assertEquals($original->getRole()->value, $restored->getRole()->value);
-        $this->assertCount(count($original->getParts()), $restored->getParts());
+        $this->assertCount(\count($original->getParts()), $restored->getParts());
         $this->assertEquals($original->getParts()[0]->getText(), $restored->getParts()[0]->getText());
         $this->assertEquals(
             $original->getParts()[1]->getFile()->getUrl(),

--- a/tests/unit/Messages/DTO/ModelMessageTest.php
+++ b/tests/unit/Messages/DTO/ModelMessageTest.php
@@ -180,7 +180,7 @@ class ModelMessageTest extends TestCase
             ]),
             function ($original, $restored) {
                 $this->assertEquals($original->getRole()->value, $restored->getRole()->value);
-                $this->assertCount(count($original->getParts()), $restored->getParts());
+                $this->assertCount(\count($original->getParts()), $restored->getParts());
                 $this->assertEquals(
                     $original->getParts()[0]->getText(),
                     $restored->getParts()[0]->getText()

--- a/tests/unit/Messages/DTO/UserMessageTest.php
+++ b/tests/unit/Messages/DTO/UserMessageTest.php
@@ -288,7 +288,7 @@ class UserMessageTest extends TestCase
             ]),
             function ($original, $restored) {
                 $this->assertEquals($original->getRole()->value, $restored->getRole()->value);
-                $this->assertCount(count($original->getParts()), $restored->getParts());
+                $this->assertCount(\count($original->getParts()), $restored->getParts());
                 $this->assertEquals(
                     $original->getParts()[0]->getText(),
                     $restored->getParts()[0]->getText()

--- a/tests/unit/Messages/Util/ModalityCombinationsUtilTest.php
+++ b/tests/unit/Messages/Util/ModalityCombinationsUtilTest.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\TestCase;
 use WordPress\AiClient\Messages\Enums\ModalityEnum;
 use WordPress\AiClient\Messages\Util\ModalityCombinationsUtil;
 
+use function array_map;
+use function count;
+
 /**
  * @covers \WordPress\AiClient\Messages\Util\ModalityCombinationsUtil
  */
@@ -96,13 +99,13 @@ class ModalityCombinationsUtilTest extends TestCase
                     },
                     $combo
                 );
-                sort($values);
-                return implode(',', $values);
+                \sort($values);
+                return \implode(',', $values);
             },
             $combinations
         );
 
-        $this->assertCount(count($normalised), array_unique($normalised));
+        $this->assertCount(count($normalised), \array_unique($normalised));
     }
 
     /**
@@ -153,10 +156,10 @@ class ModalityCombinationsUtilTest extends TestCase
 
         foreach ($optional as $modality) {
             $appearances = count(
-                array_filter(
+                \array_filter(
                     $combinations,
                     static function (array $combo) use ($modality): bool {
-                        return in_array($modality, $combo, true);
+                        return \in_array($modality, $combo, true);
                     }
                 )
             );
@@ -164,7 +167,7 @@ class ModalityCombinationsUtilTest extends TestCase
             $this->assertSame(
                 (int) $expectedAppearances,
                 $appearances,
-                sprintf('Modality "%s" should appear in exactly half the combinations.', $modality->value)
+                \sprintf('Modality "%s" should appear in exactly half the combinations.', $modality->value)
             );
         }
     }

--- a/tests/unit/Providers/DTO/ProviderMetadataTest.php
+++ b/tests/unit/Providers/DTO/ProviderMetadataTest.php
@@ -234,8 +234,8 @@ class ProviderMetadataTest extends TestCase
     public function testJsonSerialize(): void
     {
         $metadata = new ProviderMetadata('json-provider', 'JSON Provider', ProviderTypeEnum::cloud());
-        $json = json_encode($metadata);
-        $decoded = json_decode($json, true);
+        $json = \json_encode($metadata);
+        $decoded = \json_decode($json, true);
 
         $this->assertIsString($json);
         $this->assertIsArray($decoded);

--- a/tests/unit/Providers/DTO/ProviderModelsMetadataTest.php
+++ b/tests/unit/Providers/DTO/ProviderModelsMetadataTest.php
@@ -16,6 +16,8 @@ use WordPress\AiClient\Providers\Models\DTO\SupportedOption;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 use WordPress\AiClient\Providers\Models\Enums\OptionEnum;
 
+use function count;
+
 /**
  * @covers \WordPress\AiClient\Providers\DTO\ProviderModelsMetadata
  */
@@ -263,8 +265,8 @@ class ProviderModelsMetadataTest extends TestCase
             [$this->createModelMetadata('json-model', 'JSON Model')]
         );
 
-        $json = json_encode($metadata);
-        $decoded = json_decode($json, true);
+        $json = \json_encode($metadata);
+        $decoded = \json_decode($json, true);
 
         $this->assertIsString($json);
         $this->assertIsArray($decoded);
@@ -346,7 +348,10 @@ class ProviderModelsMetadataTest extends TestCase
         // Ensure models array has numeric keys starting from 0
         $this->assertArrayHasKey(0, $array[ProviderModelsMetadata::KEY_MODELS]);
         $this->assertArrayHasKey(1, $array[ProviderModelsMetadata::KEY_MODELS]);
-        $this->assertEquals(['models' => array_keys($array[ProviderModelsMetadata::KEY_MODELS])], ['models' => [0, 1]]);
+        $this->assertEquals(
+            ['models' => \array_keys($array[ProviderModelsMetadata::KEY_MODELS])],
+            ['models' => [0, 1]]
+        );
     }
 
     /**

--- a/tests/unit/Providers/Models/DTO/ModelConfigTest.php
+++ b/tests/unit/Providers/Models/DTO/ModelConfigTest.php
@@ -16,6 +16,8 @@ use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 use WordPress\AiClient\Tools\DTO\WebSearch;
 
+use function array_keys;
+
 /**
  * @covers \WordPress\AiClient\Providers\Models\DTO\ModelConfig
  */
@@ -521,8 +523,8 @@ class ModelConfigTest extends TestCase
         $config->setMaxTokens(1000);
         $config->setSystemInstruction('JSON test');
 
-        $json = json_encode($config);
-        $decoded = json_decode($json, true);
+        $json = \json_encode($config);
+        $decoded = \json_decode($json, true);
 
         $this->assertIsString($json);
         $this->assertIsArray($decoded);

--- a/tests/unit/Providers/Models/DTO/ModelMetadataTest.php
+++ b/tests/unit/Providers/Models/DTO/ModelMetadataTest.php
@@ -13,6 +13,9 @@ use WordPress\AiClient\Providers\Models\DTO\SupportedOption;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 use WordPress\AiClient\Providers\Models\Enums\OptionEnum;
 
+use function array_keys;
+use function count;
+
 /**
  * @covers \WordPress\AiClient\Providers\Models\DTO\ModelMetadata
  */
@@ -270,8 +273,8 @@ class ModelMetadataTest extends TestCase
             [new SupportedOption(OptionEnum::outputSchema(), [256, 512, 1024])]
         );
 
-        $json = json_encode($metadata);
-        $decoded = json_decode($json, true);
+        $json = \json_encode($metadata);
+        $decoded = \json_decode($json, true);
 
         $this->assertIsString($json);
         $this->assertIsArray($decoded);
@@ -320,7 +323,7 @@ class ModelMetadataTest extends TestCase
         $this->assertCount(count($allCapabilities), $array[ModelMetadata::KEY_SUPPORTED_CAPABILITIES]);
 
         // Verify all capabilities are preserved
-        $expectedValues = array_map(function ($cap) {
+        $expectedValues = \array_map(function ($cap) {
             return $cap->value;
         }, $allCapabilities);
         $this->assertEquals($expectedValues, $array[ModelMetadata::KEY_SUPPORTED_CAPABILITIES]);

--- a/tests/unit/Providers/Models/DTO/ModelRequirementsTest.php
+++ b/tests/unit/Providers/Models/DTO/ModelRequirementsTest.php
@@ -20,6 +20,11 @@ use WordPress\AiClient\Providers\Models\DTO\SupportedOption;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 use WordPress\AiClient\Providers\Models\Enums\OptionEnum;
 
+use function array_filter;
+use function array_keys;
+use function array_values;
+use function count;
+
 /**
  * @covers \WordPress\AiClient\Providers\Models\DTO\ModelRequirements
  */
@@ -234,8 +239,8 @@ class ModelRequirementsTest extends TestCase
             [new RequiredOption(OptionEnum::outputSchema(), 1536)]
         );
 
-        $json = json_encode($requirements);
-        $decoded = json_decode($json, true);
+        $json = \json_encode($requirements);
+        $decoded = \json_decode($json, true);
 
         $this->assertIsString($json);
         $this->assertIsArray($decoded);
@@ -273,7 +278,7 @@ class ModelRequirementsTest extends TestCase
         $this->assertCount(count($allCapabilities), $array[ModelRequirements::KEY_REQUIRED_CAPABILITIES]);
 
         // Verify all capabilities are preserved with correct values
-        $expectedValues = array_map(function ($cap) {
+        $expectedValues = \array_map(function ($cap) {
             return $cap->value;
         }, $allCapabilities);
         $this->assertEquals($expectedValues, $array[ModelRequirements::KEY_REQUIRED_CAPABILITIES]);

--- a/tests/unit/Providers/Models/DTO/RequiredOptionTest.php
+++ b/tests/unit/Providers/Models/DTO/RequiredOptionTest.php
@@ -160,7 +160,7 @@ class RequiredOptionTest extends TestCase
         $this->assertCount(6, $schema['properties'][RequiredOption::KEY_VALUE]['oneOf']);
 
         // Verify all allowed types
-        $types = array_map(function ($item) {
+        $types = \array_map(function ($item) {
             return $item['type'];
         }, $schema['properties'][RequiredOption::KEY_VALUE]['oneOf']);
         $this->assertContains('string', $types);
@@ -326,8 +326,8 @@ class RequiredOptionTest extends TestCase
     {
         $option = new RequiredOption(OptionEnum::outputSchema(), ['enabled' => true, 'count' => 5]);
 
-        $json = json_encode($option);
-        $decoded = json_decode($json, true);
+        $json = \json_encode($option);
+        $decoded = \json_decode($json, true);
 
         $this->assertIsString($json);
         $this->assertIsArray($decoded);

--- a/tests/unit/Providers/Models/DTO/SupportedOptionTest.php
+++ b/tests/unit/Providers/Models/DTO/SupportedOptionTest.php
@@ -12,6 +12,11 @@ use WordPress\AiClient\Messages\Enums\ModalityEnum;
 use WordPress\AiClient\Providers\Models\DTO\SupportedOption;
 use WordPress\AiClient\Providers\Models\Enums\OptionEnum;
 
+use function json_decode;
+use function json_encode;
+use function serialize;
+use function unserialize;
+
 /**
  * @covers \WordPress\AiClient\Providers\Models\DTO\SupportedOption
  */
@@ -191,7 +196,7 @@ class SupportedOptionTest extends TestCase
         $this->assertArrayHasKey('oneOf', $schema['properties'][SupportedOption::KEY_SUPPORTED_VALUES]['items']);
 
         // Verify all allowed types in items
-        $types = array_map(function ($item) {
+        $types = \array_map(function ($item) {
             return $item['type'];
         }, $schema['properties'][SupportedOption::KEY_SUPPORTED_VALUES]['items']['oneOf']);
         $this->assertContains('string', $types);
@@ -378,7 +383,7 @@ class SupportedOptionTest extends TestCase
         $array = $option->toArray();
 
         // Ensure supportedValues array has numeric keys starting from 0
-        $this->assertEquals([0, 1, 2], array_keys($array[SupportedOption::KEY_SUPPORTED_VALUES]));
+        $this->assertEquals([0, 1, 2], \array_keys($array[SupportedOption::KEY_SUPPORTED_VALUES]));
     }
 
     /**

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleImageGenerationModelTest.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleImageGenerationModelTest.php
@@ -25,6 +25,8 @@ use WordPress\AiClient\Results\DTO\GenerativeAiResult;
 use WordPress\AiClient\Results\Enums\FinishReasonEnum;
 use WordPress\AiClient\Tests\mocks\MockOpenAiCompatibleImageGenerationModel;
 
+use function json_encode;
+
 /**
  * @covers \WordPress\AiClient\Providers\OpenAiCompatibleImplementation\AbstractOpenAiCompatibleImageGenerationModel
  */

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleModelMetadataDirectoryTest.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleModelMetadataDirectoryTest.php
@@ -13,6 +13,8 @@ use WordPress\AiClient\Providers\Http\Exception\ClientException;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 use WordPress\AiClient\Tests\mocks\MockCache;
 
+use function md5;
+
 /**
  * @covers \WordPress\AiClient\Providers\OpenAiCompatibleImplementation\AbstractOpenAiCompatibleModelMetadataDirectory
  */

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
@@ -27,6 +27,8 @@ use WordPress\AiClient\Tools\DTO\FunctionCall;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 use WordPress\AiClient\Tools\DTO\FunctionResponse;
 
+use function json_encode;
+
 /**
  * @covers \WordPress\AiClient\Providers\OpenAiCompatibleImplementation\AbstractOpenAiCompatibleTextGenerationModel
  */
@@ -1156,7 +1158,7 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
 
         $this->expectException(ResponseException::class);
         $this->expectExceptionMessage(
-            sprintf(
+            \sprintf(
                 'Unexpected TestProvider API response: Invalid "%s" key: Invalid finish reason "unknown".',
                 'choices[0].finish_reason'
             )

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/MockOpenAiCompatibleModelMetadataDirectory.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/MockOpenAiCompatibleModelMetadataDirectory.php
@@ -101,9 +101,9 @@ class MockOpenAiCompatibleModelMetadataDirectory extends AbstractOpenAiCompatibl
     {
         $data = $response->getData();
         $modelsMetadata = [];
-        if (isset($data['data']) && is_array($data['data'])) {
+        if (isset($data['data']) && \is_array($data['data'])) {
             foreach ($data['data'] as $modelData) {
-                if (isset($modelData['id']) && is_string($modelData['id'])) {
+                if (isset($modelData['id']) && \is_string($modelData['id'])) {
                     if ($this->useRealModelMetadata) {
                         $modelsMetadata[] = $this->createRealModelMetadata($modelData['id']);
                     } elseif ($this->modelMetadataStubFactory !== null) {
@@ -126,7 +126,7 @@ class MockOpenAiCompatibleModelMetadataDirectory extends AbstractOpenAiCompatibl
     {
         return new ModelMetadata(
             $modelId,
-            ucfirst($modelId),
+            \ucfirst($modelId),
             [CapabilityEnum::textGeneration()],
             []
         );

--- a/tests/unit/Providers/ProviderRegistryTest.php
+++ b/tests/unit/Providers/ProviderRegistryTest.php
@@ -21,6 +21,8 @@ use WordPress\AiClient\Tests\mocks\MockNoAuthProvider;
 use WordPress\AiClient\Tests\mocks\MockProvider;
 use WordPress\AiClient\Tests\mocks\MockProviderAvailability;
 
+use function putenv;
+
 /**
  * @covers \WordPress\AiClient\Providers\ProviderRegistry
  */

--- a/tests/unit/Results/DTO/CandidateTest.php
+++ b/tests/unit/Results/DTO/CandidateTest.php
@@ -360,7 +360,7 @@ class CandidateTest extends TestCase
             function ($original, $restored) {
                 $this->assertEquals($original->getFinishReason()->value, $restored->getFinishReason()->value);
                 $this->assertCount(
-                    count($original->getMessage()->getParts()),
+                    \count($original->getMessage()->getParts()),
                     $restored->getMessage()->getParts()
                 );
                 $this->assertEquals(

--- a/tests/unit/Results/DTO/EmbeddingTest.php
+++ b/tests/unit/Results/DTO/EmbeddingTest.php
@@ -19,7 +19,7 @@ class EmbeddingTest extends TestCase
 
         $this->assertSame([0.1, 1, 0.3], $embedding->getValues());
         $this->assertSame(3, $embedding->getDimensions());
-        $this->assertSame(3, count($embedding));
+        $this->assertSame(3, \count($embedding));
         $this->assertSame([0.1, 1, 0.3], $embedding->toArray());
         $this->assertSame([0.1, 1, 0.3], $embedding->jsonSerialize());
     }

--- a/tests/unit/Results/DTO/GenerativeAiResultTest.php
+++ b/tests/unit/Results/DTO/GenerativeAiResultTest.php
@@ -882,7 +882,7 @@ class GenerativeAiResultTest extends TestCase
             ),
             function ($original, $restored) {
                 $this->assertEquals($original->getId(), $restored->getId());
-                $this->assertCount(count($original->getCandidates()), $restored->getCandidates());
+                $this->assertCount(\count($original->getCandidates()), $restored->getCandidates());
                 $this->assertEquals(
                     $original->getTokenUsage()->getTotalTokens(),
                     $restored->getTokenUsage()->getTotalTokens()


### PR DESCRIPTION
## Why

Performance. Inside a namespace, PHP resolves an unqualified function or constant name by looking in the current namespace first and only then falling back to the global one. That fallback is a runtime lookup on every single call, and it also stops opcache from substituting its optimized handlers for common built-ins like `sprintf()`, `count()`, and `is_array()`. Qualifying the reference lets it resolve at compile time instead.

## What

Normalizes `src/` and `tests/` so no global function or constant is reached via the fallback. Per file:

- Referenced **once** → leading backslash, e.g. `\gettype($value)`
- Referenced **twice or more** → `use function` / `use const` import, call sites left bare

Applied with a `token_get_all()`-based transform rather than regex, so method calls, `new`/`instanceof`, type declarations, `catch` blocks, and class constants are correctly skipped. Only functions PHP reports as internal were touched.

## Notes

- **Classes needed no changes.** PHP has no global fallback for class names, so a global class must already be imported or fully qualified for the code to run at all. This is a functions-and-constants change only.
- `cli.php` and `src/polyfills.php` are in the global namespace and are untouched.
- Adds `SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly` to `phpcs.xml.dist` to prevent regressions. It fails on any fallback reference and accepts both approved forms. It does **not** enforce the once-vs-multiple split — no stock sniff has a usage-count threshold — so that part is documented in `AGENTS.md` as a convention for reviewers.
- One line in `ProviderModelsMetadataTest.php` was wrapped after the added `\` pushed it past 120 chars.

## Testing

- `composer phpcs` clean across 207 files; `phpcbf` reports no violations, so the new rule is stable rather than merely satisfied
- `composer phpstan` no errors
- `composer test:unit` 1164 tests, 4260 assertions passing
- Integration tests not run (billable live API calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
