### PR TITLE
docs: explain the HTTP client adapter requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ While this project is stewarded by [WordPress AI Team](https://make.wordpress.or
 composer require wordpress/php-ai-client
 ```
 
+### HTTP client adapter
+
+The client uses [HTTPlug](https://httplug.io/) and PSR-18 for HTTP transport. Composer installs the abstraction, but your application must also provide a compatible HTTP client adapter before sending requests. Choose an adapter that fits your application:
+
+```bash
+# cURL adapter
+composer require php-http/curl-client
+
+# or Guzzle 7 adapter
+composer require php-http/guzzle7-adapter
+```
+
+If no adapter is available, HTTP client discovery will fail when a provider request is created. Install and configure the adapter in the same application where the PHP AI Client runs; a provider package alone does not supply a transport implementation.
+
 ## Code examples
 
 ### Text generation using a specific model

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,8 @@
         "wordpress/openai-ai-provider": "^1.0"
     },
     "suggest": {
+        "php-http/curl-client": "HTTPlug adapter for cURL HTTP requests",
+        "php-http/guzzle7-adapter": "HTTPlug adapter for Guzzle 7 HTTP requests",
         "wordpress/anthropic-ai-provider": "For Anthropic Claude model support",
         "wordpress/google-ai-provider": "For Google Gemini model support",
         "wordpress/openai-ai-provider": "For OpenAI GPT model support"


### PR DESCRIPTION
## Summary

- document the HTTPlug/PSR-18 adapter requirement immediately after installation
- show supported Composer commands for cURL and Guzzle 7 adapters
- add Composer suggestions so the missing transport dependency is visible during installation

Without an adapter, the client cannot discover an HTTP transport when a provider request is created.

## Validation

- `composer validate --no-check-publish --no-interaction`
- `git diff --check`

Fixes #82