### PR TITLE
[#281] Add ProviderData for provider-native message parts

### DIFF
--- a/src/Messages/DTO/MessagePart.php
+++ b/src/Messages/DTO/MessagePart.php
@@ -24,6 +24,7 @@ use WordPress\AiClient\Tools\DTO\FunctionResponse;
  * @phpstan-import-type FileArrayShape from File
  * @phpstan-import-type FunctionCallArrayShape from FunctionCall
  * @phpstan-import-type FunctionResponseArrayShape from FunctionResponse
+ * @phpstan-import-type ProviderDataArrayShape from ProviderData
  *
  * @phpstan-type MessagePartArrayShape array{
  *     channel: string,
@@ -32,7 +33,8 @@ use WordPress\AiClient\Tools\DTO\FunctionResponse;
  *     text?: string,
  *     file?: FileArrayShape,
  *     functionCall?: FunctionCallArrayShape,
- *     functionResponse?: FunctionResponseArrayShape
+ *     functionResponse?: FunctionResponseArrayShape,
+ *     providerData?: ProviderDataArrayShape
  * }
  *
  * @extends AbstractDataTransferObject<MessagePartArrayShape>
@@ -46,6 +48,12 @@ class MessagePart extends AbstractDataTransferObject
     public const KEY_FILE = 'file';
     public const KEY_FUNCTION_CALL = 'functionCall';
     public const KEY_FUNCTION_RESPONSE = 'functionResponse';
+
+    /**
+     * @since n.e.x.t
+     * @var string The provider-native data key.
+     */
+    public const KEY_PROVIDER_DATA = 'providerData';
 
     /**
      * @var MessagePartChannelEnum The channel this message part belongs to.
@@ -83,6 +91,12 @@ class MessagePart extends AbstractDataTransferObject
     private ?FunctionResponse $functionResponse = null;
 
     /**
+     * @since n.e.x.t
+     * @var ProviderData|null Opaque provider-native data (when type is PROVIDER_DATA).
+     */
+    private ?ProviderData $providerData = null;
+
+    /**
      * Constructor that accepts various content types and infers the message part type.
      *
      * @since 0.1.0
@@ -109,12 +123,15 @@ class MessagePart extends AbstractDataTransferObject
         } elseif ($content instanceof FunctionResponse) {
             $this->type = MessagePartTypeEnum::functionResponse();
             $this->functionResponse = $content;
+        } elseif ($content instanceof ProviderData) {
+            $this->type = MessagePartTypeEnum::providerData();
+            $this->providerData = $content;
         } else {
             $type = is_object($content) ? get_class($content) : gettype($content);
             throw new InvalidArgumentException(
                 sprintf(
                     'Unsupported content type %s. Expected string, File, '
-                    . 'FunctionCall, or FunctionResponse.',
+                    . 'FunctionCall, FunctionResponse, or ProviderData.',
                     $type
                 )
             );
@@ -206,6 +223,18 @@ class MessagePart extends AbstractDataTransferObject
     }
 
     /**
+     * Gets the opaque provider-native data.
+     *
+     * @since n.e.x.t
+     *
+     * @return ProviderData|null The provider-native data or null if not a provider data part.
+     */
+    public function getProviderData(): ?ProviderData
+    {
+        return $this->providerData;
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @since 0.1.0
@@ -284,6 +313,20 @@ class MessagePart extends AbstractDataTransferObject
                     'required' => [self::KEY_TYPE, self::KEY_FUNCTION_RESPONSE],
                     'additionalProperties' => false,
                 ],
+                [
+                    'type' => 'object',
+                    'properties' => [
+                        self::KEY_CHANNEL => $channelSchema,
+                        self::KEY_TYPE => [
+                            'type' => 'string',
+                            'const' => MessagePartTypeEnum::providerData()->value,
+                        ],
+                        self::KEY_PROVIDER_DATA => ProviderData::getJsonSchema(),
+                        self::KEY_THOUGHT_SIGNATURE => $thoughtSignatureSchema,
+                    ],
+                    'required' => [self::KEY_TYPE, self::KEY_PROVIDER_DATA],
+                    'additionalProperties' => false,
+                ],
             ],
         ];
     }
@@ -310,9 +353,11 @@ class MessagePart extends AbstractDataTransferObject
             $data[self::KEY_FUNCTION_CALL] = $this->functionCall->toArray();
         } elseif ($this->functionResponse !== null) {
             $data[self::KEY_FUNCTION_RESPONSE] = $this->functionResponse->toArray();
+        } elseif ($this->providerData !== null) {
+            $data[self::KEY_PROVIDER_DATA] = $this->providerData->toArray();
         } else {
             throw new RuntimeException(
-                'MessagePart requires one of: text, file, functionCall, or functionResponse. '
+                'MessagePart requires one of: text, file, functionCall, functionResponse, or providerData. '
                 . 'This should not be a possible condition.'
             );
         }
@@ -352,9 +397,11 @@ class MessagePart extends AbstractDataTransferObject
                 $channel,
                 $thoughtSignature
             );
+        } elseif (isset($array[self::KEY_PROVIDER_DATA])) {
+            return new self(ProviderData::fromArray($array[self::KEY_PROVIDER_DATA]), $channel, $thoughtSignature);
         } else {
             throw new InvalidArgumentException(
-                'MessagePart requires one of: text, file, functionCall, or functionResponse.'
+                'MessagePart requires one of: text, file, functionCall, functionResponse, or providerData.'
             );
         }
     }
@@ -362,7 +409,7 @@ class MessagePart extends AbstractDataTransferObject
     /**
      * Performs a deep clone of the message part.
      *
-     * This method ensures that nested objects (file, function call, function response)
+     * This method ensures that nested objects (file, function call, function response, provider data)
      * are cloned to prevent modifications to the cloned part from affecting the original.
      *
      * @since 0.4.2
@@ -377,6 +424,9 @@ class MessagePart extends AbstractDataTransferObject
         }
         if ($this->functionResponse !== null) {
             $this->functionResponse = clone $this->functionResponse;
+        }
+        if ($this->providerData !== null) {
+            $this->providerData = clone $this->providerData;
         }
     }
 }

--- a/src/Messages/DTO/ProviderData.php
+++ b/src/Messages/DTO/ProviderData.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Messages\DTO;
+
+use WordPress\AiClient\Common\AbstractDataTransferObject;
+
+/**
+ * Represents opaque message data that only the originating provider may interpret.
+ *
+ * Providers can use this DTO to preserve native conversation items and replay them
+ * in their original order without adding a core message type for each wire format.
+ * Providers are responsible for checking the provider identifier before replaying
+ * the data; the DTO does not validate or interpret the provider-native payload.
+ *
+ * @since n.e.x.t
+ *
+ * @phpstan-type ProviderDataArrayShape array{
+ *     providerId: string,
+ *     data: array<string, mixed>
+ * }
+ *
+ * @extends AbstractDataTransferObject<ProviderDataArrayShape>
+ */
+class ProviderData extends AbstractDataTransferObject
+{
+    /**
+     * @since n.e.x.t
+     * @var string The provider identifier key.
+     */
+    public const KEY_PROVIDER_ID = 'providerId';
+
+    /**
+     * @since n.e.x.t
+     * @var string The provider-native data key.
+     */
+    public const KEY_DATA = 'data';
+
+    /**
+     * @since n.e.x.t
+     * @var string The identifier of the provider that owns this data.
+     */
+    private string $providerId;
+
+    /**
+     * @since n.e.x.t
+     * @var array<string, mixed> The opaque provider-native data.
+     */
+    private array $data;
+
+    /**
+     * Constructor.
+     *
+     * @since n.e.x.t
+     *
+     * @param string $providerId The identifier of the provider that owns this data.
+     * @param array<string, mixed> $data The opaque provider-native data.
+     */
+    public function __construct(string $providerId, array $data)
+    {
+        $this->providerId = $providerId;
+        $this->data = $data;
+    }
+
+    /**
+     * Gets the identifier of the provider that owns this data.
+     *
+     * @since n.e.x.t
+     *
+     * @return string The provider identifier.
+     */
+    public function getProviderId(): string
+    {
+        return $this->providerId;
+    }
+
+    /**
+     * Gets the opaque provider-native data.
+     *
+     * @since n.e.x.t
+     *
+     * @return array<string, mixed> The provider-native data.
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public static function getJsonSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                self::KEY_PROVIDER_ID => [
+                    'type' => 'string',
+                    'description' => 'The identifier of the provider that owns this data.',
+                ],
+                self::KEY_DATA => [
+                    'type' => 'object',
+                    'additionalProperties' => true,
+                    'description' => 'Opaque provider-native message data.',
+                ],
+            ],
+            'required' => [self::KEY_PROVIDER_ID, self::KEY_DATA],
+            'additionalProperties' => false,
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     *
+     * @return ProviderDataArrayShape The provider-scoped data.
+     */
+    public function toArray(): array
+    {
+        return [
+            self::KEY_PROVIDER_ID => $this->providerId,
+            self::KEY_DATA => $this->data,
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since n.e.x.t
+     */
+    public static function fromArray(array $array): self
+    {
+        static::validateFromArrayData($array, [self::KEY_PROVIDER_ID, self::KEY_DATA]);
+
+        return new self($array[self::KEY_PROVIDER_ID], $array[self::KEY_DATA]);
+    }
+}

--- a/src/Messages/Enums/MessagePartTypeEnum.php
+++ b/src/Messages/Enums/MessagePartTypeEnum.php
@@ -15,10 +15,12 @@ use WordPress\AiClient\Common\AbstractEnum;
  * @method static self file() Creates an instance for FILE type.
  * @method static self functionCall() Creates an instance for FUNCTION_CALL type.
  * @method static self functionResponse() Creates an instance for FUNCTION_RESPONSE type.
+ * @method static self providerData() Creates an instance for PROVIDER_DATA type.
  * @method bool isText() Checks if the type is TEXT.
  * @method bool isFile() Checks if the type is FILE.
  * @method bool isFunctionCall() Checks if the type is FUNCTION_CALL.
  * @method bool isFunctionResponse() Checks if the type is FUNCTION_RESPONSE.
+ * @method bool isProviderData() Checks if the type is PROVIDER_DATA.
  */
 class MessagePartTypeEnum extends AbstractEnum
 {
@@ -41,4 +43,11 @@ class MessagePartTypeEnum extends AbstractEnum
      * Function response.
      */
     public const FUNCTION_RESPONSE = 'function_response';
+
+    /**
+     * Opaque provider-native message data.
+     *
+     * @since n.e.x.t
+     */
+    public const PROVIDER_DATA = 'provider_data';
 }

--- a/tests/unit/Messages/DTO/MessagePartTest.php
+++ b/tests/unit/Messages/DTO/MessagePartTest.php
@@ -8,9 +8,13 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use WordPress\AiClient\Common\Contracts\WithArrayTransformationInterface;
+use WordPress\AiClient\Common\Exception\RuntimeException;
 use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Files\Enums\FileTypeEnum;
+use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\ModelMessage;
+use WordPress\AiClient\Messages\DTO\ProviderData;
 use WordPress\AiClient\Messages\Enums\MessagePartChannelEnum;
 use WordPress\AiClient\Messages\Enums\MessagePartTypeEnum;
 use WordPress\AiClient\Tools\DTO\FunctionCall;
@@ -37,6 +41,7 @@ class MessagePartTest extends TestCase
         $this->assertNull($part->getFile());
         $this->assertNull($part->getFunctionCall());
         $this->assertNull($part->getFunctionResponse());
+        $this->assertNull($part->getProviderData());
     }
 
     /**
@@ -119,7 +124,7 @@ class MessagePartTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(sprintf(
-            'Unsupported content type %s. Expected string, File, FunctionCall, or FunctionResponse.',
+            'Unsupported content type %s. Expected string, File, FunctionCall, FunctionResponse, or ProviderData.',
             $expectedType
         ));
 
@@ -154,7 +159,7 @@ class MessagePartTest extends TestCase
 
         $this->assertIsArray($schema);
         $this->assertArrayHasKey('oneOf', $schema);
-        $this->assertCount(4, $schema['oneOf']); // text, file, function_call, function_response
+        $this->assertCount(5, $schema['oneOf']);
 
         // Check text variant
         $textSchema = $schema['oneOf'][0];
@@ -198,6 +203,22 @@ class MessagePartTest extends TestCase
             [MessagePart::KEY_TYPE, MessagePart::KEY_FUNCTION_RESPONSE],
             $functionResponseSchema['required']
         );
+
+        // Check provider_data variant.
+        $providerDataSchema = $schema['oneOf'][4];
+        $this->assertSame(
+            MessagePartTypeEnum::providerData()->value,
+            $providerDataSchema['properties'][MessagePart::KEY_TYPE]['const']
+        );
+        $this->assertSame(
+            ProviderData::getJsonSchema(),
+            $providerDataSchema['properties'][MessagePart::KEY_PROVIDER_DATA]
+        );
+        $this->assertSame(
+            [MessagePart::KEY_TYPE, MessagePart::KEY_PROVIDER_DATA],
+            $providerDataSchema['required']
+        );
+        $this->assertFalse($providerDataSchema['additionalProperties']);
     }
 
     /**
@@ -278,6 +299,7 @@ class MessagePartTest extends TestCase
         $this->assertArrayNotHasKey(MessagePart::KEY_FILE, $json);
         $this->assertArrayNotHasKey(MessagePart::KEY_FUNCTION_CALL, $json);
         $this->assertArrayNotHasKey(MessagePart::KEY_FUNCTION_RESPONSE, $json);
+        $this->assertArrayNotHasKey(MessagePart::KEY_PROVIDER_DATA, $json);
     }
 
     /**
@@ -485,6 +507,131 @@ class MessagePartTest extends TestCase
         $cloned = clone $original;
 
         $this->assertNotSame($original->getFunctionResponse(), $cloned->getFunctionResponse());
+    }
+
+    /**
+     * Tests creating a non-executable provider data part.
+     *
+     * @return void
+     */
+    public function testCreateWithProviderDataContent(): void
+    {
+        $providerData = new ProviderData('openai', ['type' => 'tool_search_call', 'id' => 'search_123']);
+        $part = new MessagePart($providerData);
+
+        $this->assertTrue($part->getType()->isProviderData());
+        $this->assertTrue($part->getChannel()->isContent());
+        $this->assertSame($providerData, $part->getProviderData());
+        $this->assertNull($part->getText());
+        $this->assertNull($part->getFile());
+        $this->assertNull($part->getFunctionCall());
+        $this->assertNull($part->getFunctionResponse());
+    }
+
+    /**
+     * Tests provider data round trips with channel and thought signature intact.
+     *
+     * @return void
+     */
+    public function testProviderDataRoundTrip(): void
+    {
+        $providerData = new ProviderData('google', ['toolCall' => ['toolType' => 'GOOGLE_SEARCH_WEB']]);
+        $part = new MessagePart($providerData, MessagePartChannelEnum::thought(), 'signature_fixture');
+        $array = $part->toArray();
+        $restored = MessagePart::fromArray($array);
+
+        $this->assertSame([
+            'channel' => 'thought',
+            'type' => 'provider_data',
+            'providerData' => $providerData->toArray(),
+            'thoughtSignature' => 'signature_fixture',
+        ], $array);
+        $this->assertSame($array, $restored->toArray());
+        $this->assertSame('google', $restored->getProviderData()->getProviderId());
+        $this->assertSame($providerData->getData(), $restored->getProviderData()->getData());
+        $this->assertSame($part->getChannel(), $restored->getChannel());
+        $this->assertSame($part->getThoughtSignature(), $restored->getThoughtSignature());
+
+        $decoded = json_decode(json_encode($part, JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame($array, MessagePart::fromArray($decoded)->toArray());
+    }
+
+    /**
+     * Tests provider data remains ordered beside ordinary parts in serialized messages.
+     *
+     * @return void
+     */
+    public function testProviderDataInMessageHistory(): void
+    {
+        $parts = [
+            new MessagePart(new ProviderData('openai', ['type' => 'tool_search_call', 'id' => 'search_123'])),
+            new MessagePart(new ProviderData('openai', [
+                'type' => 'tool_search_output',
+                'tools' => [['type' => 'function', 'name' => 'calendar']],
+            ])),
+            new MessagePart(new FunctionCall('call_123', 'calendar', ['day' => 'Monday'])),
+            new MessagePart('I found the calendar tool.'),
+        ];
+        $message = new ModelMessage($parts);
+        $decoded = json_decode(json_encode($message, JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
+        $restored = Message::fromArray($decoded);
+
+        $this->assertSame($message->toArray(), $restored->toArray());
+        $this->assertCount(4, $restored->getParts());
+        foreach ($parts as $index => $part) {
+            $this->assertSame($part->toArray(), $restored->getParts()[$index]->toArray());
+        }
+    }
+
+    /**
+     * Tests cloning a part creates an independent provider data DTO.
+     *
+     * @return void
+     */
+    public function testCloneClonesProviderData(): void
+    {
+        $part = new MessagePart(new ProviderData('openai', ['type' => 'tool_search_output']));
+        $cloned = clone $part;
+
+        $this->assertNotSame($part->getProviderData(), $cloned->getProviderData());
+        $this->assertSame($part->toArray(), $cloned->toArray());
+    }
+
+    /**
+     * Tests toArray rejects an internally invalid part without content.
+     *
+     * @return void
+     */
+    public function testToArrayWithoutContentThrowsException(): void
+    {
+        $part = new MessagePart('content');
+        $textProperty = new \ReflectionProperty(MessagePart::class, 'text');
+        $textProperty->setAccessible(true);
+        $textProperty->setValue($part, null);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'MessagePart requires one of: text, file, functionCall, functionResponse, or providerData.'
+        );
+
+        $part->toArray();
+    }
+
+    /**
+     * Tests fromArray rejects a provider data part without its payload.
+     *
+     * @return void
+     */
+    public function testFromArrayWithoutContentThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'MessagePart requires one of: text, file, functionCall, functionResponse, or providerData.'
+        );
+
+        MessagePart::fromArray([
+            MessagePart::KEY_TYPE => MessagePartTypeEnum::providerData()->value,
+        ]);
     }
 
     /**

--- a/tests/unit/Messages/DTO/ProviderDataTest.php
+++ b/tests/unit/Messages/DTO/ProviderDataTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordPress\AiClient\Tests\unit\Messages\DTO;
+
+use PHPUnit\Framework\TestCase;
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+use WordPress\AiClient\Messages\DTO\ProviderData;
+
+/**
+ * @covers \WordPress\AiClient\Messages\DTO\ProviderData
+ */
+class ProviderDataTest extends TestCase
+{
+    /**
+     * Tests provider-native fields survive array and JSON transformations.
+     *
+     * @dataProvider nativeDataProvider
+     * @param string $providerId The originating provider identifier.
+     * @param array<string, mixed> $data The provider-native payload.
+     * @return void
+     */
+    public function testRoundTrip(string $providerId, array $data): void
+    {
+        $providerData = new ProviderData($providerId, $data);
+        $array = ['providerId' => $providerId, 'data' => $data];
+
+        $this->assertSame($providerId, $providerData->getProviderId());
+        $this->assertSame($data, $providerData->getData());
+        $this->assertSame($array, $providerData->toArray());
+        $this->assertSame($array, ProviderData::fromArray($array)->toArray());
+
+        $decoded = json_decode(json_encode($providerData, JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame($array, ProviderData::fromArray($decoded)->toArray());
+    }
+
+    /**
+     * Provides native items without requiring provider implementations.
+     *
+     * @return array<string, array{string, array<string, mixed>}> The payloads.
+     */
+    public function nativeDataProvider(): array
+    {
+        return [
+            'tool discovery' => ['openai', [
+                'type' => 'tool_search_output',
+                'id' => 'search_123',
+                'tools' => [['type' => 'function', 'name' => 'calendar', 'defer_loading' => false]],
+                'unknown_field' => null,
+            ]],
+            'server tool call' => ['google', [
+                'thoughtSignature' => 'signature_fixture',
+                'toolCall' => ['toolType' => 'GOOGLE_SEARCH_WEB', 'args' => ['queries' => ['WordPress']]],
+            ]],
+            'server tool response' => ['google', [
+                'toolResponse' => [
+                    'toolType' => 'GOOGLE_SEARCH_WEB',
+                    'response' => ['search_suggestions' => '<div>Search suggestions</div>'],
+                ],
+            ]],
+            'empty data' => ['custom-provider', []],
+        ];
+    }
+
+    /**
+     * Tests missing required fields use the SDK exception contract.
+     *
+     * @dataProvider missingFieldsProvider
+     * @param array<string, mixed> $array The incomplete data.
+     * @return void
+     */
+    public function testMissingFields(array $array): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('missing required keys:');
+
+        ProviderData::fromArray($array);
+    }
+
+    /**
+     * Provides arrays with missing required fields.
+     *
+     * @return array<string, array{array<string, mixed>}> The incomplete arrays.
+     */
+    public function missingFieldsProvider(): array
+    {
+        return [
+            'provider identifier' => [['data' => []]],
+            'data' => [['providerId' => 'openai']],
+            'both' => [[]],
+        ];
+    }
+
+    /**
+     * Tests returned arrays and clones do not share mutable array data.
+     *
+     * @return void
+     */
+    public function testArrayIndependence(): void
+    {
+        $data = ['nested' => ['value' => 'original']];
+        $original = new ProviderData('custom-provider', $data);
+        $cloned = clone $original;
+        $data['nested']['value'] = 'input changed';
+        $retrieved = $cloned->getData();
+        $retrieved['nested']['value'] = 'getter changed';
+        $array = $original->toArray();
+        $array['data']['nested']['value'] = 'array changed';
+
+        $this->assertNotSame($original, $cloned);
+        $this->assertSame(['nested' => ['value' => 'original']], $original->getData());
+        $this->assertSame($original->getData(), $cloned->getData());
+    }
+
+    /**
+     * Tests the schema describes provider-scoped opaque object data.
+     *
+     * @return void
+     */
+    public function testJsonSchema(): void
+    {
+        $schema = ProviderData::getJsonSchema();
+
+        $this->assertSame('object', $schema['type']);
+        $this->assertSame([ProviderData::KEY_PROVIDER_ID, ProviderData::KEY_DATA], $schema['required']);
+        $this->assertSame('string', $schema['properties'][ProviderData::KEY_PROVIDER_ID]['type']);
+        $this->assertSame('object', $schema['properties'][ProviderData::KEY_DATA]['type']);
+        $this->assertTrue($schema['properties'][ProviderData::KEY_DATA]['additionalProperties']);
+        $this->assertFalse($schema['additionalProperties']);
+        $this->assertSame('{"providerId":"custom-provider","data":{}}', json_encode(
+            new ProviderData('custom-provider', [])
+        ));
+    }
+}

--- a/tests/unit/Messages/Enums/MessagePartTypeEnumTest.php
+++ b/tests/unit/Messages/Enums/MessagePartTypeEnumTest.php
@@ -37,6 +37,7 @@ class MessagePartTypeEnumTest extends TestCase
             'FILE' => 'file',
             'FUNCTION_CALL' => 'function_call',
             'FUNCTION_RESPONSE' => 'function_response',
+            'PROVIDER_DATA' => 'provider_data',
         ];
     }
 
@@ -58,5 +59,10 @@ class MessagePartTypeEnumTest extends TestCase
         $functionCall = MessagePartTypeEnum::functionCall();
         $this->assertTrue($functionCall->isFunctionCall());
         $this->assertFalse($functionCall->isFunctionResponse());
+
+        $providerData = MessagePartTypeEnum::providerData();
+        $this->assertTrue($providerData->isProviderData());
+        $this->assertFalse($providerData->isText());
+        $this->assertFalse($providerData->isFunctionCall());
     }
 }


### PR DESCRIPTION
## Why this DTO is needed

Providers return native conversation items that are neither text, files, nor client-executed function calls/responses. Dropping these items loses information needed for replay or attribution; representing them as ordinary function calls gives them the wrong meaning. `ProviderData` gives these items a serializable, provider-tagged place in message history without adding a core type for every provider-specific format.

This extracts the message-data portion previously proposed in #282 into an independent PR. #282 remains focused on function annotations.

## Issues this helps resolve

- For #281: preserve tool-discovery calls/results in their original position in conversation history so providers can replay them on subsequent turns.
- For https://github.com/WordPress/ai-provider-for-google/issues/32: give Google's `toolCall` / `toolResponse` parts a representation that retains their payloads, including signatures and search attribution data, instead of throwing or discarding them.

This is the shared DTO foundation, not a complete fix for either issue. Provider adapters still need to parse and replay the new part type; the Google request configuration fix also remains provider-owned.

## Changes

- `src/Messages/DTO/ProviderData.php`: provider ID and opaque data getters, array transformation and JSON schema, following the existing `AbstractDataTransferObject` pattern.
- `src/Messages/DTO/MessagePart.php` and `src/Messages/Enums/MessagePartTypeEnum.php`: a `PROVIDER_DATA` part with construction, access, serialization and cloning support. Existing message shapes remain unchanged.
- Corresponding tests under `tests/unit/Messages/`: array/JSON round trips, ordered mixed-message history, signatures/channels, missing fields, schema and clone behavior.

```php
$part = new MessagePart(new ProviderData('google', $partData));
```

Adapters must check `getProviderId()` before interpreting or replaying `getData()`. The DTO does not enforce that check or validate the native payload. No provider implementation, builder API, function annotation or tool-search policy changes are included. PHP 7.4 compatibility is retained.

## Verification

- `composer test:unit`: **1,213 tests / 4,426 assertions passed**.
- `composer lint`: **PHPCS and PHPStan passed**.
- `git diff --check`: passed.
- No paid integration calls were run.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-6-astra spent 1d 1h and 2,585,669 tokens on this with the user in an interactive session.