### PR TITLE
Correct OptionEnum docblocks that describe folded-in values as snake_case

### DIFF
--- a/src/Providers/Models/Enums/OptionEnum.php
+++ b/src/Providers/Models/Enums/OptionEnum.php
@@ -12,9 +12,10 @@ use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
  * Enum for model options.
  *
  * This enum dynamically includes all options from ModelConfig KEY_* constants
- * in addition to the explicitly defined constants below.
+ * in addition to the explicitly defined constants below. Values folded in from
+ * ModelConfig are copied verbatim and are therefore camelCase, not snake_case.
  *
- * Explicitly defined option (not in ModelConfig):
+ * Explicitly defined option (also defined in ModelConfig, which takes precedence):
  * @method static self inputModalities() Creates an instance for INPUT_MODALITIES option.
  * @method bool isInputModalities() Checks if the option is INPUT_MODALITIES.
  *
@@ -71,8 +72,11 @@ class OptionEnum extends AbstractEnum
     /**
      * Input modalities option.
      *
-     * This constant is not in ModelConfig as it's derived from message content,
-     * not configured directly.
+     * Input modalities are derived from message content rather than configured
+     * directly, but ModelConfig still defines KEY_INPUT_MODALITIES for model
+     * discovery. That constant is folded in by
+     * {@see self::determineClassEnumerations()} and takes precedence over this
+     * one, so the effective value of this option is 'inputModalities'.
      */
     public const INPUT_MODALITIES = 'input_modalities';
 
@@ -80,8 +84,11 @@ class OptionEnum extends AbstractEnum
      * Determines the class enumerations by reflecting on class constants.
      *
      * Overrides the parent method to dynamically add constants from ModelConfig
-     * that are prefixed with KEY_. These are transformed to remove the KEY_ prefix
-     * and converted to snake_case values.
+     * that are prefixed with KEY_. The enum constant name is the ModelConfig
+     * constant name without that prefix, while the value is copied from
+     * ModelConfig verbatim and is therefore camelCase. For example,
+     * KEY_FUNCTION_DECLARATIONS becomes FUNCTION_DECLARATIONS with the value
+     * 'functionDeclarations'.
      *
      * @since 0.1.0
      *
@@ -103,8 +110,8 @@ class OptionEnum extends AbstractEnum
                 // Remove KEY_ prefix to get the enum constant name
                 $enumConstantName = substr($constantName, 4);
 
-                // The value is the snake_case version stored in ModelConfig
-                // ModelConfig already stores these as snake_case strings
+                // The value is copied from ModelConfig verbatim, which stores
+                // these as camelCase strings
                 if (is_string($constantValue)) {
                     $constants[$enumConstantName] = $constantValue;
                 }


### PR DESCRIPTION
## Description of the change

`OptionEnum` folds `ModelConfig::KEY_*` constants in via `determineClassEnumerations()`. Four comments in the file state or imply that the resulting **values** are snake_case. They are camelCase, and always have been:

```php
ModelConfig::KEY_FUNCTION_DECLARATIONS = 'functionDeclarations';
ModelConfig::KEY_MAX_TOKENS            = 'maxTokens';
ModelConfig::KEY_OUTPUT_MIME_TYPE      = 'outputMimeType';
```

`determineClassEnumerations()` copies `$constantValue` in verbatim — there is no case transformation anywhere in the method:

```php
if (is_string($constantValue)) {
    $constants[$enumConstantName] = $constantValue;
}
```

The confusion is easy to arrive at honestly, because the enum constant *name* genuinely is upper snake case (`KEY_FUNCTION_DECLARATIONS` → `FUNCTION_DECLARATIONS`); it is only the *value* that is camelCase. This PR makes that name/value distinction explicit rather than leaving it implied.

Verified against `trunk`:

```
OptionEnum::functionDeclarations()  ->  functionDeclarations
OptionEnum::inputModalities()       ->  inputModalities
```

This is a documentation-only change. Every changed line is a comment; no constant, signature or expression is touched.

## Why it matters

These comments are load-bearing for provider authors, who need the option's string value to compare against `ModelMetadata::getSupportedOptions()` or to inspect serialized metadata. Taking the comments at face value produces code that silently never matches.

It has already cost real debugging time twice in the Ollama provider:

- A tool-support bug was initially reported as "the provider never declares `function_declarations`" ([Fueled/ai-provider-for-ollama#93](https://github.com/Fueled/ai-provider-for-ollama/issues/93)). The provider did declare it; a grep for the snake_case string simply could not find it. The real defect turned out to be the opposite of the one reported.
- The fix for that issue ([Fueled/ai-provider-for-ollama#94](https://github.com/Fueled/ai-provider-for-ollama/pull/94)) carries a defensive `option.name === 'function_declarations'` branch in its admin JS, guarding against a value that no released version of this package has ever emitted.

## Changes

`src/Providers/Models/Enums/OptionEnum.php`, four comments:

1. **Class docblock** — notes that folded-in values are camelCase, not snake_case.
2. **`determineClassEnumerations()` docblock** — replaces "converted to snake_case values" with a description that separates the constant name from the value, plus a concrete example.
3. **Inline comments in the fold loop** — "the snake_case version stored in ModelConfig" / "already stores these as snake_case strings" → camelCase.
4. **`INPUT_MODALITIES` docblock** — see below.

## A related inaccuracy, and a possible follow-up

The `INPUT_MODALITIES` docblock claimed:

> This constant is not in ModelConfig as it's derived from message content, not configured directly.

The first half is no longer true. `ModelConfig` does define `KEY_INPUT_MODALITIES = 'inputModalities'` (added deliberately, with its own note explaining it exists for model discovery). Because the fold runs *after* `parent::determineClassEnumerations()` and assigns unconditionally, the ModelConfig value overwrites the locally declared one:

```php
OptionEnum::INPUT_MODALITIES          // 'input_modalities'  (the literal)
(string) OptionEnum::inputModalities() // 'inputModalities'   (what callers actually get)
```

So `INPUT_MODALITIES = 'input_modalities'` is effectively dead — its value never reaches a caller. I have only corrected the docblock here, so this PR stays documentation-only.

Removing the constant looks safe (nothing in `src/` or `tests/` references `OptionEnum::INPUT_MODALITIES`, and `'input_modalities'` appears nowhere else in the package), and `docs/ARCHITECTURE.md:175` mentions it only in prose. But that is a code change with a different review calculus, so I have left it out. Happy to open a separate PR, fold it in here, or drop the idea — whichever you prefer.

## How to test the change

No behaviour to test. To confirm the values the comments now describe:

```bash
php -r 'require "vendor/autoload.php";
use WordPress\AiClient\Providers\Models\Enums\OptionEnum;
echo (string) OptionEnum::functionDeclarations(), "\n";
echo (string) OptionEnum::inputModalities(), "\n";
echo OptionEnum::INPUT_MODALITIES, "\n";'
```

Expected:

```
functionDeclarations
inputModalities
input_modalities
```

`phpcs --standard=PSR12` is clean on the changed file, and `php -l` passes.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Tracing the folded-in values through git history to confirm they were never snake_case, verifying the emitted values at runtime, and drafting these comment corrections. The final wording was reviewed and edited by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
