### PR TITLE
Allow token usage statistics to be unavailable

### DIFF
--- a/src/Results/Contracts/ResultInterface.php
+++ b/src/Results/Contracts/ResultInterface.php
@@ -32,9 +32,9 @@ interface ResultInterface
      *
      * @since 0.1.0
      *
-     * @return TokenUsage Token usage statistics.
+     * @return TokenUsage|null Token usage statistics, or null when the provider did not supply them.
      */
-    public function getTokenUsage(): TokenUsage;
+    public function getTokenUsage(): ?TokenUsage;
 
     /**
      * Gets the provider metadata.

--- a/src/Results/DTO/GenerativeAiResult.php
+++ b/src/Results/DTO/GenerativeAiResult.php
@@ -29,7 +29,7 @@ use WordPress\AiClient\Results\Contracts\ResultInterface;
  * @phpstan-type GenerativeAiResultArrayShape array{
  *     id: string,
  *     candidates: array<CandidateArrayShape>,
- *     tokenUsage: TokenUsageArrayShape,
+ *     tokenUsage?: TokenUsageArrayShape|null,
  *     providerMetadata: ProviderMetadataArrayShape,
  *     modelMetadata: ModelMetadataArrayShape,
  *     additionalData?: array<string, mixed>
@@ -56,9 +56,9 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
     private array $candidates;
 
     /**
-     * @var TokenUsage Token usage statistics.
+     * @var TokenUsage|null Token usage statistics, or null when not provided.
      */
-    private TokenUsage $tokenUsage;
+    private ?TokenUsage $tokenUsage;
 
     /**
      * @var ProviderMetadata Provider metadata.
@@ -82,7 +82,7 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
      *
      * @param string $id Unique identifier for this result.
      * @param Candidate[] $candidates The generated candidates.
-     * @param TokenUsage $tokenUsage Token usage statistics.
+     * @param TokenUsage|null $tokenUsage Token usage statistics, or null when not provided.
      * @param ProviderMetadata $providerMetadata Provider metadata.
      * @param ModelMetadata $modelMetadata Model metadata.
      * @param array<string, mixed> $additionalData Additional data.
@@ -91,7 +91,7 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
     public function __construct(
         string $id,
         array $candidates,
-        TokenUsage $tokenUsage,
+        ?TokenUsage $tokenUsage,
         ProviderMetadata $providerMetadata,
         ModelMetadata $modelMetadata,
         array $additionalData = []
@@ -135,7 +135,7 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
      *
      * @since 0.1.0
      */
-    public function getTokenUsage(): TokenUsage
+    public function getTokenUsage(): ?TokenUsage
     {
         return $this->tokenUsage;
     }
@@ -446,7 +446,13 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
                     'minItems' => 1,
                     'description' => 'The generated candidates.',
                 ],
-                self::KEY_TOKEN_USAGE => TokenUsage::getJsonSchema(),
+                self::KEY_TOKEN_USAGE => [
+                    'anyOf' => [
+                        TokenUsage::getJsonSchema(),
+                        ['type' => 'null'],
+                    ],
+                    'description' => 'Token usage statistics, when supplied by the provider.',
+                ],
                 self::KEY_PROVIDER_METADATA => ProviderMetadata::getJsonSchema(),
                 self::KEY_MODEL_METADATA => ModelMetadata::getJsonSchema(),
                 self::KEY_ADDITIONAL_DATA => [
@@ -458,7 +464,6 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
             'required' => [
                 self::KEY_ID,
                 self::KEY_CANDIDATES,
-                self::KEY_TOKEN_USAGE,
                 self::KEY_PROVIDER_METADATA,
                 self::KEY_MODEL_METADATA
             ],
@@ -477,7 +482,7 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
         return [
             self::KEY_ID => $this->id,
             self::KEY_CANDIDATES => array_map(fn(Candidate $candidate) => $candidate->toArray(), $this->candidates),
-            self::KEY_TOKEN_USAGE => $this->tokenUsage->toArray(),
+            self::KEY_TOKEN_USAGE => $this->tokenUsage === null ? null : $this->tokenUsage->toArray(),
             self::KEY_PROVIDER_METADATA => $this->providerMetadata->toArray(),
             self::KEY_MODEL_METADATA => $this->modelMetadata->toArray(),
             self::KEY_ADDITIONAL_DATA => $this->additionalData,
@@ -494,7 +499,6 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
         static::validateFromArrayData($array, [
             self::KEY_ID,
             self::KEY_CANDIDATES,
-            self::KEY_TOKEN_USAGE,
             self::KEY_PROVIDER_METADATA,
             self::KEY_MODEL_METADATA
         ]);
@@ -507,7 +511,9 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
         return new self(
             $array[self::KEY_ID],
             $candidates,
-            TokenUsage::fromArray($array[self::KEY_TOKEN_USAGE]),
+            array_key_exists(self::KEY_TOKEN_USAGE, $array) && $array[self::KEY_TOKEN_USAGE] !== null
+                ? TokenUsage::fromArray($array[self::KEY_TOKEN_USAGE])
+                : null,
             ProviderMetadata::fromArray($array[self::KEY_PROVIDER_METADATA]),
             ModelMetadata::fromArray($array[self::KEY_MODEL_METADATA]),
             $array[self::KEY_ADDITIONAL_DATA] ?? []
@@ -529,7 +535,9 @@ class GenerativeAiResult extends AbstractDataTransferObject implements ResultInt
             $clonedCandidates[] = clone $candidate;
         }
         $this->candidates = $clonedCandidates;
-        $this->tokenUsage = clone $this->tokenUsage;
+        if ($this->tokenUsage !== null) {
+            $this->tokenUsage = clone $this->tokenUsage;
+        }
         $this->providerMetadata = clone $this->providerMetadata;
         $this->modelMetadata = clone $this->modelMetadata;
     }

--- a/src/Results/DTO/TokenUsage.php
+++ b/src/Results/DTO/TokenUsage.php
@@ -18,10 +18,10 @@ use WordPress\AiClient\Common\AbstractDataTransferObject;
  * @since 0.1.0
  *
  * @phpstan-type TokenUsageArrayShape array{
- *     promptTokens: int,
- *     completionTokens: int,
- *     totalTokens: int,
- *     thoughtTokens?: int
+ *     promptTokens: int|null,
+ *     completionTokens: int|null,
+ *     totalTokens: int|null,
+ *     thoughtTokens?: int|null
  * }
  *
  * @extends AbstractDataTransferObject<TokenUsageArrayShape>
@@ -33,19 +33,19 @@ class TokenUsage extends AbstractDataTransferObject
     public const KEY_TOTAL_TOKENS = 'totalTokens';
     public const KEY_THOUGHT_TOKENS = 'thoughtTokens';
     /**
-     * @var int Number of tokens in the prompt.
+     * @var int|null Number of tokens in the prompt.
      */
-    private int $promptTokens;
+    private ?int $promptTokens;
 
     /**
-     * @var int Number of tokens in the completion, including any thought tokens.
+     * @var int|null Number of tokens in the completion, including any thought tokens.
      */
-    private int $completionTokens;
+    private ?int $completionTokens;
 
     /**
-     * @var int Total number of tokens used.
+     * @var int|null Total number of tokens used.
      */
-    private int $totalTokens;
+    private ?int $totalTokens;
 
     /**
      * @var int|null Number of tokens used for thinking, as a subset of completion tokens.
@@ -57,13 +57,17 @@ class TokenUsage extends AbstractDataTransferObject
      *
      * @since 0.1.0
      *
-     * @param int $promptTokens Number of tokens in the prompt.
-     * @param int $completionTokens Number of tokens in the completion, including any thought tokens.
-     * @param int $totalTokens Total number of tokens used.
+     * @param int|null $promptTokens Number of tokens in the prompt, or null when not provided.
+     * @param int|null $completionTokens Number of tokens in the completion, or null when not provided.
+     * @param int|null $totalTokens Total number of tokens used, or null when not provided.
      * @param int|null $thoughtTokens Number of tokens used for thinking, as a subset of completion tokens.
      */
-    public function __construct(int $promptTokens, int $completionTokens, int $totalTokens, ?int $thoughtTokens = null)
-    {
+    public function __construct(
+        ?int $promptTokens = null,
+        ?int $completionTokens = null,
+        ?int $totalTokens = null,
+        ?int $thoughtTokens = null
+    ) {
         $this->promptTokens = $promptTokens;
         $this->completionTokens = $completionTokens;
         $this->totalTokens = $totalTokens;
@@ -75,9 +79,9 @@ class TokenUsage extends AbstractDataTransferObject
      *
      * @since 0.1.0
      *
-     * @return int The prompt token count.
+     * @return int|null The prompt token count, or null when not provided.
      */
-    public function getPromptTokens(): int
+    public function getPromptTokens(): ?int
     {
         return $this->promptTokens;
     }
@@ -87,9 +91,9 @@ class TokenUsage extends AbstractDataTransferObject
      *
      * @since 0.1.0
      *
-     * @return int The completion token count.
+     * @return int|null The completion token count, or null when not provided.
      */
-    public function getCompletionTokens(): int
+    public function getCompletionTokens(): ?int
     {
         return $this->completionTokens;
     }
@@ -99,9 +103,9 @@ class TokenUsage extends AbstractDataTransferObject
      *
      * @since 0.1.0
      *
-     * @return int The total token count.
+     * @return int|null The total token count, or null when not provided.
      */
-    public function getTotalTokens(): int
+    public function getTotalTokens(): ?int
     {
         return $this->totalTokens;
     }
@@ -129,15 +133,15 @@ class TokenUsage extends AbstractDataTransferObject
             'type' => 'object',
             'properties' => [
                 self::KEY_PROMPT_TOKENS => [
-                    'type' => 'integer',
+                    'type' => ['integer', 'null'],
                     'description' => 'Number of tokens in the prompt.',
                 ],
                 self::KEY_COMPLETION_TOKENS => [
-                    'type' => 'integer',
+                    'type' => ['integer', 'null'],
                     'description' => 'Number of tokens in the completion, including any thought tokens.',
                 ],
                 self::KEY_TOTAL_TOKENS => [
-                    'type' => 'integer',
+                    'type' => ['integer', 'null'],
                     'description' => 'Total number of tokens used.',
                 ],
                 self::KEY_THOUGHT_TOKENS => [

--- a/tests/unit/Results/DTO/GenerativeAiResultTest.php
+++ b/tests/unit/Results/DTO/GenerativeAiResultTest.php
@@ -87,6 +87,31 @@ class GenerativeAiResultTest extends TestCase
     }
 
     /**
+     * Tests creating a result when the provider does not report token usage.
+     *
+     * @return void
+     */
+    public function testCreateWithoutTokenUsage(): void
+    {
+        $candidate = new Candidate(
+            new ModelMessage([new MessagePart('Response without usage')]),
+            FinishReasonEnum::stop(),
+            1
+        );
+
+        $result = new GenerativeAiResult(
+            'result_without_usage',
+            [$candidate],
+            null,
+            $this->createTestProviderMetadata(),
+            $this->createTestModelMetadata()
+        );
+
+        $this->assertNull($result->getTokenUsage());
+        $this->assertNull($result->toArray()[GenerativeAiResult::KEY_TOKEN_USAGE]);
+    }
+
+    /**
      * Tests creating result with multiple candidates.
      *
      * @return void
@@ -709,7 +734,7 @@ class GenerativeAiResultTest extends TestCase
         $this->assertArrayHasKey('required', $schema);
         $this->assertContains(GenerativeAiResult::KEY_ID, $schema['required']);
         $this->assertContains(GenerativeAiResult::KEY_CANDIDATES, $schema['required']);
-        $this->assertContains(GenerativeAiResult::KEY_TOKEN_USAGE, $schema['required']);
+        $this->assertNotContains(GenerativeAiResult::KEY_TOKEN_USAGE, $schema['required']);
         $this->assertContains(GenerativeAiResult::KEY_PROVIDER_METADATA, $schema['required']);
         $this->assertContains(GenerativeAiResult::KEY_MODEL_METADATA, $schema['required']);
         $this->assertNotContains(GenerativeAiResult::KEY_ADDITIONAL_DATA, $schema['required']);

--- a/tests/unit/Results/DTO/TokenUsageTest.php
+++ b/tests/unit/Results/DTO/TokenUsageTest.php
@@ -43,6 +43,20 @@ class TokenUsageTest extends TestCase
     }
 
     /**
+     * Tests creating TokenUsage when a provider does not report usage.
+     *
+     * @return void
+     */
+    public function testCreateWithoutValues(): void
+    {
+        $tokenUsage = new TokenUsage();
+
+        $this->assertNull($tokenUsage->getPromptTokens());
+        $this->assertNull($tokenUsage->getCompletionTokens());
+        $this->assertNull($tokenUsage->getTotalTokens());
+    }
+
+    /**
      * Tests creating TokenUsage with large values.
      *
      * @return void
@@ -114,9 +128,9 @@ class TokenUsageTest extends TestCase
         $this->assertArrayHasKey(TokenUsage::KEY_TOTAL_TOKENS, $schema['properties']);
 
         // Check each property type
-        $this->assertEquals('integer', $schema['properties'][TokenUsage::KEY_PROMPT_TOKENS]['type']);
-        $this->assertEquals('integer', $schema['properties'][TokenUsage::KEY_COMPLETION_TOKENS]['type']);
-        $this->assertEquals('integer', $schema['properties'][TokenUsage::KEY_TOTAL_TOKENS]['type']);
+        $this->assertEquals(['integer', 'null'], $schema['properties'][TokenUsage::KEY_PROMPT_TOKENS]['type']);
+        $this->assertEquals(['integer', 'null'], $schema['properties'][TokenUsage::KEY_COMPLETION_TOKENS]['type']);
+        $this->assertEquals(['integer', 'null'], $schema['properties'][TokenUsage::KEY_TOTAL_TOKENS]['type']);
 
         // Check descriptions
         $this->assertArrayHasKey('description', $schema['properties'][TokenUsage::KEY_PROMPT_TOKENS]);


### PR DESCRIPTION
Closes #158

Allows providers to omit token usage statistics without manufacturing zero values. TokenUsage fields and accessors now accept null, GenerativeAiResult can carry a null usage object, array and JSON schema transformations preserve the absence, and unit coverage documents the behavior.