### PR TITLE
Add provider hook for preparing function declarations

### DIFF
--- a/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
+++ b/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
@@ -492,6 +492,7 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
     {
         $tools = [];
         foreach ($functionDeclarations as $functionDeclaration) {
+            $functionDeclaration = $this->prepareFunctionDeclarationForRequest($functionDeclaration);
             $tools[] = [
                 'type' => 'function',
                 'function' => $functionDeclaration->toArray(),
@@ -499,6 +500,23 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
         }
 
         return $tools;
+    }
+
+    /**
+     * Prepares a function declaration for the provider request.
+     *
+     * Providers can override this method to adapt a function declaration's
+     * input schema to the compatibility requirements of their API.
+     *
+     * @since n.e.x.t
+     *
+     * @param FunctionDeclaration $functionDeclaration The function declaration.
+     * @return FunctionDeclaration The prepared function declaration.
+     */
+    protected function prepareFunctionDeclarationForRequest(
+        FunctionDeclaration $functionDeclaration
+    ): FunctionDeclaration {
+        return $functionDeclaration;
     }
 
     /**

--- a/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
+++ b/tests/unit/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModelTest.php
@@ -927,6 +927,44 @@ class AbstractOpenAiCompatibleTextGenerationModelTest extends TestCase
     }
 
     /**
+     * Tests that providers can customize function declarations before serialization.
+     *
+     * @return void
+     */
+    public function testPrepareToolsParamAllowsProviderCustomization(): void
+    {
+        $functionDeclaration = new FunctionDeclaration(
+            'original_name',
+            'Description',
+            ['type' => 'object']
+        );
+        $model = new class (
+            $this->modelMetadata,
+            $this->providerMetadata,
+            $this->mockHttpTransporter,
+            $this->mockRequestAuthentication
+        ) extends MockOpenAiCompatibleTextGenerationModel {
+            /**
+             * {@inheritDoc}
+             */
+            protected function prepareFunctionDeclarationForRequest(
+                FunctionDeclaration $functionDeclaration
+            ): FunctionDeclaration {
+                return new FunctionDeclaration(
+                    $functionDeclaration->getName() . '_prepared',
+                    $functionDeclaration->getDescription(),
+                    $functionDeclaration->getParameters()
+                );
+            }
+        };
+
+        $prepared = $model->exposePrepareToolsParam([$functionDeclaration]);
+
+        $this->assertSame('original_name_prepared', $prepared[0]['function']['name']);
+        $this->assertSame(['type' => 'object'], $prepared[0]['function']['parameters']);
+    }
+
+    /**
      * Tests prepareResponseFormatParam() with null schema.
      *
      * @return void


### PR DESCRIPTION
## Summary

- add a protected no-op hook for preparing function declarations before serialization
- invoke the hook from the shared OpenAI-compatible tools path
- add unit coverage proving a provider override can adapt a declaration

Provider APIs accept different subsets of JSON Schema for tool input parameters. This hook lets a provider normalize its own declarations without changing the canonical `FunctionDeclaration` DTO or affecting the default payload.

Fixes #256

## Validation

- `composer test:unit` — 1,165 tests, 4,262 assertions
- `composer lint` — PHPCS and PHPStan pass
- `git diff --check`

## AI assistance disclosure

AI assistance was used for drafting and test scaffolding. The implementation and validation were reviewed before submission.